### PR TITLE
fix: correct KV cache sizing for variable workloads to prevent OOM

### DIFF
--- a/automation/test-execution/ansible/ansible.md
+++ b/automation/test-execution/ansible/ansible.md
@@ -227,10 +227,10 @@ Pre-configured in [inventory/group_vars/all/test-workloads.yml](inventory/group_
 
 ### Variable Workloads (Realistic Traffic)
 
-| Workload | ISL±σ:OSL±σ | Use Case | Baseline vLLM Args |
+| Workload | ISL±σ:OSL±σ (max) | Use Case | Baseline vLLM Args |
 |----------|---------|----------|-----------|
-| `chat_var` | 512±128:256±64 | Realistic chat traffic | `--dtype=bfloat16 --no-enable-prefix-caching` |
-| `code_var` | 512±128:4096±1024 | Realistic code generation | `--dtype=bfloat16 --no-enable-prefix-caching` |
+| `chat_var` | 512±128:512±128 (1024:1024) | Realistic chat traffic | `--dtype=bfloat16 --no-enable-prefix-caching` |
+| `code_var` | 1024±256:1024±256 (2048:2048) | Realistic code generation | `--dtype=bfloat16 --no-enable-prefix-caching` |
 
 **Note:** Baseline mode disables both prefix caching and radix cache for true baseline measurements. Production mode enables caching optimizations.
 

--- a/models/llm-models/model-matrix.yaml
+++ b/models/llm-models/model-matrix.yaml
@@ -33,8 +33,8 @@ matrix:
         code: "3GiB"          # 2048 tokens, 32 concurrent
         summarization: "3GiB" # 2304 tokens, 32 concurrent
         reasoning: "3GiB"     # 2304 tokens, 32 concurrent
-        chat_var: "2GiB"      # Same as chat
-        code_var: "3GiB"      # Same as code
+        chat_var: "3GiB"      # 2048 max tokens, 32 concurrent, 1.5x safety
+        code_var: "6GiB"      # 4096 max tokens, 32 concurrent, 1.5x safety
       default_workloads:
         - chat
       test_suites:
@@ -64,8 +64,8 @@ matrix:
         code: "9GiB"          # 2048 tokens, 32 concurrent
         summarization: "9GiB" # 2304 tokens, 32 concurrent
         reasoning: "10GiB"    # 2304 tokens, 32 concurrent
-        chat_var: "5GiB"      # Same as chat
-        code_var: "9GiB"      # Same as code
+        chat_var: "11GiB"     # 2048 max tokens, 32 concurrent, 1.5x safety
+        code_var: "21GiB"     # 4096 max tokens, 32 concurrent, 1.5x safety
       default_workloads:
         - chat
       test_suites:
@@ -96,8 +96,8 @@ matrix:
         code: "2GiB"          # 2048 tokens, 32 concurrent
         summarization: "2GiB" # 2304 tokens, 32 concurrent
         reasoning: "2GiB"     # 2304 tokens, 32 concurrent
-        chat_var: "1GiB"      # Same as chat
-        code_var: "2GiB"      # Same as code
+        chat_var: "3GiB"      # 2048 max tokens, 32 concurrent, 1.5x safety
+        code_var: "5GiB"      # 4096 max tokens, 32 concurrent, 1.5x safety
       default_workloads:
         - chat
       test_suites:
@@ -128,8 +128,8 @@ matrix:
         code: "2GiB"          # 2048 tokens, 32 concurrent
         summarization: "2GiB" # 2304 tokens, 32 concurrent
         reasoning: "3GiB"     # 2304 tokens, 32 concurrent
-        chat_var: "1GiB"      # Same as chat
-        code_var: "2GiB"      # Same as code
+        chat_var: "4GiB"      # 2048 max tokens, 32 concurrent, 1.5x safety
+        code_var: "7GiB"      # 4096 max tokens, 32 concurrent, 1.5x safety
       default_workloads:
         - chat
         - summarization
@@ -160,8 +160,8 @@ matrix:
         code: "4GiB"          # 2048 tokens, 32 concurrent
         summarization: "4GiB" # 2304 tokens, 32 concurrent
         reasoning: "5GiB"     # 2304 tokens, 32 concurrent
-        chat_var: "2GiB"      # Same as chat
-        code_var: "4GiB"      # Same as code
+        chat_var: "8GiB"      # 2048 max tokens, 32 concurrent, 1.5x safety
+        code_var: "15GiB"     # 4096 max tokens, 32 concurrent, 1.5x safety
       default_workloads:
         - chat
         - summarization
@@ -192,8 +192,8 @@ matrix:
         code: "5GiB"          # 2048 tokens, 32 concurrent
         summarization: "4GiB" # 2304 tokens, 32 concurrent
         reasoning: "5GiB"     # 2304 tokens, 32 concurrent
-        chat_var: "3GiB"      # Same as chat
-        code_var: "5GiB"      # Same as code
+        chat_var: "8GiB"      # 2048 max tokens, 32 concurrent, 1.5x safety
+        code_var: "15GiB"     # 4096 max tokens, 32 concurrent, 1.5x safety
       default_workloads:
         - chat
       test_suites:
@@ -224,8 +224,8 @@ matrix:
         code: "3GiB"          # 2048 tokens, 32 concurrent
         summarization: "3GiB" # 2304 tokens, 32 concurrent
         reasoning: "4GiB"     # 2304 tokens, 32 concurrent
-        chat_var: "2GiB"      # Same as chat
-        code_var: "3GiB"      # Same as code
+        chat_var: "6GiB"      # 2048 max tokens, 32 concurrent, 1.5x safety
+        code_var: "11GiB"     # 4096 max tokens, 32 concurrent, 1.5x safety
       default_workloads:
         - chat
         - code
@@ -256,8 +256,8 @@ matrix:
         code: "2GiB"          # 2048 tokens, 32 concurrent
         summarization: "2GiB" # 2304 tokens, 32 concurrent
         reasoning: "2GiB"     # 2304 tokens, 32 concurrent
-        chat_var: "1GiB"      # Same as chat
-        code_var: "2GiB"      # Same as code
+        chat_var: "4GiB"      # 2048 max tokens, 32 concurrent, 1.5x safety
+        code_var: "7GiB"      # 4096 max tokens, 32 concurrent, 1.5x safety
       default_workloads:
         - chat
         - code
@@ -300,8 +300,8 @@ matrix:
         code: "4GiB"          # 2048 tokens, 32 concurrent
         summarization: "3GiB" # 2304 tokens, 32 concurrent
         reasoning: "4GiB"     # 2304 tokens, 32 concurrent
-        chat_var: "2GiB"      # Same as chat
-        code_var: "4GiB"      # Same as code
+        chat_var: "4GiB"      # 2048 max tokens, 32 concurrent, 1.5x safety
+        code_var: "7GiB"      # 4096 max tokens, 32 concurrent, 1.5x safety
       default_workloads:
         - rag       # Primary - leverages large context
         - chat      # Baseline conversational

--- a/models/models.md
+++ b/models/models.md
@@ -404,7 +404,11 @@ KV Cache Size (GB) = Total Bytes ÷ (1024³)
 
 ### KV Cache Sizes by Model and Workload
 
-Calculated with **32 concurrent requests** (MAX concurrency across all workloads) and 25% safety margin (1.25x):
+Calculated with **32 concurrent requests** (MAX concurrency across all workloads):
+
+**Safety Margins:**
+- **Fixed workloads** (chat, rag, code, summarization, reasoning): 25% safety margin (1.25x)
+- **Variable workloads** (chat_var, code_var): 50% safety margin (1.5x) to account for multiple concurrent requests at max token lengths
 
 **Note**: All KV cache sizes are calculated for 32 concurrent requests to provide maximum headroom:
 - **chat**: 32 concurrent (MAX)
@@ -412,6 +416,8 @@ Calculated with **32 concurrent requests** (MAX concurrency across all workloads
 - **code**: 32 concurrent (MAX)
 - **summarization**: 32 concurrent (MAX)
 - **reasoning**: 32 concurrent (MAX)
+- **chat_var**: 32 concurrent at max 2048 tokens (1024 + 1024)
+- **code_var**: 32 concurrent at max 4096 tokens (2048 + 2048)
 
 #### Chat Workload (512:512, 1024 tokens)
 
@@ -482,6 +488,38 @@ Calculated with **32 concurrent requests** (MAX concurrency across all workloads
 | qwen3-0.6b | 0.0821 GB | 3.28 GB | 4 GiB |
 | qwen2.5-3b-instruct | 0.0403 GB | 1.61 GB | 2 GiB |
 | gpt-oss-20b | 0.0954 GB | 3.82 GB | 4 GiB |
+
+#### Chat Variable Workload (max 1024:1024, 2048 tokens, 32 concurrent)
+
+**Note**: Sized for maximum token counts with 1.5x safety margin
+
+| Model | Per-Request | 32 × 1.5x | Configured |
+|-------|-------------|-----------|------------|
+| llama-3.2-1b-instruct | 0.0625 GB | 3.00 GB | 3 GiB |
+| llama-3.2-3b-instruct | 0.2188 GB | 10.5 GB | 11 GiB |
+| tinyllama-1.1b-chat | 0.0430 GB | 2.06 GB | 3 GiB |
+| opt-125m | 0.0452 GB | 2.17 GB | 4 GiB |
+| opt-1.3b | 0.0954 GB | 4.58 GB | 8 GiB |
+| granite-3.2-2b-instruct | 0.1042 GB | 5.00 GB | 8 GiB |
+| qwen3-0.6b | 0.0730 GB | 3.50 GB | 6 GiB |
+| qwen2.5-3b-instruct | 0.0358 GB | 1.72 GB | 4 GiB |
+| gpt-oss-20b | 0.0848 GB | 4.07 GB | 4 GiB |
+
+#### Code Variable Workload (max 2048:2048, 4096 tokens, 32 concurrent)
+
+**Note**: Sized for maximum token counts with 1.5x safety margin
+
+| Model | Per-Request | 32 × 1.5x | Configured |
+|-------|-------------|-----------|------------|
+| llama-3.2-1b-instruct | 0.125 GB | 6.00 GB | 6 GiB |
+| llama-3.2-3b-instruct | 0.438 GB | 21.0 GB | 21 GiB |
+| tinyllama-1.1b-chat | 0.086 GB | 4.12 GB | 5 GiB |
+| opt-125m | 0.090 GB | 4.32 GB | 7 GiB |
+| opt-1.3b | 0.191 GB | 9.17 GB | 15 GiB |
+| granite-3.2-2b-instruct | 0.208 GB | 10.0 GB | 15 GiB |
+| qwen3-0.6b | 0.146 GB | 7.01 GB | 11 GiB |
+| qwen2.5-3b-instruct | 0.072 GB | 3.46 GB | 7 GiB |
+| gpt-oss-20b | 0.170 GB | 8.16 GB | 7 GiB |
 
 ### Usage in Test Automation
 

--- a/tests/concurrent-load/concurrent-load.md
+++ b/tests/concurrent-load/concurrent-load.md
@@ -59,7 +59,7 @@ This test suite evaluates generative LLM models across multiple architecture fam
 
 | Variable | Description | Baseline Tests | Realistic Tests |
 | --- | --- | --- | --- |
-| **Workload** | Input/Output token counts (ISL:OSL) | • Chat (512:256)<br>• RAG (4096:512)<br>• CodeGen (512:4096)<br>• Summarization (1024:256) | • Chat (512±128:256±64)<br>• CodeGen (512±128:4096±1024) |
+| **Workload** | Input/Output token counts (ISL:OSL) | • Chat (512:512)<br>• RAG (7680:512)<br>• Code (1024:1024)<br>• Summarization (2048:256) | • Chat (512±128:512±128, max 1024:1024)<br>• Code (1024±256:1024±256, max 2048:2048) |
 | **Test Duration** | Time per profile | `--max-seconds=600` (10 min) | `--max-seconds=600` (10 min) |
 | **Warmup** | Warmup period | `--warmup=0.1` (10% = 60s) | `--warmup=0.1` (10% = 60s) |
 | **Request Timeout** | Max time per request | `--request-timeout=600` | `--request-timeout=600` |
@@ -82,20 +82,20 @@ Concurrency levels: **{1, 2, 4, 8, 16, 32}**
 
 | Test ID | Model | Workload | Primary Metric Focus |
 | --- | --- | --- | --- |
-| CONC-LLAMA32-CHAT | Llama-3.2-1B | Chat (512:256) | P95 Latency Scaling (Baseline) |
-| CONC-LLAMA32-RAG | Llama-3.2-1B | RAG (4096:512) | P95 Latency for Long Context RAG |
-| CONC-LLAMA32-CODE | Llama-3.2-1B | CodeGen (512:4096) | P95 Latency for Long Output (Baseline) |
-| CONC-QWEN06-CHAT | Qwen/Qwen3-0.6B | Chat (512:256) | P95 Latency (Efficient Model) |
-| CONC-QWEN06-CODE | Qwen/Qwen3-0.6B | CodeGen (512:4096) | P95 Latency for Long Output |
-| CONC-GRANITE32-CHAT | granite-3.2-2b-instruct | Chat (512:256) | P95 Latency (Enterprise) |
-| CONC-GRANITE32-RAG | granite-3.2-2b-instruct | RAG (4096:512) | P95 Latency for Enterprise RAG |
-| CONC-GRANITE32-CODE | granite-3.2-2b-instruct | CodeGen (512:4096) | P95 Latency for Code Generation |
-| CONC-GPT20B-CHAT | gpt-oss-20b | Chat (512:256) | P95 Latency (Large-Scale MoE) |
-| CONC-GPT20B-RAG | gpt-oss-20b | RAG (4096:512) | P95 Latency for Long Context RAG (128k capable) |
-| CONC-GPT20B-CODE | gpt-oss-20b | CodeGen (512:4096) | P95 Latency for Code Generation (MoE) |
-| CONC-TINY11-CHAT | TinyLlama-1.1B | Chat (512:256) | P95 Latency (Small Llama) |
-| CONC-OPT125M-SUMM | facebook/opt-125m | Summarization (1024:256) | P95 Latency for Summarization |
-| CONC-OPT125M-CHAT | facebook/opt-125m | Chat (512:256) | P95 Latency (Small Baseline) |
+| CONC-LLAMA32-CHAT | Llama-3.2-1B | Chat (512:512) | P95 Latency Scaling (Baseline) |
+| CONC-LLAMA32-RAG | Llama-3.2-1B | RAG (7680:512) | P95 Latency for Long Context RAG |
+| CONC-LLAMA32-CODE | Llama-3.2-1B | Code (1024:1024) | P95 Latency for Long Output (Baseline) |
+| CONC-QWEN06-CHAT | Qwen/Qwen3-0.6B | Chat (512:512) | P95 Latency (Efficient Model) |
+| CONC-QWEN06-CODE | Qwen/Qwen3-0.6B | Code (1024:1024) | P95 Latency for Long Output |
+| CONC-GRANITE32-CHAT | granite-3.2-2b-instruct | Chat (512:512) | P95 Latency (Enterprise) |
+| CONC-GRANITE32-RAG | granite-3.2-2b-instruct | RAG (7680:512) | P95 Latency for Enterprise RAG |
+| CONC-GRANITE32-CODE | granite-3.2-2b-instruct | Code (1024:1024) | P95 Latency for Code Generation |
+| CONC-GPT20B-CHAT | gpt-oss-20b | Chat (512:512) | P95 Latency (Large-Scale MoE) |
+| CONC-GPT20B-RAG | gpt-oss-20b | RAG (7680:512) | P95 Latency for Long Context RAG (128k capable) |
+| CONC-GPT20B-CODE | gpt-oss-20b | Code (1024:1024) | P95 Latency for Code Generation (MoE) |
+| CONC-TINY11-CHAT | TinyLlama-1.1B | Chat (512:512) | P95 Latency (Small Llama) |
+| CONC-OPT125M-SUMM | facebook/opt-125m | Summarization (2048:256) | P95 Latency for Summarization |
+| CONC-OPT125M-CHAT | facebook/opt-125m | Chat (512:512) | P95 Latency (Small Baseline) |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -107,14 +107,14 @@ Concurrency levels: **{1, 2, 4, 8, 16, 32}**
 
 | Test ID | Model | Workload | Primary Metric Focus |
 | --- | --- | --- | --- |
-| CONC-LLAMA32-CHAT-VAR | Llama-3.2-1B | Chat (512±128:256±64) | P95 Latency (Realistic) |
-| CONC-LLAMA32-CODE-VAR | Llama-3.2-1B | CodeGen (512±128:4096±1024) | P95 Latency for Long Output (Realistic) |
-| CONC-QWEN06-CHAT-VAR | Qwen/Qwen3-0.6B | Chat (512±128:256±64) | P95 Latency (Realistic) |
-| CONC-QWEN06-CODE-VAR | Qwen/Qwen3-0.6B | CodeGen (512±128:4096±1024) | P95 Latency for Long Output (Realistic) |
-| CONC-GRANITE32-CHAT-VAR | granite-3.2-2b-instruct | Chat (512±128:256±64) | P95 Latency (Realistic) |
-| CONC-GPT20B-CHAT-VAR | gpt-oss-20b | Chat (512±128:256±64) | P95 Latency (Realistic, Large-Scale) |
-| CONC-TINY11-CHAT-VAR | TinyLlama-1.1B | Chat (512±128:256±64) | P95 Latency (Realistic) |
-| CONC-OPT125M-SUMM-VAR | facebook/opt-125m | Summarization (1024±256:256±64) | P95 Latency for Summarization (Realistic) |
+| CONC-LLAMA32-CHAT-VAR | Llama-3.2-1B | Chat (512±128:512±128) | P95 Latency (Realistic) |
+| CONC-LLAMA32-CODE-VAR | Llama-3.2-1B | Code (1024±256:1024±256) | P95 Latency for Long Output (Realistic) |
+| CONC-QWEN06-CHAT-VAR | Qwen/Qwen3-0.6B | Chat (512±128:512±128) | P95 Latency (Realistic) |
+| CONC-QWEN06-CODE-VAR | Qwen/Qwen3-0.6B | Code (1024±256:1024±256) | P95 Latency for Long Output (Realistic) |
+| CONC-GRANITE32-CHAT-VAR | granite-3.2-2b-instruct | Chat (512±128:512±128) | P95 Latency (Realistic) |
+| CONC-GPT20B-CHAT-VAR | gpt-oss-20b | Chat (512±128:512±128) | P95 Latency (Realistic, Large-Scale) |
+| CONC-TINY11-CHAT-VAR | TinyLlama-1.1B | Chat (512±128:512±128) | P95 Latency (Realistic) |
+| CONC-OPT125M-SUMM-VAR | facebook/opt-125m | Summarization (2048±512:256±64) | P95 Latency for Summarization (Realistic) |
 
 <!-- markdownlint-enable MD013 -->
 


### PR DESCRIPTION
Variable workloads (chat_var, code_var) were sized for mean token counts instead of maximum, risking out-of-memory errors with concurrent requests at max lengths. Updated to use 1.5x safety margin on max token counts (2048 for chat_var, 4096 for code_var). Fixed workload documentation inconsistencies across all test suite descriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined variable workload token variability ranges with expanded max-range notation.
  * Updated KV cache sizing methodology with workload-specific safety margins (1.25x for fixed, 1.5x for variable workloads).
  * Added new workload sizing reference tables documenting per-model KV cache targets.

* **Configuration**
  * Increased KV cache allocations for variable workload models to support higher concurrent request capacity.
  * Updated concurrent-load test configurations with new baseline and realistic workload token ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->