### PR TITLE
fix: make requested_cores optional in external mode with graceful war…

### DIFF
--- a/automation/test-execution/ansible/llm-benchmark-auto.yml
+++ b/automation/test-execution/ansible/llm-benchmark-auto.yml
@@ -64,7 +64,6 @@
       when:
         - vllm_mode == 'external'
         - requested_cores is defined
-        - requested_cores | int > 0
 
     - name: Override core count to 0 for external mode
       ansible.builtin.set_fact:

--- a/automation/test-execution/ansible/llm-benchmark-auto.yml
+++ b/automation/test-execution/ansible/llm-benchmark-auto.yml
@@ -49,20 +49,36 @@
       ansible.builtin.assert:
         that:
           - workload_type is defined
-          - requested_cores is defined
         fail_msg: |
           Missing required variables. Please provide:
           -e "workload_type=<summarization|chat|code|rag>"
-          -e "requested_cores=<8|16|32|64|...>"
           Note: test_model is optional in external mode (will be queried from endpoint)
       when: vllm_mode == 'external'
 
-    - name: Validate requested_cores is a positive integer
+    - name: Warn if cores specified in external mode
+      ansible.builtin.debug:
+        msg:
+          - "⚠️  Warning: requested_cores={{ requested_cores }} specified but not used in external mode"
+          - "   External endpoints have their own CPU allocation - core count will be ignored"
+          - "   Core count will be set to 0 for metadata purposes"
+      when:
+        - vllm_mode == 'external'
+        - requested_cores is defined
+        - requested_cores | int > 0
+
+    - name: Override core count to 0 for external mode
+      ansible.builtin.set_fact:
+        requested_cores: 0
+      when:
+        - vllm_mode == 'external'
+
+    - name: Validate requested_cores is a positive integer (managed mode only)
       ansible.builtin.assert:
         that:
           - requested_cores | int > 0
           - requested_cores | int == requested_cores | float
         fail_msg: "requested_cores must be a positive integer, got: {{ requested_cores }}"
+      when: vllm_mode == 'managed'
 
     - name: Validate workload_type is supported
       ansible.builtin.assert:

--- a/automation/test-execution/ansible/llm-benchmark-concurrent-load.yml
+++ b/automation/test-execution/ansible/llm-benchmark-concurrent-load.yml
@@ -88,7 +88,6 @@
       when:
         - vllm_mode == 'external'
         - requested_cores is defined
-        - requested_cores | int > 0
 
     - name: Override core count to 0 for external mode
       ansible.builtin.set_fact:
@@ -98,7 +97,7 @@
 
     - name: Normalize core configuration input
       ansible.builtin.set_fact:
-        effective_requested_cores: "{{ requested_cores if (requested_cores is defined and requested_cores | int > 0) else (core_sweep_counts | first if (core_sweep_counts is defined and core_sweep_counts | length > 0) else 0) }}"
+        effective_requested_cores: "{{ 0 if vllm_mode == 'external' else (requested_cores if (requested_cores is defined and requested_cores | int > 0) else (core_sweep_counts | first if (core_sweep_counts is defined and core_sweep_counts | length > 0) else 0)) }}"
 
     - name: Validate single core configuration for concurrent load testing
       ansible.builtin.assert:

--- a/automation/test-execution/ansible/llm-benchmark-concurrent-load.yml
+++ b/automation/test-execution/ansible/llm-benchmark-concurrent-load.yml
@@ -63,7 +63,7 @@
           - base_workload in ['chat', 'rag', 'code', 'summarization']
         fail_msg: "base_workload must be one of: chat, rag, code, summarization"
 
-    - name: Validate required parameters
+    - name: Validate required parameters (managed mode only)
       ansible.builtin.assert:
         that:
           - >-
@@ -77,6 +77,24 @@
 
           The concurrent load test requires at least one core configuration to test.
           This playbook will run 3 phases with the specified core configuration(s).
+      when: vllm_mode == 'managed'
+
+    - name: Warn if cores specified in external mode
+      ansible.builtin.debug:
+        msg:
+          - "⚠️  Warning: requested_cores={{ requested_cores }} specified but not used in external mode"
+          - "   External endpoints have their own CPU allocation - core count will be ignored"
+          - "   Core count will be set to 0 for metadata purposes"
+      when:
+        - vllm_mode == 'external'
+        - requested_cores is defined
+        - requested_cores | int > 0
+
+    - name: Override core count to 0 for external mode
+      ansible.builtin.set_fact:
+        requested_cores: 0
+      when:
+        - vllm_mode == 'external'
 
     - name: Normalize core configuration input
       ansible.builtin.set_fact:
@@ -132,7 +150,7 @@
           - "Phase 1 (Baseline - Fixed, No Cache): {{ 'SKIP' if (skip_phase_1 | default(false) | bool) else 'RUN' }}"
           - "Phase 2 (Realistic - Variable, No Cache): {{ 'SKIP' if (skip_phase_2 | default(false) | bool) else ('RUN' if has_variable_workload else 'N/A') }}"
           - "Phase 3 (Production - Variable, With Cache): {{ 'SKIP' if (skip_phase_3 | default(false) | bool) else ('RUN' if has_variable_workload else 'N/A') }}"
