### PR TITLE
feat: add vLLM scale-out deployment with nginx load balancing

### DIFF
--- a/automation/test-execution/ansible/ansible.md
+++ b/automation/test-execution/ansible/ansible.md
@@ -223,6 +223,15 @@ Done! See sections below for advanced usage and additional playbooks.
 | [collect-logs.yml](collect-logs.yml) | Collect logs from DUT | After tests |
 | [health-check.yml](health-check.yml) | Check vLLM server health | Standalone or imported |
 
+### Scale-Out Deployment
+
+| Playbook | Purpose | Usage |
+|----------|---------|-------|
+| [start-vllm-scaleout.yml](start-vllm-scaleout.yml) | Deploy N vLLM instances with nginx load balancing | `-e "scaleout_num_instances=5 scaleout_cores_per_instance=32"` |
+| [stop-vllm-scaleout.yml](stop-vllm-scaleout.yml) | Stop and cleanup scale-out deployment | `-e "scaleout_cleanup_volumes=true"` (optional) |
+
+**See the [vLLM Scale-Out Guide](../../docs/vllm-scaleout.md) for complete documentation.**
+
 ## Workload Types
 
 Pre-configured in [inventory/group_vars/all/test-workloads.yml](inventory/group_vars/all/test-workloads.yml):

--- a/automation/test-execution/ansible/ansible.md
+++ b/automation/test-execution/ansible/ansible.md
@@ -210,6 +210,15 @@ Done! See sections below for advanced usage and additional playbooks.
 | [collect-logs.yml](collect-logs.yml) | Collect logs from DUT | After tests |
 | [health-check.yml](health-check.yml) | Check vLLM server health | Standalone or imported |
 
+### Scale-Out Deployment
+
+| Playbook | Purpose | Usage |
+|----------|---------|-------|
+| [start-vllm-scaleout.yml](start-vllm-scaleout.yml) | Deploy N vLLM instances with nginx load balancing | `-e "scaleout_num_instances=5 scaleout_cores_per_instance=32"` |
+| [stop-vllm-scaleout.yml](stop-vllm-scaleout.yml) | Stop and cleanup scale-out deployment | `-e "scaleout_cleanup_volumes=true"` (optional) |
+
+**See the [vLLM Scale-Out Guide](../../docs/vllm-scaleout.md) for complete documentation.**
+
 ## Workload Types
 
 Pre-configured in [inventory/group_vars/all/test-workloads.yml](inventory/group_vars/all/test-workloads.yml):

--- a/automation/test-execution/ansible/inventory/examples/vllm-scaleout-deployment.yml
+++ b/automation/test-execution/ansible/inventory/examples/vllm-scaleout-deployment.yml
@@ -1,0 +1,100 @@
+---
+# Example Inventory for vLLM Scale-Out Deployment
+# Copy this to your main inventory and customize
+#
+# Usage:
+#   ansible-playbook -i inventory/examples/vllm-scaleout-deployment.yml start-vllm-scaleout.yml
+
+all:
+  children:
+    dut:
+      hosts:
+        vllm-server:
+          ansible_host: 192.168.1.100  # Change to your DUT IP
+          ansible_user: root
+          ansible_connection: ssh
+
+      vars:
+        # vLLM Server Configuration (from existing setup)
+        vllm_server:
+          container_runtime: podman
+          container_image: "docker.io/vllm/vllm-openai-cpu:v0.18.0"
+          host: "0.0.0.0"
+          port: 8000
+
+        # Model cache and logs
+        model_cache_dir: /var/lib/vllm-models
+        log_dir: /tmp/vllm-logs
+
+        # ======================================================================
+        # vLLM Scale-Out Configuration
+        # ======================================================================
+
+        # Scenario 1: Default - 5 instances, 32 cores each, least connections
+        scaleout_num_instances: 5
+        scaleout_cores_per_instance: 32
+        scaleout_start_core: 32
+        scaleout_enable_smt: false
+        scaleout_enable_prefix_caching: true
+        scaleout_nginx_policy: "least_conn"
+        scaleout_nginx_port: 8080
+
+        # Model to deploy
+        test_model: "RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8"
+
+        # Optional: HuggingFace token for gated models
+        # scaleout_hf_token: "hf_your_token_here"
+
+        # ======================================================================
+        # Alternative Scenarios (comment/uncomment as needed)
+        # ======================================================================
+
+        # Scenario 2: High instance count with smaller cores
+        # scaleout_num_instances: 8
+        # scaleout_cores_per_instance: 8
+        # scaleout_start_core: 32
+        # scaleout_enable_smt: true
+        # scaleout_nginx_policy: "round_robin"
+
+        # Scenario 3: Medium instance count
+        # scaleout_num_instances: 6
+        # scaleout_cores_per_instance: 16
+        # scaleout_start_core: 32
+        # scaleout_enable_smt: false
+        # scaleout_nginx_policy: "least_conn"
+
+        # Scenario 4: Prefix caching disabled
+        # scaleout_num_instances: 4
+        # scaleout_cores_per_instance: 32
+        # scaleout_enable_prefix_caching: false
+        # scaleout_nginx_policy: "ip_hash"
+
+        # ======================================================================
+        # Advanced Options
+        # ======================================================================
+
+        # Custom vLLM arguments
+        # scaleout_vllm_extra_args:
+        #   - "--max-model-len"
+        #   - "4096"
+        #   - "--dtype"
+        #   - "bfloat16"
+
+        # Custom nginx cores
+        # scaleout_nginx_cores: "1-15"
+
+        # Custom container images
+        # scaleout_vllm_image: "quay.io/vllm/automation-vllm:cpu-24515584412"
+        # scaleout_nginx_image: "nginx:alpine"
+
+    load_generator:
+      hosts:
+        benchmark-client:
+          ansible_host: 192.168.1.101  # Change to your load generator IP
+          ansible_user: root
+          ansible_connection: ssh
+
+      vars:
+        # GuideLLM configuration (for benchmarking the scale-out deployment)
+        guidellm:
+          target_url: "http://192.168.1.100:8080/v1"  # Points to nginx load balancer

--- a/automation/test-execution/ansible/inventory/group_vars/all/benchmark-tools.yml
+++ b/automation/test-execution/ansible/inventory/group_vars/all/benchmark-tools.yml
@@ -94,8 +94,9 @@ benchmark_tool:
     use_container: true
 
     # Container image for vllm bench
+    # Should match the vLLM server image for version consistency
     # Can be overridden with environment variable: export VLLM_BENCH_CONTAINER_IMAGE=...
-    container_image: "{{ lookup('env', 'VLLM_BENCH_CONTAINER_IMAGE') | default('quay.io/mtahhan/vllm:arm-base-cpu', true) }}"
+    container_image: "{{ lookup('env', 'VLLM_BENCH_CONTAINER_IMAGE') | default('docker.io/vllm/vllm-openai-cpu:v0.18.0', true) }}"
 
     # Number of prompts for embedding benchmark tests
     # Trade-off: sample size vs test duration

