### PR TITLE
Improve GuideLLM benchmark start UX, progress logging, and result collection fallback

### DIFF
--- a/automation/test-execution/ansible/llm-benchmark-auto.yml
+++ b/automation/test-execution/ansible/llm-benchmark-auto.yml
@@ -549,13 +549,38 @@
       when: is_core_sweep is not defined or not is_core_sweep
 
     - name: Fetch results to local machine
-      ansible.posix.synchronize:
-        src: "{{ bench_config.results_dir }}/{{ actual_model | replace('/', '__') }}/{{ workload_type }}-{{ test_run_id }}/{{ core_configuration.name }}/"
-        dest: "{{ hostvars['localhost']['local_results_base'] }}/{{ actual_model | replace('/', '__') }}/{{ workload_type }}-{{ test_run_id }}/{{ core_configuration.name }}/"
-        mode: pull
-        recursive: true
-      when: is_core_sweep is not defined or not is_core_sweep
+      block:
+        - name: Fetch results to local machine via synchronize
+          ansible.posix.synchronize:
+            src: "{{ bench_config.results_dir }}/{{ actual_model | replace('/', '__') }}/{{ workload_type }}-{{ test_run_id }}/{{ core_configuration.name }}/"
+            dest: "{{ hostvars['localhost']['local_results_base'] }}/{{ actual_model | replace('/', '__') }}/{{ workload_type }}-{{ test_run_id }}/{{ core_configuration.name }}/"
+            mode: pull
+            recursive: true
+      rescue:
+        - name: Note synchronize fallback
+          ansible.builtin.debug:
+            msg: "Result sync via synchronize failed; falling back to per-file fetch."
 
+        - name: Fetch benchmarks.json to local machine (fallback)
+          ansible.builtin.fetch:
+            src: "{{ bench_config.results_dir }}/{{ actual_model | replace('/', '__') }}/{{ workload_type }}-{{ test_run_id }}/{{ core_configuration.name }}/benchmarks.json"
+            dest: "{{ hostvars['localhost']['local_results_base'] }}/{{ actual_model | replace('/', '__') }}/{{ workload_type }}-{{ test_run_id }}/{{ core_configuration.name }}/benchmarks.json"
+            flat: true
+
+        - name: Fetch benchmarks.csv to local machine (fallback)
+          ansible.builtin.fetch:
+            src: "{{ bench_config.results_dir }}/{{ actual_model | replace('/', '__') }}/{{ workload_type }}-{{ test_run_id }}/{{ core_configuration.name }}/benchmarks.csv"
+            dest: "{{ hostvars['localhost']['local_results_base'] }}/{{ actual_model | replace('/', '__') }}/{{ workload_type }}-{{ test_run_id }}/{{ core_configuration.name }}/benchmarks.csv"
+            flat: true
+
+        - name: Fetch test-metadata.json to local machine (fallback)
+          ansible.builtin.fetch:
+            src: "{{ bench_config.results_dir }}/{{ actual_model | replace('/', '__') }}/{{ workload_type }}-{{ test_run_id }}/{{ core_configuration.name }}/test-metadata.json"
+            dest: "{{ hostvars['localhost']['local_results_base'] }}/{{ actual_model | replace('/', '__') }}/{{ workload_type }}-{{ test_run_id }}/{{ core_configuration.name }}/test-metadata.json"
+            flat: true
+          failed_when: false
+
+      when: is_core_sweep is not defined or not is_core_sweep
     # Copy GuideLLM log from controller to final results directory
     # The log is fetched to controller's ~/benchmark-results by the benchmark_guidellm role
     # but synchronize above pulls from load_generator, so we need this separate copy

--- a/automation/test-execution/ansible/roles/benchmark_guidellm/tasks/benchmark_progress_poll.yml
+++ b/automation/test-execution/ansible/roles/benchmark_guidellm/tasks/benchmark_progress_poll.yml
@@ -46,3 +46,4 @@
 - name: Continue polling while benchmark is still running (containerized)
   ansible.builtin.include_tasks: benchmark_progress_poll.yml
   when: guidellm_container_running | bool
+  

--- a/automation/test-execution/ansible/roles/benchmark_guidellm/tasks/benchmark_progress_poll.yml
+++ b/automation/test-execution/ansible/roles/benchmark_guidellm/tasks/benchmark_progress_poll.yml
@@ -46,4 +46,3 @@
 - name: Continue polling while benchmark is still running (containerized)
   ansible.builtin.include_tasks: benchmark_progress_poll.yml
   when: guidellm_container_running | bool
-  