-          - "Core Configuration: {{ effective_requested_cores }} cores"
+          - "Core Configuration: {{ '0 cores (external endpoint manages its own CPUs)' if vllm_mode == 'external' else (effective_requested_cores | string) + ' cores' }}"
           - "============================================================"
 
 # ==========================================================================

--- a/docs/dashboards-quickstart.md
+++ b/docs/dashboards-quickstart.md
@@ -123,10 +123,9 @@ When testing external vLLM deployments (cloud, K8s, production):
 export VLLM_ENDPOINT_MODE=external
 export VLLM_ENDPOINT_URL=http://your-endpoint:8000
 
-# 2. Run test
+# 2. Run test (cores not needed in external mode)
 ansible-playbook llm-benchmark-concurrent-load.yml \
-  -e "base_workload=chat" \
-  -e "requested_cores=16"
+  -e "base_workload=chat"
 
 # 3. View results in Streamlit (client metrics + server metrics if available)
 cd automation/test-execution/dashboard-examples/vllm_dashboard

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -249,8 +249,7 @@ export VLLM_ENDPOINT_URL=http://your-vllm-instance:8000
 
 # Run concurrent load test (model auto-detected from endpoint)
 ansible-playbook -i inventory/hosts.yml llm-benchmark-concurrent-load.yml \
-  -e "base_workload=chat" \
-  -e "requested_cores=16"
+  -e "base_workload=chat"
 ```
 
 **Features:**
@@ -266,7 +265,7 @@ ansible-playbook -i inventory/hosts.yml llm-benchmark-concurrent-load.yml \
 - `LOADGEN_HOSTNAME=...` - Load generator hostname/IP
 - `ANSIBLE_SSH_KEY=...` - SSH key for load generator access
 
-**Note:** `DUT_HOSTNAME` not required in external mode (endpoint accessed directly via HTTP).
+**Note:** `DUT_HOSTNAME` and `requested_cores` not required in external mode (endpoint accessed directly via HTTP and manages its own CPU allocation).
 
 ### Concurrent Load Testing
 

--- a/docs/metrics-collection.md
+++ b/docs/metrics-collection.md
@@ -240,9 +240,9 @@ export VLLM_ENDPOINT_URL=http://your-endpoint:8000
 curl http://your-endpoint:8000/metrics
 # → Returns Prometheus metrics (vllm:*, etc.)
 
-# Run test
+# Run test (cores not needed - external endpoint manages its own CPUs)
 ansible-playbook llm-benchmark-concurrent-load.yml \
-  -e "base_workload=chat" -e "requested_cores=16"
+  -e "base_workload=chat"
 
 # Result: vllm-metrics.json created ✅
 ```
@@ -256,9 +256,9 @@ export VLLM_ENDPOINT_URL=http://production-lb.company.com:8000
 curl http://production-lb.company.com:8000/metrics
 # → 403 Forbidden (metrics not publicly exposed)
 
-# Run test
+# Run test (cores not needed - external endpoint manages its own CPUs)
 ansible-playbook llm-benchmark-concurrent-load.yml \
-  -e "base_workload=chat" -e "requested_cores=16"
+  -e "base_workload=chat"
 
 # Result: Only benchmarks.json created (client metrics) ⚠️
 ```


### PR DESCRIPTION
When testing external endpoints, we don't control the server's CPU allocation, so requested_cores is not relevant. This change makes the core count parameter optional for external mode while keeping it required for managed mode.

Changes:
- Remove requested_cores from external mode validation (no longer required)
- Always override to 0 in external mode (whether provided or not)
- Warn users if they specify cores in external mode (informational)
- Fix display to show "0 cores (external endpoint manages its own CPUs)"
- Skip cores validation when vllm_mode=external
- Update task names to clarify "(managed mode only)"
- Core count remains required/validated in managed mode

Benefits:
- Simpler command for external endpoints (no cores parameter needed)
- Clear warning when cores are unnecessarily specified
- Display correctly shows external mode doesn't use cores
- Metadata correctly shows cores=0 for external mode tests
- No confusion about whether cores are used in external mode

Usage:

export VLLM_ENDPOINT_MODE=external
export VLLM_ENDPOINT_URL=http://my-vllm.com:8000
ansible-playbook ... -e "base_workload=chat"

ansible-playbook ... -e "test_model=..." -e "requested_cores=16"

example output:

```
TASK [Warn if cores specified in external mode] ***********************************************************************************************************************************************************
ok: [localhost] => {
    "msg": [
        "⚠️  Warning: requested_cores=16 specified but not used in external mode",
        "   External endpoints have their own CPU allocation - core count will be ignored",
        "   Core count will be set to 0 for metadata purposes"
    ]
}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed core-configuration handling for external mode so core counts are ignored and set to 0.
  * Added warnings when core parameters are supplied but ignored in external mode.
  * Restricted numeric core validation to managed mode only.

* **Improvements**
  * Clarified configuration display to show external endpoints manage their own CPUs.

* **Documentation**
  * Updated run/test examples and notes to remove core-count arguments for external mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->