--- a/automation/test-execution/ansible/inventory/group_vars/all/vllm-scaleout.yml
+++ b/automation/test-execution/ansible/inventory/group_vars/all/vllm-scaleout.yml
@@ -1,0 +1,130 @@
+---
+# ============================================================================
+# vLLM Scale-Out Configuration
+# ============================================================================
+# Configuration for deploying multiple vLLM instances with nginx load balancing
+#
+# These settings control the scale-out deployment playbook (start-vllm-scaleout.yml)
+# Override these in your inventory or via command line with -e
+# ============================================================================
+
+# ============================================================================
+# Instance Configuration
+# ============================================================================
+
+# Number of vLLM instances to deploy (1-10)
+scaleout_num_instances: 5
+
+# Cores per instance (8, 16, or 32)
+# Total cores used = num_instances * cores_per_instance
+scaleout_cores_per_instance: 32
+
+# Starting CPU core number (instances will be allocated sequentially from this core)
+# Example: start_core=32, 3 instances, 32 cores each:
+#   Instance 1: cores 32-63
+#   Instance 2: cores 64-95
+#   Instance 3: cores 96-127
+scaleout_start_core: 32
+
+# Enable SMT/HyperThreading cores (true/false)
+# When enabled, allocates both physical and logical cores
+# Requires proper NUMA topology configuration
+scaleout_enable_smt: false
+
+# Enable prefix caching (true/false)
+# Prefix caching can significantly improve performance for repeated prompts
+scaleout_enable_prefix_caching: true
+
+# ============================================================================
+# Nginx Load Balancer Configuration
+# ============================================================================
+
+# CPU cores allocated to nginx (format: "start-end")
+scaleout_nginx_cores: "1-15"
+
+# External port for nginx load balancer
+scaleout_nginx_port: 8080
+
+# Load balancing policy
+# Options:
+#   - round_robin: Distribute requests evenly across all instances (default behavior)
+#   - least_conn: Send requests to instance with fewest active connections (best for varying request durations)
+#   - ip_hash: Consistent routing based on client IP (session affinity)
+scaleout_nginx_policy: "least_conn"
+
+# ============================================================================
+# Container Configuration
+# ============================================================================
+
+# vLLM container image
+# Options:
+#   - docker.io/vllm/vllm-openai-cpu:v0.18.0 (official vLLM)
+#   - quay.io/vllm/automation-vllm:cpu-24515584412 (Red Hat AI optimized)
+#   - localhost/vllm-rhaiis:latest (custom built)
+scaleout_vllm_image: "docker.io/vllm/vllm-openai-cpu:v0.18.0"
+
+# Nginx container image
+scaleout_nginx_image: "nginx:alpine"
+
+# Network and volume names
+scaleout_network_name: "vllm-network"
+scaleout_volume_name: "hf-cache"
+
+# ============================================================================
+# Model Configuration
+# ============================================================================
+
+# Model to deploy (can be HuggingFace model ID or local path)
+# This can be overridden at runtime with -e scaleout_model_name="model/name"
+# scaleout_model_name: "RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8"
+
+# Optional: Additional vLLM arguments
+# Uncomment and customize as needed
+# scaleout_vllm_extra_args:
+#   - "--max-model-len"
+#   - "2048"
+#   - "--dtype"
+#   - "bfloat16"
+#   - "--gpu-memory-utilization"
+#   - "0.9"
+
+# ============================================================================
+# Advanced Configuration
+# ============================================================================
+
+# Health check settings
+scaleout_health_check_retries: 30
+scaleout_health_check_delay: 5
+
+# Configuration directory on target system
+scaleout_config_dir: "/tmp/vllm-scaleout"
+
+# SMT core offset (system-specific, adjust based on NUMA topology)
+# Typical values:
+#   - 192 for systems with 192 physical cores
+#   - Auto-detect from lscpu if available
+scaleout_smt_offset: 192
+scaleout_smt_cores_per_instance: 8
+
+# ============================================================================
+# Example Configurations
+# ============================================================================
+#
+# Example 1: 3 instances, 16 cores each, round-robin
+#   scaleout_num_instances: 3
+#   scaleout_cores_per_instance: 16
+#   scaleout_nginx_policy: "round_robin"
+#
+# Example 2: 8 instances, 8 cores each, with SMT, least connections
+#   scaleout_num_instances: 8
+#   scaleout_cores_per_instance: 8
+#   scaleout_enable_smt: true
+#   scaleout_nginx_policy: "least_conn"
+#
+# Example 3: High-performance setup with prefix caching disabled
+#   scaleout_num_instances: 4
+#   scaleout_cores_per_instance: 32
+#   scaleout_enable_prefix_caching: false
+#   scaleout_nginx_policy: "ip_hash"
+#
+# ============================================================================

--- a/automation/test-execution/ansible/roles/vllm_scaleout/defaults/main.yml
+++ b/automation/test-execution/ansible/roles/vllm_scaleout/defaults/main.yml
@@ -1,0 +1,48 @@
+---
+# vLLM Scale-Out Role - Default Variables
+# These can be overridden in inventory or playbook
+
+# Deployment configuration
+scaleout_num_instances: 5
+scaleout_cores_per_instance: 32
+scaleout_start_core: 32
+scaleout_enable_smt: false
+scaleout_enable_prefix_caching: true
+
+# Nginx configuration
+scaleout_nginx_cores: "1-15"
+scaleout_nginx_port: 8080
+scaleout_nginx_policy: "least_conn"  # Options: round_robin, least_conn, ip_hash
+
+# Container configuration
+scaleout_vllm_image: "docker.io/vllm/vllm-openai-cpu:v0.18.0"
+scaleout_nginx_image: "nginx:alpine"
+scaleout_network_name: "vllm-network"
+scaleout_volume_name: "hf-cache"
+
+# Model configuration (override from inventory)
+scaleout_model_name: "{{ test_model | default('RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8') }}"
+
+# HuggingFace token (optional, set in inventory/group_vars/all/credentials.yml)
+# scaleout_hf_token: ""
+
+# Health check settings
+scaleout_health_check_retries: 30
+scaleout_health_check_delay: 5
+
+# Directories
+scaleout_config_dir: "/tmp/vllm-scaleout"
+scaleout_model_cache_dir: "{{ model_cache_dir | default('/var/lib/vllm-models') }}"
+
+# Advanced vLLM options (optional)
+scaleout_vllm_extra_args: []
+# Example:
+# scaleout_vllm_extra_args:
+#   - "--max-model-len"
+#   - "2048"
+#   - "--dtype"
+#   - "bfloat16"
+
+# SMT core offset (system-specific, adjust based on topology)
+scaleout_smt_offset: 192
+scaleout_smt_cores_per_instance: 8

