### PR TITLE
[ISSUE-52] Add summarization_var workload for phase 2/3

### DIFF
--- a/automation/test-execution/ansible/inventory/group_vars/all/test-workloads.yml
+++ b/automation/test-execution/ansible/inventory/group_vars/all/test-workloads.yml
@@ -161,6 +161,25 @@ test_configs:
       - "--max-model-len=8192"          # Limit model context to workload needs (max 4096 tokens)
     kv_cache_space: "40GiB"             # Fallback value - should be overridden by model-specific kv_cache_sizes
 
+
+  # Summarization workload with variability (Realistic traffic simulation)
+  summarization_var:
+    workload_type: "summarization_var"
+    isl: 1024                           # Mean input length
+    isl_stdev: 256                      # Input length std dev (~25% variance)
+    isl_min: 512                        # Minimum input (short articles)
+    isl_max: 2048                       # Maximum input (long articles)
+    osl: 256                            # Mean output length
+    osl_stdev: 64                       # Output length std dev (~25% variance)
+    osl_min: 128                        # Minimum output (brief summaries)
+    osl_max: 512                        # Maximum output (detailed summaries)
+    variability: true                   # Enable statistical distribution
+    backend: "openai-completions"
+    vllm_args:
+      - "--dtype=bfloat16"
+      - "--no-enable-prefix-caching"    # Baseline mode: no prefix caching
+    kv_cache_space: "40GiB"             # ~1280 avg tokens * ~32 concurrent
+
 # ============================================================================
 # Prefix Caching Mode Configurations
 # ============================================================================

--- a/automation/test-execution/ansible/llm-benchmark-concurrent-load.yml
+++ b/automation/test-execution/ansible/llm-benchmark-concurrent-load.yml
@@ -112,7 +112,7 @@
     requested_cores: "{{ requested_cores if (requested_cores is defined) else omit }}"
   when:
     - not (skip_phase_2 | default(false) | bool)
-    - (base_workload + '_var') in ['chat_var', 'code_var']
+    - (base_workload + '_var') in ['chat_var', 'code_var', 'summarization_var']
 
 - name: Phase 2 Complete
   hosts: localhost
@@ -151,7 +151,7 @@
     requested_cores: "{{ requested_cores if (requested_cores is defined) else omit }}"
   when:
     - not (skip_phase_3 | default(false) | bool)
-    - (base_workload + '_var') in ['chat_var', 'code_var']
+    - (base_workload + '_var') in ['chat_var', 'code_var', 'summarization_var']
 
 - name: Phase 3 Complete
   hosts: localhost

--- a/automation/test-execution/ansible/llm-benchmark-concurrent-load.yml
+++ b/automation/test-execution/ansible/llm-benchmark-concurrent-load.yml
@@ -60,7 +60,7 @@
 
     - name: Check if variable workload exists
       ansible.builtin.set_fact:
-        has_variable_workload: "{{ variable_workload in ['chat_var', 'code_var'] }}"
+        has_variable_workload: "{{ variable_workload in ['chat_var', 'code_var','summarization_var'] }}"
 
     - name: Display test suite configuration
       ansible.builtin.debug:
@@ -118,13 +118,13 @@
   hosts: localhost
   gather_facts: false
   vars:
-    has_variable_workload: "{{ (base_workload + '_var') in ['chat_var', 'code_var'] }}"
+    has_variable_workload: "{{ (base_workload + '_var') in ['chat_var', 'code_var','summarization_var' ] }}"
   tasks:
     - name: Phase 2 skipped notification
       ansible.builtin.debug:
         msg:
           - "⊘ Phase 2 Skipped: No variable workload defined for {{ base_workload }}"
-          - "  Variable workloads only available for: chat, code"
+          - "  Variable workloads only available for: chat, code, summarization"
       when:
         - not (skip_phase_2 | default(false) | bool)
         - not has_variable_workload
@@ -157,14 +157,14 @@
   hosts: localhost
   gather_facts: false
   vars:
-    has_variable_workload: "{{ (base_workload + '_var') in ['chat_var', 'code_var'] }}"
+    has_variable_workload: "{{ (base_workload + '_var') in ['chat_var', 'code_var','summarization_var'] }}"
   tasks:
     - name: Phase 3 skipped notification
       ansible.builtin.debug:
         msg:
           - "⊘ Phase 3 Skipped: No variable workload defined for {{ base_workload }}"
           - "  Production testing (Phase 3) requires variable workload"
-          - "  Variable workloads only available for: chat, code"
+          - "  Variable workloads only available for: chat, code, summarization"
       when:
         - not (skip_phase_3 | default(false) | bool)
         - not has_variable_workload
@@ -186,7 +186,7 @@
   hosts: localhost
   gather_facts: false
   vars:
-    has_variable_workload: "{{ (base_workload + '_var') in ['chat_var', 'code_var'] }}"
+    has_variable_workload: "{{ (base_workload + '_var') in ['chat_var', 'code_var','summarization_var'] }}"
   tasks:
     - name: Display test suite summary
       ansible.builtin.debug:


### PR DESCRIPTION
Simple update to add summarization_var workload

TBD - need to verfiy with @maryamtahhan about updating documentation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a variable-length summarization workload for performance testing, using the OpenAI Completions backend and variability across input/output lengths.

* **Chores**
  * Tuned runtime settings for this workload (bfloat16 precision, prefix-caching disabled, workload-specific KV cache sizing) and included the new variant in Phase 2 and Phase 3 benchmark runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->