--- a/automation/test-execution/ansible/roles/benchmark_guidellm/tasks/benchmark_progress_poll.yml
+++ b/automation/test-execution/ansible/roles/benchmark_guidellm/tasks/benchmark_progress_poll.yml
@@ -1,0 +1,48 @@
+- name: Check whether GuideLLM container is still running (containerized)
+  ansible.builtin.command:
+    cmd: "podman ps --format {{ '{{.Names}}' }}"
+  register: guidellm_ps_check
+  changed_when: false
+
+- name: Compute elapsed benchmark time (containerized)
+  ansible.builtin.set_fact:
+    guidellm_elapsed_seconds: "{{ (lookup('pipe', 'date +%s') | int) - (guidellm_wait_start_epoch | int) }}"
+    guidellm_container_running: "{{ guidellm_container_name in guidellm_ps_check.stdout_lines }}"
+
+- name: Build progress message (containerized)
+  ansible.builtin.set_fact:
+    guidellm_progress_message: >-
+      {{ lookup('pipe', 'date -u +%Y-%m-%dT%H:%M:%SZ') }} | RUNNING |
+      elapsed={{ '%02d' | format(((guidellm_elapsed_seconds | int) // 60) | int) }}:{{ '%02d' | format(((guidellm_elapsed_seconds | int) % 60) | int) }}
+  when: guidellm_container_running | bool
+
+- name: Append benchmark progress to controller-side log only when message changes
+  ansible.builtin.shell: >-
+    printf '%s\n' {{ (guidellm_progress_message | trim) | quote }} >> {{ guidellm_progress_log_file | quote }}
+  delegate_to: localhost
+  changed_when: false
+  when:
+    - guidellm_container_running | bool
+    - (guidellm_progress_message | trim) != (guidellm_last_progress_message | trim)
+
+- name: Remember last benchmark progress message
+  ansible.builtin.set_fact:
+    guidellm_last_progress_message: "{{ guidellm_progress_message | trim }}"
+  when: guidellm_container_running | bool
+
+- name: Fail if safety timeout is exceeded while waiting for benchmark completion (containerized)
+  ansible.builtin.fail:
+    msg: >-
+      GuideLLM benchmark did not complete before safety timeout of {{ guidellm_wait_timeout_seconds }} seconds.
+  when:
+    - guidellm_container_running | bool
+    - (guidellm_elapsed_seconds | int) >= (guidellm_wait_timeout_seconds | int)
+
+- name: Pause before next benchmark status check (containerized)
+  ansible.builtin.pause:
+    seconds: "{{ guidellm_poll_seconds }}"
+  when: guidellm_container_running | bool
+
+- name: Continue polling while benchmark is still running (containerized)
+  ansible.builtin.include_tasks: benchmark_progress_poll.yml
+  when: guidellm_container_running | bool

--- a/automation/test-execution/ansible/roles/benchmark_guidellm/tasks/main.yml
+++ b/automation/test-execution/ansible/roles/benchmark_guidellm/tasks/main.yml
@@ -199,31 +199,93 @@
         ] | min
       }}
 
+- name: Record benchmark wait start time (containerized)
+  ansible.builtin.set_fact:
+    guidellm_wait_start_epoch: "{{ lookup('pipe', 'date +%s') | int }}"
+    guidellm_expected_seconds: "{{ guidellm_max_seconds | default(guidellm_cfg.max_seconds | default(600)) | int }}"
+    guidellm_poll_seconds: 30
+    guidellm_last_progress_message: ""
+    guidellm_container_name: "guidellm-{{ workload_type }}-{{ core_cfg.name }}"
+  when: use_guidellm_container | bool
+
+- name: Set controller-side benchmark progress log directory (containerized)
+  ansible.builtin.set_fact:
+    guidellm_progress_log_dir: "{{ (playbook_dir + '/../../../progress-logs') | realpath }}"
+  when: use_guidellm_container | bool
+
+- name: Set controller-side benchmark progress log file (containerized)
+  ansible.builtin.set_fact:
+    guidellm_progress_log_file: >-
+      {{ guidellm_progress_log_dir }}/{{ test_model | replace('/', '__') }}-{{ workload_type }}-{{ core_cfg.name }}-progress.log
+  when: use_guidellm_container | bool
+
+- name: Ensure controller-side benchmark progress log directory exists
+  ansible.builtin.file:
+    path: "{{ guidellm_progress_log_dir }}"
+    state: directory
+    mode: "0755"
+  delegate_to: localhost
+  when: use_guidellm_container | bool
+
+- name: Initialize benchmark progress log on controller
+  ansible.builtin.copy:
+    dest: "{{ guidellm_progress_log_file }}"
+    content: ""
+    mode: "0644"
+  delegate_to: localhost
+  when: use_guidellm_container | bool
+
+- name: Write benchmark start entry to progress log
+  ansible.builtin.shell: >-
+    printf '%s\n' {{ (lookup('pipe', 'date -u +%Y-%m-%dT%H:%M:%SZ') ~ ' | START') | quote }} >> {{ guidellm_progress_log_file | quote }}
+  delegate_to: localhost
+  changed_when: false
+  when: use_guidellm_container | bool
+
 - name: Display benchmark start info (containerized)
   ansible.builtin.debug:
     msg:
       - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
       - "GuideLLM Benchmark Started (Container Mode)"
       - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-      - "Container: {{ guidellm_container.container.Id[:12] }}"
+      - "Container: {{ guidellm_container.container.Id[:12] if (guidellm_container is defined and guidellm_container.container is defined and guidellm_container.container.Id is defined) else 'N/A' }}"
       - "Max Duration: {{ guidellm_cfg.max_seconds }}s | Max Requests: {{ guidellm_cfg.max_requests }}"
       - "Safety Timeout: {{ guidellm_wait_timeout_seconds }}s ({{ (guidellm_wait_timeout_seconds | int / 60) | round(1) }} min)"
-      - "{{ 'Location: localhost' if ansible_connection == 'local' else 'Location: ' + ansible_host }}"
+      - "{{ 'Location: localhost' if ansible_connection == 'local' else 'Location: ' + (ansible_host | default(inventory_hostname)) }}"
       - ""
-      - "⚠️  Ansible will now wait silently for completion"
-      - "⚠️  This may take several minutes (or hours for sweep tests)"
+      - "Progress log:"
+      - "  {{ guidellm_progress_log_file }}"
       - ""
-      - "To monitor progress, open another terminal and run:"
+      - "Watch progress:"
+      - "  tail -F {{ guidellm_progress_log_file }}"
+      - ""
+      - "Optional: container logs, open another terminal and run:"
       - "  {{ monitor_cmd }}"
       - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   when: use_guidellm_container | bool
 
-- name: Wait for GuideLLM benchmark to complete (containerized)
+- name: Poll for GuideLLM benchmark completion with visible progress (containerized)
+  ansible.builtin.include_tasks: benchmark_progress_poll.yml
+  when: use_guidellm_container | bool
+
+- name: Write benchmark completion entry to progress log
+  ansible.builtin.shell: >-
+    printf '%s\n' {{ (lookup('pipe', 'date -u +%Y-%m-%dT%H:%M:%SZ') ~ ' | COMPLETED') | quote }} >> {{ guidellm_progress_log_file | quote }}
+  delegate_to: localhost
+  changed_when: false
+  when: use_guidellm_container | bool
+
+- name: Wait for GuideLLM benchmark to complete and capture exit code (containerized)
   ansible.builtin.command:
-    cmd: "timeout {{ guidellm_wait_timeout_seconds }} podman wait guidellm-{{ workload_type }}-{{ core_cfg.name }}"
+    cmd: "podman wait {{ guidellm_container_name }}"
   register: guidellm_exit_code_container
   changed_when: false
-  failed_when: guidellm_exit_code_container.rc != 0 and guidellm_exit_code_container.rc != 124
+  failed_when: guidellm_exit_code_container.rc != 0
+  when: use_guidellm_container | bool
+
+- name: Announce benchmark completion (containerized)
+  ansible.builtin.debug:
+    msg: "GuideLLM benchmark completed. Collecting results."
   when: use_guidellm_container | bool
 
 - name: Get container exit details


### PR DESCRIPTION
This PR improves the usability and reliability of GuideLLM benchmark execution.

Changes included:

- consolidated benchmark start messaging into a single structured output block
- added controller-side progress logging for clean live monitoring with `tail -F`
- simplified progress states to `START`, `RUNNING`, and `COMPLETED`
- reduced misleading runtime messaging by removing target-overrun warning states
- added fallback result collection logic to preserve existing `synchronize` behavior while supporting environments where it fails
- validated local result generation and artifact collection end-to-end

**Example progress log**

```
2026-04-14T12:19:42Z | START
2026-04-14T12:20:16Z | RUNNING | elapsed=00:04
2026-04-14T13:19:51Z | COMPLETED
```

**Validation notes**

- benchmark completed successfully
- progress log updated cleanly during execution
- result artefacts were written locally
- fallback result collection path resolved the controller-side fetch issue observed previously

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added real-time progress monitoring with elapsed-time updates and periodic progress messages.
  * Added controller-side progress logging with timestamped START and COMPLETED markers.

* **Reliability**
  * Added a guarded fallback for results collection that ensures files are retrieved even if the primary transfer fails.

* **Improvements**
  * Improved container lifecycle handling and stricter exit-code failure detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->