--- a/automation/test-execution/ansible/roles/vllm_scaleout/tasks/cleanup.yml
+++ b/automation/test-execution/ansible/roles/vllm_scaleout/tasks/cleanup.yml
@@ -1,0 +1,29 @@
+---
+# Cleanup tasks for vLLM scale-out deployment
+# This can be imported by other playbooks
+
+- name: Stop all vLLM containers
+  containers.podman.podman_container:
+    name: "vllm-instance-{{ item }}"
+    state: absent
+  loop: "{{ range(1, scaleout_num_instances + 1) | list }}"
+  ignore_errors: true
+  when: vllm_server.container_runtime == 'podman'
+
+- name: Stop nginx container
+  containers.podman.podman_container:
+    name: vllm-nginx-lb
+    state: absent
+  ignore_errors: true
+  when: vllm_server.container_runtime == 'podman'
+
+- name: Remove network
+  containers.podman.podman_network:
+    name: "{{ scaleout_network_name }}"
+    state: absent
+  ignore_errors: true
+  when: vllm_server.container_runtime == 'podman'
+
+- name: Display cleanup completion
+  ansible.builtin.debug:
+    msg: "vLLM scale-out cleanup completed"

--- a/automation/test-execution/ansible/roles/vllm_scaleout/tasks/main.yml
+++ b/automation/test-execution/ansible/roles/vllm_scaleout/tasks/main.yml
@@ -1,0 +1,129 @@
+---
+# vLLM Scale-Out Deployment Tasks
+
+- name: Display scale-out configuration
+  ansible.builtin.debug:
+    msg:
+      - "vLLM Scale-Out Deployment Configuration:"
+      - "  Instances: {{ scaleout_num_instances }}"
+      - "  Cores per instance: {{ scaleout_cores_per_instance }}"
+      - "  Start core: {{ scaleout_start_core }}"
+      - "  SMT enabled: {{ scaleout_enable_smt }}"
+      - "  Prefix caching: {{ scaleout_enable_prefix_caching }}"
+      - "  Nginx policy: {{ scaleout_nginx_policy }}"
+      - "  Nginx port: {{ scaleout_nginx_port }}"
+      - "  Model: {{ scaleout_model_name }}"
+
+- name: Calculate CPU sets for each instance
+  ansible.builtin.set_fact:
+    scaleout_instance_cpusets: >-
+      {{
+        scaleout_instance_cpusets | default([]) +
+        [
+          (
+            (scaleout_start_core + (item - 1) * scaleout_cores_per_instance) | string + '-' +
+            (scaleout_start_core + item * scaleout_cores_per_instance - 1) | string +
+            (
+              (',' + (scaleout_smt_offset + (item - 1) * scaleout_smt_cores_per_instance) | string + '-' +
+              (scaleout_smt_offset + item * scaleout_smt_cores_per_instance - 1) | string)
+              if scaleout_enable_smt else ''
+            )
+          )
+        ]
+      }}
+  loop: "{{ range(1, scaleout_num_instances + 1) | list }}"
+
+- name: Display calculated CPU sets
+  ansible.builtin.debug:
+    msg:
+      - "Calculated CPU sets:"
+      - "{{ scaleout_instance_cpusets }}"
+
+- name: Create scale-out configuration directory
+  ansible.builtin.file:
+    path: "{{ scaleout_config_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Generate nginx configuration
+  ansible.builtin.template:
+    src: nginx.conf.j2
+    dest: "{{ scaleout_config_dir }}/nginx.conf"
+    mode: "0644"
+
+- name: Generate docker-compose configuration
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ scaleout_config_dir }}/docker-compose.yml"
+    mode: "0644"
+
+- name: Display generated configuration paths
+  ansible.builtin.debug:
+    msg:
+      - "Configuration files generated:"
+      - "  docker-compose.yml: {{ scaleout_config_dir }}/docker-compose.yml"
+      - "  nginx.conf: {{ scaleout_config_dir }}/nginx.conf"
+
+- name: Create podman network for vLLM scale-out
+  containers.podman.podman_network:
+    name: "{{ scaleout_network_name }}"
+    state: present
+  when: vllm_server.container_runtime == 'podman'
+
+- name: Create volume for HuggingFace cache
+  containers.podman.podman_volume:
+    name: "{{ scaleout_volume_name }}"
+    state: present
+  when: vllm_server.container_runtime == 'podman'
+
+- name: Start vLLM scale-out deployment with docker-compose
+  ansible.builtin.shell:
+    cmd: "podman-compose -f {{ scaleout_config_dir }}/docker-compose.yml up -d"
+    chdir: "{{ scaleout_config_dir }}"
+  when: vllm_server.container_runtime == 'podman'
+  register: compose_up
+
+- name: Display compose output
+  ansible.builtin.debug:
+    var: compose_up.stdout_lines
+  when: compose_up.stdout_lines is defined
+
+- name: Wait for vLLM instances to initialize
+  ansible.builtin.pause:
+    seconds: "{{ scaleout_health_check_delay * 2 }}"
+    prompt: "Waiting for vLLM instances to initialize..."
+
+- name: Check health of each vLLM instance
+  ansible.builtin.uri:
+    url: "http://localhost:{{ scaleout_nginx_port }}/health"
+    method: GET
+    status_code: 200
+  register: health_check
+  retries: "{{ scaleout_health_check_retries }}"
+  delay: "{{ scaleout_health_check_delay }}"
+  until: health_check.status == 200
+
+- name: Display deployment summary
+  ansible.builtin.debug:
+    msg:
+      - "╔══════════════════════════════════════════════════════════════════╗"
+      - "║ vLLM Scale-Out Deployment Successful                             ║"
+      - "╚══════════════════════════════════════════════════════════════════╝"
+      - ""
+      - "Deployment Details:"
+      - "  • Number of instances: {{ scaleout_num_instances }}"
+      - "  • Cores per instance: {{ scaleout_cores_per_instance }}"
+      - "  • Load balancing: {{ scaleout_nginx_policy }}"
+      - "  • Prefix caching: {{ scaleout_enable_prefix_caching | ternary('Enabled', 'Disabled') }}"
+      - ""
+      - "Access Points:"
+      - "  • Load Balancer: http://{{ ansible_host }}:{{ scaleout_nginx_port }}"
+      - "  • Health Check: http://{{ ansible_host }}:{{ scaleout_nginx_port }}/health"
+      - "  • Models API: http://{{ ansible_host }}:{{ scaleout_nginx_port }}/v1/models"
+      - "  • Chat API: http://{{ ansible_host }}:{{ scaleout_nginx_port }}/v1/chat/completions"
+      - "  • Nginx Status: http://{{ ansible_host }}:{{ scaleout_nginx_port }}/nginx_status"
+      - ""
+      - "Management Commands:"
+      - "  • View logs: podman-compose -f {{ scaleout_config_dir }}/docker-compose.yml logs -f"
+      - "  • Stop deployment: podman-compose -f {{ scaleout_config_dir }}/docker-compose.yml down"
+      - "  • Restart: podman-compose -f {{ scaleout_config_dir }}/docker-compose.yml restart"

--- a/automation/test-execution/ansible/roles/vllm_scaleout/templates/docker-compose.yml.j2
+++ b/automation/test-execution/ansible/roles/vllm_scaleout/templates/docker-compose.yml.j2
@@ -1,0 +1,72 @@
+version: '3.8'
+
+services:
+{% for i in range(1, scaleout_num_instances + 1) %}
+  # vLLM Instance {{ i }}
+  vllm-{{ i }}:
+    image: {{ scaleout_vllm_image }}
+    container_name: vllm-instance-{{ i }}
+    cpuset: "{{ scaleout_instance_cpusets[i - 1] }}"
+    cap_add:
+      - SYS_NICE
+    security_opt:
+      - seccomp=unconfined
+    environment:
+      - HF_HUB_OFFLINE=0
+      - HF_HOME=/root/.cache/huggingface
+{% if scaleout_hf_token is defined and scaleout_hf_token != '' %}
+      - HF_TOKEN={{ scaleout_hf_token }}
+{% endif %}
+    volumes:
+      - {{ scaleout_volume_name }}:/root/.cache/huggingface
+    command:
+      - --model
+      - {{ scaleout_model_name }}
+      - --port
+      - "8000"
+      - --host
+      - "0.0.0.0"
+{% if scaleout_enable_prefix_caching %}
+      - --enable-prefix-caching
+{% endif %}
+{% for arg in scaleout_vllm_extra_args %}
+      - {{ arg }}
+{% endfor %}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - {{ scaleout_network_name }}
+    restart: unless-stopped
+
+{% endfor %}
+  # Nginx Load Balancer
+  nginx:
+    image: {{ scaleout_nginx_image }}
+    container_name: vllm-nginx-lb
+    cpuset: "{{ scaleout_nginx_cores }}"
+    ports:
+      - "{{ scaleout_nginx_port }}:80"
+    volumes:
+      - {{ scaleout_config_dir }}/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+{% for i in range(1, scaleout_num_instances + 1) %}
+      - vllm-{{ i }}
+{% endfor %}
+    networks:
+      - {{ scaleout_network_name }}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+networks:
+  {{ scaleout_network_name }}:
+    driver: bridge
+
+volumes:
+  {{ scaleout_volume_name }}:

--- a/automation/test-execution/ansible/roles/vllm_scaleout/templates/nginx.conf.j2
+++ b/automation/test-execution/ansible/roles/vllm_scaleout/templates/nginx.conf.j2
@@ -1,0 +1,81 @@
+events {
+    worker_connections 4096;
+}
+
+http {
+    # Upstream configuration for vLLM instances
+    upstream vllm_backend {
+{% if scaleout_nginx_policy == 'least_conn' %}
+        least_conn;
+{% elif scaleout_nginx_policy == 'ip_hash' %}
+        ip_hash;
+{% endif %}
+{# round_robin is default, no directive needed #}
+
+{% for i in range(1, scaleout_num_instances + 1) %}
+        server vllm-{{ i }}:8000 max_fails=3 fail_timeout=30s;
+{% endfor %}
+    }
+
+    # Logging
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log warn;
+
+    # Server configuration
+    server {
+        listen 80;
+        server_name _;
+
+        # Increase timeouts for long-running inference requests
+        proxy_connect_timeout 300s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
+        send_timeout 300s;
+
+        # Increase buffer sizes for streaming responses
+        proxy_buffer_size 128k;
+        proxy_buffers 8 256k;
+        proxy_busy_buffers_size 512k;
+
+        # Health check endpoint
+        location /health {
+            proxy_pass http://vllm_backend/health;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+
+            # Retry on next upstream if one fails
+            proxy_next_upstream error timeout http_502 http_503 http_504;
+            proxy_next_upstream_tries {{ scaleout_num_instances }};
+        }
+
+        # Main API endpoints
+        location / {
+            proxy_pass http://vllm_backend;
+            proxy_http_version 1.1;
+
+            # Headers
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Connection "";
+
+            # Enable streaming for SSE (Server-Sent Events)
+            proxy_buffering off;
+            proxy_cache off;
+
+            # Retry on next upstream if one fails
+            proxy_next_upstream error timeout http_502 http_503 http_504;
+            proxy_next_upstream_tries {{ scaleout_num_instances }};
+
+            # Client settings
+            client_max_body_size 50M;
+        }
+
+        # Nginx status endpoint
+        location /nginx_status {
+            stub_status on;
+            access_log off;
+        }
+    }
+}

--- a/automation/test-execution/ansible/start-vllm-scaleout.yml
+++ b/automation/test-execution/ansible/start-vllm-scaleout.yml
@@ -1,0 +1,82 @@
+---
+# Start vLLM Scale-Out Deployment
+# Deploys multiple vLLM instances with nginx load balancing
+#
+# Usage:
+#   ansible-playbook start-vllm-scaleout.yml
+#   ansible-playbook start-vllm-scaleout.yml -e "scaleout_num_instances=3 scaleout_cores_per_instance=16"
+#   ansible-playbook start-vllm-scaleout.yml -e "scaleout_nginx_policy=round_robin"
+#
+# Configuration options (override with -e):
+#   - scaleout_num_instances: Number of vLLM instances (default: 5)
+#   - scaleout_cores_per_instance: Cores per instance - 8, 16, or 32 (default: 32)
+#   - scaleout_start_core: Starting CPU core (default: 32)
+#   - scaleout_enable_smt: Enable SMT/HT cores (default: false)
+#   - scaleout_enable_prefix_caching: Enable prefix caching (default: true)
+#   - scaleout_nginx_policy: Load balancing policy - round_robin, least_conn, ip_hash (default: least_conn)
+#   - scaleout_nginx_port: Nginx port (default: 8080)
+#   - scaleout_model_name: Model to deploy (default: from inventory)
+#
+# Examples:
+#   # Deploy 3 instances with 16 cores each, round-robin policy
+#   ansible-playbook start-vllm-scaleout.yml -e "scaleout_num_instances=3 scaleout_cores_per_instance=16 scaleout_nginx_policy=round_robin"
+#
+#   # Deploy 8 instances with 8 cores each, with SMT enabled
+#   ansible-playbook start-vllm-scaleout.yml -e "scaleout_num_instances=8 scaleout_cores_per_instance=8 scaleout_enable_smt=true"
+#
+#   # Deploy with prefix caching disabled
+#   ansible-playbook start-vllm-scaleout.yml -e "scaleout_enable_prefix_caching=false"
+
+- name: "Deploy vLLM Scale-Out Environment"
+  hosts: dut
+  become: true
+  vars:
+    # Override these via -e or in inventory
+    # See defaults in roles/vllm_scaleout/defaults/main.yml
+
+  pre_tasks:
+    - name: Check if podman-compose is installed
+      ansible.builtin.command: which podman-compose
+      register: podman_compose_check
+      changed_when: false
+      failed_when: false
+
+    - name: Fail if podman-compose is not installed
+      ansible.builtin.fail:
+        msg: |
+          podman-compose is not installed on the target system.
+          Install it with: pip3 install podman-compose
+      when: podman_compose_check.rc != 0
+
+    - name: Validate configuration
+      ansible.builtin.assert:
+        that:
+          - scaleout_num_instances | int > 0
+          - scaleout_num_instances | int <= 10
+          - scaleout_cores_per_instance | int in [8, 16, 32]
+          - scaleout_nginx_policy in ['round_robin', 'least_conn', 'ip_hash']
+        fail_msg: |
+          Invalid configuration:
+            - scaleout_num_instances must be 1-10
+            - scaleout_cores_per_instance must be 8, 16, or 32
+            - scaleout_nginx_policy must be round_robin, least_conn, or ip_hash
+
+  roles:
+    - role: vllm_scaleout
+
+  post_tasks:
+    - name: Test deployment health
+      ansible.builtin.uri:
+        url: "http://localhost:{{ scaleout_nginx_port }}/v1/models"
+        method: GET
+        return_content: true
+      register: models_api
+      retries: 3
+      delay: 5
+
+    - name: Display available models
+      ansible.builtin.debug:
+        msg:
+          - "Available models:"
+          - "{{ models_api.json | to_nice_json }}"
+      when: models_api.json is defined

--- a/automation/test-execution/ansible/stop-vllm-scaleout.yml
+++ b/automation/test-execution/ansible/stop-vllm-scaleout.yml
@@ -1,0 +1,72 @@
+---
+# Stop vLLM Scale-Out Deployment
+# Stops and removes all vLLM instances and nginx load balancer
+#
+# Usage:
+#   ansible-playbook stop-vllm-scaleout.yml
+#   ansible-playbook stop-vllm-scaleout.yml -e "scaleout_cleanup_volumes=true"
+
+- name: "Stop vLLM Scale-Out Deployment"
+  hosts: dut
+  become: true
+  vars:
+    scaleout_config_dir: "/tmp/vllm-scaleout"
+    scaleout_network_name: "vllm-network"
+    scaleout_volume_name: "hf-cache"
+    scaleout_cleanup_volumes: false  # Set to true to remove volumes
+
+  tasks:
+    - name: Check if configuration directory exists
+      ansible.builtin.stat:
+        path: "{{ scaleout_config_dir }}/docker-compose.yml"
+      register: compose_file
+
+    - name: Stop and remove containers
+      ansible.builtin.shell:
+        cmd: "podman-compose -f {{ scaleout_config_dir }}/docker-compose.yml down"
+        chdir: "{{ scaleout_config_dir }}"
+      when:
+        - compose_file.stat.exists
+        - vllm_server.container_runtime == 'podman'
+      register: compose_down
+      ignore_errors: true
+
+    - name: Display compose down output
+      ansible.builtin.debug:
+        var: compose_down.stdout_lines
+      when: compose_down.stdout_lines is defined
+
+    - name: Remove podman network
+      containers.podman.podman_network:
+        name: "{{ scaleout_network_name }}"
+        state: absent
+      when: vllm_server.container_runtime == 'podman'
+      ignore_errors: true
+
+    - name: Remove volume (if cleanup requested)
+      containers.podman.podman_volume:
+        name: "{{ scaleout_volume_name }}"
+        state: absent
+      when:
+        - vllm_server.container_runtime == 'podman'
+        - scaleout_cleanup_volumes | bool
+      ignore_errors: true
+
+    - name: Remove configuration directory (if cleanup requested)
+      ansible.builtin.file:
+        path: "{{ scaleout_config_dir }}"
+        state: absent
+      when: scaleout_cleanup_volumes | bool
+
+    - name: Display cleanup summary
+      ansible.builtin.debug:
+        msg:
+          - "╔══════════════════════════════════════════════════════════════════╗"
+          - "║ vLLM Scale-Out Deployment Stopped                                ║"
+          - "╚══════════════════════════════════════════════════════════════════╝"
+          - ""
+          - "Cleanup Status:"
+          - "  • Containers: Stopped and removed"
+          - "  • Network: Removed"
+          - "  • Volumes: {{ scaleout_cleanup_volumes | ternary('Removed', 'Preserved (use -e scaleout_cleanup_volumes=true to remove)') }}"
+          - "  • Config files: {{ scaleout_cleanup_volumes | ternary('Removed', 'Preserved at ' + scaleout_config_dir) }}"

--- a/docs/vllm-scaleout.md
+++ b/docs/vllm-scaleout.md
@@ -1,0 +1,370 @@
+---
+layout: default
+title: vLLM Scale-Out Deployment
+---
+
+## vLLM Scale-Out Deployment
+
+Deploy and test multiple vLLM instances with nginx load balancing for performance testing at scale.
+
+## Overview
+
+The scale-out deployment allows you to run N vLLM instances on a single DUT with configurable:
+
+- **Number of instances** (1-10)
+- **Cores per instance** (8, 16, or 32 cores)
+- **SMT/HyperThreading** (enable/disable)
+- **Prefix caching** (enable/disable)
+- **Load balancing policy** (round-robin, least connections, IP hash)
+
+### Architecture
+
+```
+┌─────────────────────────────────────────┐
+│  Load Generator Host                    │
+│  • GuideLLM concurrent tests            │
+└─────────────────────────────────────────┘
+              │
+              ▼
+┌─────────────────────────────────────────┐
+│  DUT Host (Remote)                      │
+│  ┌───────────────────────────────────┐  │
+│  │ Nginx LB (port 8080)              │  │
+│  └───────────────────────────────────┘  │
+│         │                               │
+│    ┌────┼────┐                         │
+│    ▼    ▼    ▼                         │
+│  [vLLM][vLLM][vLLM]  (N instances)    │
+│  32core 32core 32core                 │
+└─────────────────────────────────────────┘
+```
+
+**Key Points:**
+- All vLLM instances run on **one DUT host** (different CPU cores)
+- Nginx runs on **same DUT host** (via podman-compose)  
+- GuideLLM runs on **load_generator host** (remote)
+- Same deployment pattern as existing single-instance benchmarks
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+On the DUT:
+```bash
+pip3 install podman-compose
+```
+
+### Deploy
+
+```bash
+cd automation/test-execution/ansible
+
+# Deploy with defaults (5 instances × 32 cores, least connections)
+ansible-playbook start-vllm-scaleout.yml
+```
+
+### Test
+
+```bash
+# Health check
+curl http://DUT_IP:8080/health
+
+# Run concurrent benchmarks from load_generator
+ansible-playbook llm-benchmark-concurrent-load.yml
+```
+
+### Stop
+
+```bash
+ansible-playbook stop-vllm-scaleout.yml
+```
+
+---
+
+## Configuration
+
+### Parameters
+
+| Parameter | Default | Options | Description |
+|-----------|---------|---------|-------------|
+| `scaleout_num_instances` | 5 | 1-10 | Number of vLLM instances |
+| `scaleout_cores_per_instance` | 32 | 8, 16, 32 | CPU cores per instance |
+| `scaleout_enable_smt` | false | true/false | Enable SMT/HT cores |
+| `scaleout_enable_prefix_caching` | true | true/false | Enable prefix caching |
+| `scaleout_nginx_policy` | least_conn | round_robin, least_conn, ip_hash | Load balancing |
+
+### Load Balancing Policies
+
+- **`round_robin`** - Even distribution (best for uniform requests)
+- **`least_conn`** - Route to least busy (best for mixed workloads) ⭐ Recommended
+- **`ip_hash`** - Session affinity (best for stateful operations)
+
+### Example Configuration
+
+Edit `inventory/hosts.yml`:
+
+```yaml
+all:
+  children:
+    dut:
+      hosts:
+        vllm-server:
+          ansible_host: 192.168.1.101
+      vars:
+        scaleout_num_instances: 5
+        scaleout_cores_per_instance: 32
+        scaleout_nginx_policy: "least_conn"
+        test_model: "RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8"
+```
+
+See `inventory/examples/vllm-scaleout-deployment.yml` for complete example.
+
+---
+
+## Usage Examples
+
+### Custom Instance Count
+
+```bash
+# Deploy 3 instances with 16 cores each
+ansible-playbook start-vllm-scaleout.yml \
+  -e "scaleout_num_instances=3 scaleout_cores_per_instance=16"
+```
+
+### Different Load Balancing
+
+```bash
+# Use round-robin policy
+ansible-playbook start-vllm-scaleout.yml \
+  -e "scaleout_nginx_policy=round_robin"
+```
+
+### Enable SMT Cores
+
+```bash
+# Deploy 8 instances with 8 cores each + SMT
+ansible-playbook start-vllm-scaleout.yml \
+  -e "scaleout_num_instances=8 scaleout_cores_per_instance=8 scaleout_enable_smt=true"
+```
+
+### Disable Prefix Caching
+
+```bash
+ansible-playbook start-vllm-scaleout.yml \
+  -e "scaleout_enable_prefix_caching=false"
+```
+
+---
+
+## Testing & Benchmarking
+
+### Concurrent Load Testing
+
+```bash
+# Standard concurrent test
+ansible-playbook llm-benchmark-concurrent-load.yml
+
+# Auto benchmark sweep
+ansible-playbook llm-benchmark-auto.yml
+
+# Custom parameters
+ansible-playbook llm-benchmark-concurrent-load.yml \
+  -e "concurrent_users=50" \
+  -e "test_duration=300"
+```
+
+### Test Multiple Configurations
+
+```bash
+#!/bin/bash
+# Test different instance counts
+for n in 3 5 8; do
+  ansible-playbook start-vllm-scaleout.yml -e "scaleout_num_instances=$n"
+  ansible-playbook llm-benchmark-concurrent-load.yml
+  ansible-playbook collect-sweep-results.yml
+  ansible-playbook stop-vllm-scaleout.yml
+  sleep 30
+done
+```
+
+---
+
+## Management
+
+### View Status
+
+On the DUT:
+```bash
+# Container status
+podman ps
+
+# Service logs
+podman logs vllm-nginx-lb -f           # Nginx (see load distribution)
+podman logs vllm-instance-1 -f         # Specific vLLM instance
+
+# Nginx stats
+curl http://localhost:8080/nginx_status
+```
+
+### Restart Deployment
+
+```bash
+podman-compose -f /tmp/vllm-scaleout/docker-compose.yml restart
+```
+
+### Stop Deployment
+
+```bash
+# Stop (keep model cache)
+ansible-playbook stop-vllm-scaleout.yml
+
+# Stop and remove everything
+ansible-playbook stop-vllm-scaleout.yml -e "scaleout_cleanup_volumes=true"
+```
+
+---
+
+## Common Scenarios
+
+### Scenario 1: Test Instance Scaling
+
+Compare performance with 3, 5, and 8 instances:
+
+```bash
+for n in 3 5 8; do
+  ansible-playbook start-vllm-scaleout.yml -e "scaleout_num_instances=$n"
+  ansible-playbook llm-benchmark-concurrent-load.yml
+  ansible-playbook stop-vllm-scaleout.yml
+done
+```
+
+### Scenario 2: Test Core Allocation
+
+Compare 8 vs 16 vs 32 cores per instance:
+
+```bash
+for cores in 8 16 32; do
+  ansible-playbook start-vllm-scaleout.yml -e "scaleout_cores_per_instance=$cores"
+  ansible-playbook llm-benchmark-concurrent-load.yml
+  ansible-playbook stop-vllm-scaleout.yml
+done
+```
+
+### Scenario 3: Test Load Balancing Policies
+
+```bash
+for policy in round_robin least_conn; do
+  ansible-playbook start-vllm-scaleout.yml -e "scaleout_nginx_policy=$policy"
+  ansible-playbook llm-benchmark-concurrent-load.yml
+  ansible-playbook stop-vllm-scaleout.yml
+done
+```
+
+### Scenario 4: Test Prefix Caching Impact
+
+```bash
+for caching in true false; do
+  ansible-playbook start-vllm-scaleout.yml -e "scaleout_enable_prefix_caching=$caching"
+  ansible-playbook llm-benchmark-concurrent-load.yml
+  ansible-playbook stop-vllm-scaleout.yml
+done
+```
+
+---
+
+## Troubleshooting
+
+### Deployment Fails
+
+**Check prerequisites:**
+```bash
+podman-compose --version
+lscpu  # Verify sufficient cores available
+```
+
+**Check for conflicts:**
+```bash
+podman ps | grep -E "8000|8080"  # Check port usage
+```
+
+### Instance Won't Start
+
+```bash
+# Check logs
+podman logs vllm-instance-1
+
+# Common issues:
+# - Insufficient memory
+# - Model download failure (need HF token?)
+# - CPU core conflicts
+```
+
+### Nginx Not Distributing
+
+```bash
+# Verify nginx configuration
+podman exec vllm-nginx-lb nginx -t
+
+# Check upstream status
+curl http://localhost:8080/nginx_status
+
+# View load distribution
+podman logs vllm-nginx-lb | grep "upstream"
+```
+
+### Can't Connect from Load Generator
+
+```bash
+# On DUT, check firewall
+firewall-cmd --add-port=8080/tcp --permanent
+firewall-cmd --reload
+
+# Test locally first
+curl http://localhost:8080/health
+```
+
+---
+
+## Performance Tips
+
+1. **Match cores to NUMA nodes** - Use `lscpu --extended` to view topology
+2. **Disable SMT for vLLM** - Usually provides better single-thread performance
+3. **Enable prefix caching** - Significant speedup for repeated prompts
+4. **Use least_conn policy** - Best for mixed workloads
+5. **Monitor memory** - Each instance needs adequate RAM for the model
+6. **Test incrementally** - More instances isn't always better (overhead vs parallelism)
+
+---
+
+## Files & Directories
+
+### Playbooks
+
+- `automation/test-execution/ansible/start-vllm-scaleout.yml` - Deploy scale-out
+- `automation/test-execution/ansible/stop-vllm-scaleout.yml` - Cleanup
+
+### Configuration
+
+- `inventory/group_vars/all/vllm-scaleout.yml` - Default settings
+- `inventory/examples/vllm-scaleout-deployment.yml` - Example inventory
+
+### Role
+
+- `roles/vllm_scaleout/` - Ansible role for deployment
+  - `defaults/main.yml` - Default variables
+  - `tasks/main.yml` - Deployment tasks
+  - `templates/` - Jinja2 templates for docker-compose and nginx
+
+---
+
+## Related Documentation
+
+- [Getting Started Guide](getting-started.md) - Initial setup
+- [Methodology Overview](methodology/overview.md) - Testing methodology
+- [Metrics Collection](metrics-collection.md) - Performance metrics
+
+For detailed Ansible documentation, see:
+- [Full Ansible Guide](https://github.com/redhat-et/vllm-cpu-perf-eval/blob/main/automation/test-execution/ansible/ansible.md)
+- [Configuration Reference](https://github.com/redhat-et/vllm-cpu-perf-eval/blob/main/automation/test-execution/ansible/inventory/group_vars/all/vllm-scaleout.yml)

--- a/docs/vllm-scaleout.md
+++ b/docs/vllm-scaleout.md
@@ -1,0 +1,370 @@
+---
+layout: default
+title: vLLM Scale-Out Deployment
+---
+
+## vLLM Scale-Out Deployment
+
+Deploy and test multiple vLLM instances with nginx load balancing for performance testing at scale.
+
+## Overview
+
+The scale-out deployment allows you to run N vLLM instances on a single DUT with configurable:
+
+- **Number of instances** (1-10)
+- **Cores per instance** (8, 16, or 32 cores)
+- **SMT/HyperThreading** (enable/disable)
+- **Prefix caching** (enable/disable)
+- **Load balancing policy** (round-robin, least connections, IP hash)
+
+### Architecture
+
+```
+┌─────────────────────────────────────────┐
+│  Load Generator Host                    │
+│  • GuideLLM concurrent tests            │
+└─────────────────────────────────────────┘
+              │
+              ▼
+┌─────────────────────────────────────────┐
+│  DUT Host (Remote)                      │
+│  ┌───────────────────────────────────┐  │
+│  │ Nginx LB (port 8080)              │  │
+│  └───────────────────────────────────┘  │
+│         │                               │
+│    ┌────┼────┐                         │
+│    ▼    ▼    ▼                         │
+│  [vLLM][vLLM][vLLM]  (N instances)    │
+│  32core 32core 32core                 │
+└─────────────────────────────────────────┘
+```
+
+**Key Points:**
+- All vLLM instances run on **one DUT host** (different CPU cores)
+- Nginx runs on **same DUT host** (via podman-compose)
+- GuideLLM runs on **load_generator host** (remote)
+- Same deployment pattern as existing single-instance benchmarks
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+On the DUT:
+```bash
+pip3 install podman-compose
+```
+
+### Deploy
+
+```bash
+cd automation/test-execution/ansible
+
+# Deploy with defaults (5 instances × 32 cores, least connections)
+ansible-playbook start-vllm-scaleout.yml
+```
+
+### Test
+
+```bash
+# Health check
+curl http://DUT_IP:8080/health
+
+# Run concurrent benchmarks from load_generator
+ansible-playbook llm-benchmark-concurrent-load.yml
+```
+
+### Stop
+
+```bash
+ansible-playbook stop-vllm-scaleout.yml
+```
+
+---
+
+## Configuration
+
+### Parameters
+
+| Parameter | Default | Options | Description |
+|-----------|---------|---------|-------------|
+| `scaleout_num_instances` | 5 | 1-10 | Number of vLLM instances |
+| `scaleout_cores_per_instance` | 32 | 8, 16, 32 | CPU cores per instance |
+| `scaleout_enable_smt` | false | true/false | Enable SMT/HT cores |
+| `scaleout_enable_prefix_caching` | true | true/false | Enable prefix caching |
+| `scaleout_nginx_policy` | least_conn | round_robin, least_conn, ip_hash | Load balancing |
+
+### Load Balancing Policies
+
+- **`round_robin`** - Even distribution (best for uniform requests)
+- **`least_conn`** - Route to least busy (best for mixed workloads) ⭐ Recommended
+- **`ip_hash`** - Session affinity (best for stateful operations)
+
+### Example Configuration
+
+Edit `inventory/hosts.yml`:
+
+```yaml
+all:
+  children:
+    dut:
+      hosts:
+        vllm-server:
+          ansible_host: 192.168.1.101
+      vars:
+        scaleout_num_instances: 5
+        scaleout_cores_per_instance: 32
+        scaleout_nginx_policy: "least_conn"
+        test_model: "RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8"
+```
+
+See `inventory/examples/vllm-scaleout-deployment.yml` for complete example.
+
+---
+
+## Usage Examples
+
+### Custom Instance Count
+
+```bash
+# Deploy 3 instances with 16 cores each
+ansible-playbook start-vllm-scaleout.yml \
+  -e "scaleout_num_instances=3 scaleout_cores_per_instance=16"
+```
+
+### Different Load Balancing
+
+```bash
+# Use round-robin policy
+ansible-playbook start-vllm-scaleout.yml \
+  -e "scaleout_nginx_policy=round_robin"
+```
+
+### Enable SMT Cores
+
+```bash
+# Deploy 8 instances with 8 cores each + SMT
+ansible-playbook start-vllm-scaleout.yml \
+  -e "scaleout_num_instances=8 scaleout_cores_per_instance=8 scaleout_enable_smt=true"
+```
+
+### Disable Prefix Caching
+
+```bash
+ansible-playbook start-vllm-scaleout.yml \
+  -e "scaleout_enable_prefix_caching=false"
+```
+
+---
+
+## Testing & Benchmarking
+
+### Concurrent Load Testing
+
+```bash
+# Standard concurrent test
+ansible-playbook llm-benchmark-concurrent-load.yml
+
+# Auto benchmark sweep
+ansible-playbook llm-benchmark-auto.yml
+
+# Custom parameters
+ansible-playbook llm-benchmark-concurrent-load.yml \
+  -e "concurrent_users=50" \
+  -e "test_duration=300"
+```
+
+### Test Multiple Configurations
+
+```bash
+#!/bin/bash
+# Test different instance counts
+for n in 3 5 8; do
+  ansible-playbook start-vllm-scaleout.yml -e "scaleout_num_instances=$n"
+  ansible-playbook llm-benchmark-concurrent-load.yml
+  ansible-playbook collect-sweep-results.yml
+  ansible-playbook stop-vllm-scaleout.yml
+  sleep 30
+done
+```
+
+---
+
+## Management
+
+### View Status
+
+On the DUT:
+```bash
+# Container status
+podman ps
+
+# Service logs
+podman logs vllm-nginx-lb -f           # Nginx (see load distribution)
+podman logs vllm-instance-1 -f         # Specific vLLM instance
+
+# Nginx stats
+curl http://localhost:8080/nginx_status
+```
+
+### Restart Deployment
+
+```bash
+podman-compose -f /tmp/vllm-scaleout/docker-compose.yml restart
+```
+
+### Stop Deployment
+
+```bash
+# Stop (keep model cache)
+ansible-playbook stop-vllm-scaleout.yml
+
+# Stop and remove everything
+ansible-playbook stop-vllm-scaleout.yml -e "scaleout_cleanup_volumes=true"
+```
+
+---
+
+## Common Scenarios
+
+### Scenario 1: Test Instance Scaling
+
+Compare performance with 3, 5, and 8 instances:
+
+```bash
+for n in 3 5 8; do
+  ansible-playbook start-vllm-scaleout.yml -e "scaleout_num_instances=$n"
+  ansible-playbook llm-benchmark-concurrent-load.yml
+  ansible-playbook stop-vllm-scaleout.yml
+done
+```
+
+### Scenario 2: Test Core Allocation
+
+Compare 8 vs 16 vs 32 cores per instance:
+
+```bash
+for cores in 8 16 32; do
+  ansible-playbook start-vllm-scaleout.yml -e "scaleout_cores_per_instance=$cores"
+  ansible-playbook llm-benchmark-concurrent-load.yml
+  ansible-playbook stop-vllm-scaleout.yml
+done
+```
+
+### Scenario 3: Test Load Balancing Policies
+
+```bash
+for policy in round_robin least_conn; do
+  ansible-playbook start-vllm-scaleout.yml -e "scaleout_nginx_policy=$policy"
+  ansible-playbook llm-benchmark-concurrent-load.yml
+  ansible-playbook stop-vllm-scaleout.yml
+done
+```
+
+### Scenario 4: Test Prefix Caching Impact
+
+```bash
+for caching in true false; do
+  ansible-playbook start-vllm-scaleout.yml -e "scaleout_enable_prefix_caching=$caching"
+  ansible-playbook llm-benchmark-concurrent-load.yml
+  ansible-playbook stop-vllm-scaleout.yml
+done
+```
+
+---
+
+## Troubleshooting
+
+### Deployment Fails
+
+**Check prerequisites:**
+```bash
+podman-compose --version
+lscpu  # Verify sufficient cores available
+```
+
+**Check for conflicts:**
+```bash
+podman ps | grep -E "8000|8080"  # Check port usage
+```
+
+### Instance Won't Start
+
+```bash
+# Check logs
+podman logs vllm-instance-1
+
+# Common issues:
+# - Insufficient memory
+# - Model download failure (need HF token?)
+# - CPU core conflicts
+```
+
+### Nginx Not Distributing
+
+```bash
+# Verify nginx configuration
+podman exec vllm-nginx-lb nginx -t
+
+# Check upstream status
+curl http://localhost:8080/nginx_status
+
+# View load distribution
+podman logs vllm-nginx-lb | grep "upstream"
+```
+
+### Can't Connect from Load Generator
+
+```bash
+# On DUT, check firewall
+firewall-cmd --add-port=8080/tcp --permanent
+firewall-cmd --reload
+
+# Test locally first
+curl http://localhost:8080/health
+```
+
+---
+
+## Performance Tips
+
+1. **Match cores to NUMA nodes** - Use `lscpu --extended` to view topology
+2. **Disable SMT for vLLM** - Usually provides better single-thread performance
+3. **Enable prefix caching** - Significant speedup for repeated prompts
+4. **Use least_conn policy** - Best for mixed workloads
+5. **Monitor memory** - Each instance needs adequate RAM for the model
+6. **Test incrementally** - More instances isn't always better (overhead vs parallelism)
+
+---
+
+## Files & Directories
+
+### Playbooks
+
+- `automation/test-execution/ansible/start-vllm-scaleout.yml` - Deploy scale-out
+- `automation/test-execution/ansible/stop-vllm-scaleout.yml` - Cleanup
+
+### Configuration
+
+- `inventory/group_vars/all/vllm-scaleout.yml` - Default settings
+- `inventory/examples/vllm-scaleout-deployment.yml` - Example inventory
+
+### Role
+
+- `roles/vllm_scaleout/` - Ansible role for deployment
+  - `defaults/main.yml` - Default variables
+  - `tasks/main.yml` - Deployment tasks
+  - `templates/` - Jinja2 templates for docker-compose and nginx
+
+---
+
+## Related Documentation
+
+- [Getting Started Guide](getting-started.md) - Initial setup
+- [Methodology Overview](methodology/overview.md) - Testing methodology
+- [Metrics Collection](metrics-collection.md) - Performance metrics
+
+For detailed Ansible documentation, see:
+- [Full Ansible Guide](https://github.com/redhat-et/vllm-cpu-perf-eval/blob/main/automation/test-execution/ansible/ansible.md)
+- [Configuration Reference](https://github.com/redhat-et/vllm-cpu-perf-eval/blob/main/automation/test-execution/ansible/inventory/group_vars/all/vllm-scaleout.yml)

--- a/index.md
+++ b/index.md
@@ -23,6 +23,12 @@ This site provides complete testing methodology, automation tools, and platform 
   </div>
 
   <div class="link-card">
+    <h3>⚖️ vLLM Scale-Out</h3>
+    <p>Deploy multiple vLLM instances with nginx load balancing</p>
+    <a href="docs/vllm-scaleout">Scale-Out Guide →</a>
+  </div>
+
+  <div class="link-card">
     <h3>🧪 Test Suites</h3>
     <p>Explore concurrent load, scalability, and embedding model tests</p>
     <a href="tests/tests">Test Suites Overview →</a>


### PR DESCRIPTION
Adds turnkey Ansible automation for deploying multiple vLLM instances on a single DUT with configurable nginx load balancing. Enables performance testing at scale with flexible configuration of instance count (1-10), cores per instance (8/16/32), SMT, prefix caching, and load balancing policies (round-robin/least-conn/ip-hash). Includes comprehensive documentation, example inventory, and integration with existing GuideLLM benchmark playbooks.