### PR TITLE
feat: add custom test naming with dashboard filtering

### DIFF
--- a/automation/test-execution/ansible/ansible.md
+++ b/automation/test-execution/ansible/ansible.md
@@ -612,7 +612,7 @@ ansible-playbook -i inventory/hosts.yml llm-benchmark-auto.yml \
   -e "test_name=baseline-v1"
 ```
 
-**Result:** Test run ID becomes `baseline-v1-20260423-143022` (name + timestamp)
+**Result:** Test run ID becomes `20260423-143022-baseline-v1` (timestamp + name)
 
 **Core sweep with custom name:**
 

--- a/automation/test-execution/ansible/ansible.md
+++ b/automation/test-execution/ansible/ansible.md
@@ -597,6 +597,50 @@ ansible-playbook -i inventory/hosts.yml llm-benchmark-auto.yml \
 
 Defaults are defined in [inventory/group_vars/all/benchmark-tools.yml](inventory/group_vars/all/benchmark-tools.yml).
 
+### Custom Test Naming
+
+Assign custom names to benchmark tests for easier identification and filtering in Streamlit dashboards.
+
+**Usage:**
+
+```bash
+# Single test with custom name
+ansible-playbook -i inventory/hosts.yml llm-benchmark-auto.yml \
+  -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \
+  -e "workload_type=chat" \
+  -e "requested_cores=16" \
+  -e "test_name=baseline-v1"
+```
+
+**Result:** Test run ID becomes `baseline-v1-20260423-143022` (name + timestamp)
+
+**Core sweep with custom name:**
+
+```bash
+ansible-playbook -i inventory/hosts.yml llm-core-sweep-auto.yml \
+  -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \
+  -e "workload_type=chat" \
+  -e "requested_cores_list=[8,16,32,64]" \
+  -e "test_name=perf-optimization-test"
+```
+
+All tests in the sweep share the custom name.
+
+**Dashboard filtering:**
+
+When tests have custom names, Streamlit dashboards automatically display a "Custom Test Names" filter, allowing you to:
+- Filter results by test name
+- Compare specific test runs
+- Track iterations (e.g., baseline-v1, baseline-v2, optimized-v1)
+
+**Best practices:**
+- Keep names under 30 characters
+- Use alphanumeric characters and hyphens only
+- Examples: `baseline-v1`, `cache-enabled`, `production-candidate`, `bug-123-repro`
+- Avoid spaces (use hyphens instead)
+
+**Backward compatibility:** Tests without `test_name` work as before (timestamp-only IDs).
+
 ## Troubleshooting
 
 ### Connection Issues

--- a/automation/test-execution/ansible/llm-benchmark-auto.yml
+++ b/automation/test-execution/ansible/llm-benchmark-auto.yml
@@ -111,25 +111,21 @@
         fail_msg: "guidellm_max_requests must be a positive integer, got: {{ guidellm_max_requests }}"
       when: guidellm_max_requests is defined
 
-    - name: Generate timestamp component for test run ID
-      ansible.builtin.set_fact:
-        _test_timestamp: "{{ lookup('pipe', 'date +%Y%m%d-%H%M%S') }}"
-      when: test_run_id is not defined
-
-    - name: Generate test run ID with custom name if provided
-      ansible.builtin.set_fact:
-        test_run_id: "{{ test_name }}-{{ _test_timestamp }}"
+    - name: Validate test_name format if provided
+      ansible.builtin.assert:
+        that:
+          - test_name | length >= 1
+          - test_name | length <= 30
+          - test_name is match('^[A-Za-z0-9-]+$')
+        fail_msg: "test_name must be 1-30 chars, alphanumeric or hyphens only, got: '{{ test_name }}'"
       when:
-        - test_run_id is not defined
         - test_name is defined
         - test_name | length > 0
 
-    - name: Generate test run ID without custom name (default)
+    - name: Generate test run ID
       ansible.builtin.set_fact:
-        test_run_id: "{{ _test_timestamp }}"
-      when:
-        - test_run_id is not defined
-        - (test_name is not defined or test_name | length == 0)
+        test_run_id: "{{ (test_name is defined and test_name | length > 0) | ternary((lookup('pipe', 'date +%Y%m%d-%H%M%S') ~ '-' ~ test_name), lookup('pipe', 'date +%Y%m%d-%H%M%S')) }}"
+      when: test_run_id is not defined
 
     - name: Handle external endpoint model detection/validation
       when: vllm_mode == 'external'
@@ -536,7 +532,7 @@
         content: |
           {
             "test_run_id": "{{ test_run_id }}",
-            "test_name": "{{ hostvars['localhost']['test_name'] | default('') }}",
+            "test_name": "{{ test_name | default('') }}",
             "config_type": "auto",
             "core_config_name": "{{ core_configuration.name }}",
             "core_count": {{ core_configuration.cores }},

--- a/automation/test-execution/ansible/llm-benchmark-auto.yml
+++ b/automation/test-execution/ansible/llm-benchmark-auto.yml
@@ -111,10 +111,25 @@
         fail_msg: "guidellm_max_requests must be a positive integer, got: {{ guidellm_max_requests }}"
       when: guidellm_max_requests is defined
 
-    - name: Generate test run ID if not provided
+    - name: Generate timestamp component for test run ID
       ansible.builtin.set_fact:
-        test_run_id: "{{ lookup('pipe', 'date +%Y%m%d-%H%M%S') }}"
+        _test_timestamp: "{{ lookup('pipe', 'date +%Y%m%d-%H%M%S') }}"
       when: test_run_id is not defined
+
+    - name: Generate test run ID with custom name if provided
+      ansible.builtin.set_fact:
+        test_run_id: "{{ test_name }}-{{ _test_timestamp }}"
+      when:
+        - test_run_id is not defined
+        - test_name is defined
+        - test_name | length > 0
+
+    - name: Generate test run ID without custom name (default)
+      ansible.builtin.set_fact:
+        test_run_id: "{{ _test_timestamp }}"
+      when:
+        - test_run_id is not defined
+        - (test_name is not defined or test_name | length == 0)
 
     - name: Handle external endpoint model detection/validation
       when: vllm_mode == 'external'
@@ -521,6 +536,7 @@
         content: |
           {
             "test_run_id": "{{ test_run_id }}",
+            "test_name": "{{ hostvars['localhost']['test_name'] | default('') }}",
             "config_type": "auto",
             "core_config_name": "{{ core_configuration.name }}",
             "core_count": {{ core_configuration.cores }},

--- a/automation/test-execution/ansible/llm-core-sweep-auto.yml
+++ b/automation/test-execution/ansible/llm-core-sweep-auto.yml
@@ -15,7 +15,8 @@
   gather_facts: false
   any_errors_fatal: true
   vars:
-    test_run_id: "{{ lookup('pipe', 'date +%Y%m%d-%H%M%S') }}"
+    _test_timestamp: "{{ lookup('pipe', 'date +%Y%m%d-%H%M%S') }}"
+    test_run_id: "{{ (test_name ~ '-' ~ _test_timestamp) if (test_name is defined and test_name | length > 0) else _test_timestamp }}"
 
   tasks:
     - name: Detect if running from AWX

--- a/automation/test-execution/ansible/llm-core-sweep-auto.yml
+++ b/automation/test-execution/ansible/llm-core-sweep-auto.yml
@@ -16,9 +16,20 @@
   any_errors_fatal: true
   vars:
     _test_timestamp: "{{ lookup('pipe', 'date +%Y%m%d-%H%M%S') }}"
-    test_run_id: "{{ (test_name ~ '-' ~ _test_timestamp) if (test_name is defined and test_name | length > 0) else _test_timestamp }}"
+    test_run_id: "{{ (_test_timestamp ~ '-' ~ test_name) if (test_name is defined and test_name | length > 0) else _test_timestamp }}"
 
   tasks:
+    - name: Validate test_name format if provided
+      ansible.builtin.assert:
+        that:
+          - test_name | length >= 1
+          - test_name | length <= 30
+          - test_name is match('^[A-Za-z0-9-]+$')
+        fail_msg: "test_name must be 1-30 chars, alphanumeric or hyphens only, got: '{{ test_name }}'"
+      when:
+        - test_name is defined
+        - test_name | length > 0
+
     - name: Detect if running from AWX
       ansible.builtin.set_fact:
         awx_job_id: "{{ lookup('env', 'AWX_JOB_ID') }}"

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/1_📊_Client_Metrics.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/1_📊_Client_Metrics.py
@@ -600,9 +600,10 @@ def render_performance_plots(df: pd.DataFrame):
             endpoint_short = endpoint_url.split('//', 1)[-1].rsplit('@', 1)[-1].split('/', 1)[0]
             base_label = f"{endpoint_short} | {full_model} | {vllm_version} | TP={tp} | {workload}"
 
-        # Add test_name to label if it exists
+        # Add test_name to label if it exists (with run ID for disambiguation)
         if test_name and test_name.strip():
-            base_label = f"[{test_name}] {base_label}"
+            run_id_short = test_id[:8] if len(test_id) >= 8 else test_id
+            base_label = f"[{test_name}] {base_label} (run {run_id_short})"
 
         # Plot each selected percentile
         for percentile in selected_percentiles:
@@ -685,9 +686,10 @@ def render_performance_plots(df: pd.DataFrame):
                 'Backend': backend,
             }
 
-            # Add test name if it exists
+            # Add test name if it exists (with run ID for disambiguation)
             if test_name and test_name.strip():
-                row['Test Name'] = test_name
+                run_id_short = test_id[:8] if len(test_id) >= 8 else test_id
+                row['Test Name'] = f"{test_name} (run {run_id_short})"
 
             # Add platform/cores for managed, endpoint for external
             if vllm_mode == 'managed':
@@ -994,11 +996,13 @@ def render_compare_versions(df: pd.DataFrame):
         baseline_label = f"Baseline: {baseline_endpoint_short} | {baseline_run_info['vllm_version']} | {baseline_run_info['workload']}"
         compare_label = f"Compare: {compare_endpoint_short} | {compare_run_info['vllm_version']} | {compare_run_info['workload']}"
 
-    # Add test names to labels if they exist
+    # Add test names to labels if they exist (with run ID for disambiguation)
     if baseline_run_info.get('test_name') and baseline_run_info['test_name'].strip():
-        baseline_label = f"[{baseline_run_info['test_name']}] {baseline_label}"
+        baseline_run_id_short = baseline_run_info['test_run_id'][:8] if len(baseline_run_info['test_run_id']) >= 8 else baseline_run_info['test_run_id']
+        baseline_label = f"[{baseline_run_info['test_name']}] {baseline_label} (run {baseline_run_id_short})"
     if compare_run_info.get('test_name') and compare_run_info['test_name'].strip():
-        compare_label = f"[{compare_run_info['test_name']}] {compare_label}"
+        compare_run_id_short = compare_run_info['test_run_id'][:8] if len(compare_run_info['test_run_id']) >= 8 else compare_run_info['test_run_id']
+        compare_label = f"[{compare_run_info['test_name']}] {compare_label} (run {compare_run_id_short})"
 
     # Throughput
     for data, name, color in [

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/1_📊_Client_Metrics.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/1_📊_Client_Metrics.py
@@ -238,7 +238,7 @@ def render_filters(df: pd.DataFrame, test_mode: str) -> pd.DataFrame:
             )
 
         # Test name filter (separate row if any tests have custom names)
-        if df['test_name'].str.len().sum() > 0:
+        if df['test_name'].astype(str).ne('').any():
             test_names = sorted([n for n in df['test_name'].unique() if n])
             if test_names:
                 st.markdown("**Test Name Filter:**")
@@ -251,8 +251,10 @@ def render_filters(df: pd.DataFrame, test_mode: str) -> pd.DataFrame:
                 )
             else:
                 selected_test_names = []
+            all_test_names = test_names
         else:
             selected_test_names = []
+            all_test_names = []
 
         st.markdown('</div>', unsafe_allow_html=True)
 
@@ -266,8 +268,8 @@ def render_filters(df: pd.DataFrame, test_mode: str) -> pd.DataFrame:
             df['guidellm_version'].isin(selected_guidellm_versions)
         ]
 
-        # Apply test name filter if any selected
-        if selected_test_names:
+        # Apply test name filter only if user has deselected some names
+        if selected_test_names and selected_test_names != all_test_names:
             filtered_df = filtered_df[filtered_df['test_name'].isin(selected_test_names)]
 
     else:  # external mode
@@ -333,7 +335,7 @@ def render_filters(df: pd.DataFrame, test_mode: str) -> pd.DataFrame:
             )
 
         # Test name filter (separate row if any tests have custom names)
-        if df['test_name'].str.len().sum() > 0:
+        if df['test_name'].astype(str).ne('').any():
             test_names = sorted([n for n in df['test_name'].unique() if n])
             if test_names:
                 st.markdown("**Test Name Filter:**")
@@ -346,8 +348,10 @@ def render_filters(df: pd.DataFrame, test_mode: str) -> pd.DataFrame:
                 )
             else:
                 selected_test_names = []
+            all_test_names = test_names
         else:
             selected_test_names = []
+            all_test_names = []
 
         st.markdown('</div>', unsafe_allow_html=True)
 
@@ -361,8 +365,8 @@ def render_filters(df: pd.DataFrame, test_mode: str) -> pd.DataFrame:
             df['model_source'].isin(selected_sources)
         ]
 
-        # Apply test name filter if any selected
-        if selected_test_names:
+        # Apply test name filter only if user has deselected some names
+        if selected_test_names and selected_test_names != all_test_names:
             filtered_df = filtered_df[filtered_df['test_name'].isin(selected_test_names)]
 
     return filtered_df

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/1_📊_Client_Metrics.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/1_📊_Client_Metrics.py
@@ -559,10 +559,10 @@ def render_performance_plots(df: pd.DataFrame):
         # For metrics without percentiles, use the base column
         selected_percentiles = [None]
 
-    # Group by test configuration
+    # Group by test configuration (include test_name to separate named tests)
     grouped = df.groupby([
         'platform', 'model_short', 'workload', 'vllm_version',
-        'cores', 'tensor_parallel', 'test_run_id'
+        'cores', 'tensor_parallel', 'test_name', 'test_run_id'
     ])
 
     # Create plot
@@ -579,7 +579,7 @@ def render_performance_plots(df: pd.DataFrame):
 
     color_idx = 0
 
-    for (platform, model, workload, vllm_version, cores, tp, test_id), group_df in grouped:
+    for (platform, model, workload, vllm_version, cores, tp, test_name, test_id), group_df in grouped:
         # Sort by selected x-axis
         group_df = group_df.sort_values(x_col)
 
@@ -595,6 +595,10 @@ def render_performance_plots(df: pd.DataFrame):
             endpoint_url = group_df['vllm_endpoint_url'].iloc[0]
             endpoint_short = endpoint_url.split('//', 1)[-1].rsplit('@', 1)[-1].split('/', 1)[0]
             base_label = f"{endpoint_short} | {full_model} | {vllm_version} | TP={tp} | {workload}"
+
+        # Add test_name to label if it exists
+        if test_name and test_name.strip():
+            base_label = f"[{test_name}] {base_label}"
 
         # Plot each selected percentile
         for percentile in selected_percentiles:
@@ -664,7 +668,7 @@ def render_performance_plots(df: pd.DataFrame):
 
         for (
             platform, model, workload,
-            vllm_version, cores, tp, test_id
+            vllm_version, cores, tp, test_name, test_id
         ), group_df in grouped:
             backend = group_df['backend'].iloc[0]
             vllm_mode = group_df['vllm_mode'].iloc[0]
@@ -676,6 +680,10 @@ def render_performance_plots(df: pd.DataFrame):
                 'TP': tp,
                 'Backend': backend,
             }
+
+            # Add test name if it exists
+            if test_name and test_name.strip():
+                row['Test Name'] = test_name
 
             # Add platform/cores for managed, endpoint for external
             if vllm_mode == 'managed':
@@ -981,6 +989,12 @@ def render_compare_versions(df: pd.DataFrame):
         compare_endpoint_short = compare_endpoint.split('//', 1)[-1].rsplit('@', 1)[-1].split('/', 1)[0]
         baseline_label = f"Baseline: {baseline_endpoint_short} | {baseline_run_info['vllm_version']} | {baseline_run_info['workload']}"
         compare_label = f"Compare: {compare_endpoint_short} | {compare_run_info['vllm_version']} | {compare_run_info['workload']}"
+
+    # Add test names to labels if they exist
+    if baseline_run_info.get('test_name') and baseline_run_info['test_name'].strip():
+        baseline_label = f"[{baseline_run_info['test_name']}] {baseline_label}"
+    if compare_run_info.get('test_name') and compare_run_info['test_name'].strip():
+        compare_label = f"[{compare_run_info['test_name']}] {compare_label}"
 
     # Throughput
     for data, name, color in [

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/1_📊_Client_Metrics.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/1_📊_Client_Metrics.py
@@ -97,6 +97,7 @@ def load_guidellm_data(results_dir: str) -> pd.DataFrame:
                 row = {
                     # Metadata
                     'test_run_id': metadata.get('test_run_id', 'unknown'),
+                    'test_name': metadata.get('test_name', ''),
                     'platform': metadata.get('platform', 'unknown'),
                     'model': metadata.get('model', 'unknown'),
                     'model_short': metadata.get('model', 'unknown').split('/')[-1],
@@ -236,6 +237,23 @@ def render_filters(df: pd.DataFrame, test_mode: str) -> pd.DataFrame:
                 key="guidellm_version_filter_managed"
             )
 
+        # Test name filter (separate row if any tests have custom names)
+        if df['test_name'].str.len().sum() > 0:
+            test_names = sorted([n for n in df['test_name'].unique() if n])
+            if test_names:
+                st.markdown("**Test Name Filter:**")
+                selected_test_names = st.multiselect(
+                    "Custom Test Names",
+                    test_names,
+                    default=test_names,
+                    key="test_name_filter_managed",
+                    help="Filter by custom test names (if provided during test run)"
+                )
+            else:
+                selected_test_names = []
+        else:
+            selected_test_names = []
+
         st.markdown('</div>', unsafe_allow_html=True)
 
         # Apply filters
@@ -247,6 +265,10 @@ def render_filters(df: pd.DataFrame, test_mode: str) -> pd.DataFrame:
             df['vllm_version'].isin(selected_versions) &
             df['guidellm_version'].isin(selected_guidellm_versions)
         ]
+
+        # Apply test name filter if any selected
+        if selected_test_names:
+            filtered_df = filtered_df[filtered_df['test_name'].isin(selected_test_names)]
 
     else:  # external mode
         # External mode filters - endpoint-based filtering
@@ -310,6 +332,23 @@ def render_filters(df: pd.DataFrame, test_mode: str) -> pd.DataFrame:
                 help="'auto-detected' = model discovered from endpoint, 'specified' = model explicitly provided"
             )
 
+        # Test name filter (separate row if any tests have custom names)
+        if df['test_name'].str.len().sum() > 0:
+            test_names = sorted([n for n in df['test_name'].unique() if n])
+            if test_names:
+                st.markdown("**Test Name Filter:**")
+                selected_test_names = st.multiselect(
+                    "Custom Test Names",
+                    test_names,
+                    default=test_names,
+                    key="test_name_filter_external",
+                    help="Filter by custom test names (if provided during test run)"
+                )
+            else:
+                selected_test_names = []
+        else:
+            selected_test_names = []
+
         st.markdown('</div>', unsafe_allow_html=True)
 
         # Apply filters
@@ -321,6 +360,10 @@ def render_filters(df: pd.DataFrame, test_mode: str) -> pd.DataFrame:
             df['guidellm_version'].isin(selected_guidellm_versions) &
             df['model_source'].isin(selected_sources)
         ]
+
+        # Apply test name filter if any selected
+        if selected_test_names:
+            filtered_df = filtered_df[filtered_df['test_name'].isin(selected_test_names)]
 
     return filtered_df
 

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/1_📊_Client_Metrics.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/1_📊_Client_Metrics.py
@@ -250,10 +250,10 @@ def render_filters(df: pd.DataFrame, test_mode: str) -> pd.DataFrame:
                     help="Filter by custom test names (if provided during test run)"
                 )
             else:
-                selected_test_names = []
+                selected_test_names = None
             all_test_names = test_names
         else:
-            selected_test_names = []
+            selected_test_names = None
             all_test_names = []
 
         st.markdown('</div>', unsafe_allow_html=True)
@@ -268,8 +268,8 @@ def render_filters(df: pd.DataFrame, test_mode: str) -> pd.DataFrame:
             df['guidellm_version'].isin(selected_guidellm_versions)
         ]
 
-        # Apply test name filter only if user has deselected some names
-        if selected_test_names and selected_test_names != all_test_names:
+        # Apply test name filter if available (None means no filter, empty list means no results)
+        if selected_test_names is not None:
             filtered_df = filtered_df[filtered_df['test_name'].isin(selected_test_names)]
 
     else:  # external mode
@@ -347,10 +347,10 @@ def render_filters(df: pd.DataFrame, test_mode: str) -> pd.DataFrame:
                     help="Filter by custom test names (if provided during test run)"
                 )
             else:
-                selected_test_names = []
+                selected_test_names = None
             all_test_names = test_names
         else:
-            selected_test_names = []
+            selected_test_names = None
             all_test_names = []
 
         st.markdown('</div>', unsafe_allow_html=True)
@@ -365,8 +365,8 @@ def render_filters(df: pd.DataFrame, test_mode: str) -> pd.DataFrame:
             df['model_source'].isin(selected_sources)
         ]
 
-        # Apply test name filter only if user has deselected some names
-        if selected_test_names and selected_test_names != all_test_names:
+        # Apply test name filter if available (None means no filter, empty list means no results)
+        if selected_test_names is not None:
             filtered_df = filtered_df[filtered_df['test_name'].isin(selected_test_names)]
 
     return filtered_df
@@ -602,7 +602,7 @@ def render_performance_plots(df: pd.DataFrame):
 
         # Add test_name to label if it exists (with run ID for disambiguation)
         if test_name and test_name.strip():
-            run_id_short = test_id[:8] if len(test_id) >= 8 else test_id
+            run_id_short = test_id[-12:] if len(test_id) >= 12 else test_id
             base_label = f"[{test_name}] {base_label} (run {run_id_short})"
 
         # Plot each selected percentile
@@ -688,7 +688,7 @@ def render_performance_plots(df: pd.DataFrame):
 
             # Add test name if it exists (with run ID for disambiguation)
             if test_name and test_name.strip():
-                run_id_short = test_id[:8] if len(test_id) >= 8 else test_id
+                run_id_short = test_id[-12:] if len(test_id) >= 12 else test_id
                 row['Test Name'] = f"{test_name} (run {run_id_short})"
 
             # Add platform/cores for managed, endpoint for external
@@ -787,7 +787,7 @@ def render_compare_versions(df: pd.DataFrame):
         # Get available test runs for this configuration
         baseline_test_runs = baseline_df[['test_run_id', 'vllm_version', 'workload', 'tensor_parallel']].drop_duplicates()
         baseline_test_run_options = {
-            f"{row['test_run_id'][:8]} | {row['vllm_version']} | {row['workload']} | TP={row['tensor_parallel']}": row['test_run_id']
+            f"{row['test_run_id'][-12:] if len(row['test_run_id']) >= 12 else row['test_run_id']} | {row['vllm_version']} | {row['workload']} | TP={row['tensor_parallel']}": row['test_run_id']
             for _, row in baseline_test_runs.iterrows()
         }
 
@@ -832,7 +832,7 @@ def render_compare_versions(df: pd.DataFrame):
         # Get available test runs for this configuration
         compare_test_runs = compare_df[['test_run_id', 'vllm_version', 'workload', 'tensor_parallel']].drop_duplicates()
         compare_test_run_options = {
-            f"{row['test_run_id'][:8]} | {row['vllm_version']} | {row['workload']} | TP={row['tensor_parallel']}": row['test_run_id']
+            f"{row['test_run_id'][-12:] if len(row['test_run_id']) >= 12 else row['test_run_id']} | {row['vllm_version']} | {row['workload']} | TP={row['tensor_parallel']}": row['test_run_id']
             for _, row in compare_test_runs.iterrows()
         }
 
@@ -998,10 +998,10 @@ def render_compare_versions(df: pd.DataFrame):
 
     # Add test names to labels if they exist (with run ID for disambiguation)
     if baseline_run_info.get('test_name') and baseline_run_info['test_name'].strip():
-        baseline_run_id_short = baseline_run_info['test_run_id'][:8] if len(baseline_run_info['test_run_id']) >= 8 else baseline_run_info['test_run_id']
+        baseline_run_id_short = baseline_run_info['test_run_id'][-12:] if len(baseline_run_info['test_run_id']) >= 12 else baseline_run_info['test_run_id']
         baseline_label = f"[{baseline_run_info['test_name']}] {baseline_label} (run {baseline_run_id_short})"
     if compare_run_info.get('test_name') and compare_run_info['test_name'].strip():
-        compare_run_id_short = compare_run_info['test_run_id'][:8] if len(compare_run_info['test_run_id']) >= 8 else compare_run_info['test_run_id']
+        compare_run_id_short = compare_run_info['test_run_id'][-12:] if len(compare_run_info['test_run_id']) >= 12 else compare_run_info['test_run_id']
         compare_label = f"[{compare_run_info['test_name']}] {compare_label} (run {compare_run_id_short})"
 
     # Throughput

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/1_📊_Client_Metrics.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/1_📊_Client_Metrics.py
@@ -637,7 +637,7 @@ def render_performance_plots(df: pd.DataFrame):
     fig.update_layout(
         title=f"{selected_metric_family} vs {selected_x_axis}",
         xaxis_title=selected_x_axis,
-        yaxis_title=f"{selected_metric_family} ({metric_config['unit']})",
+        yaxis_title=selected_metric_family,
         height=600,
         hovermode='closest',
         legend=dict(

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/2_🖥️_Server_Metrics.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/2_🖥️_Server_Metrics.py
@@ -1012,6 +1012,13 @@ elif current_section == "⚖️ Compare Configurations":
             compare_endpoint_short = compare_endpoint_short.split('//', 1)[-1].rsplit('@', 1)[-1].split('/', 1)[0]
         baseline_label = f"Baseline: {baseline_endpoint_short} | vLLM {baseline_result.get('vllm_version', 'unknown')} | GuideLLM {baseline_result.get('guidellm_version', 'unknown')} | {baseline_result.get('workload', 'unknown')}"
         compare_label = f"Compare: {compare_endpoint_short} | vLLM {compare_result.get('vllm_version', 'unknown')} | GuideLLM {compare_result.get('guidellm_version', 'unknown')} | {compare_result.get('workload', 'unknown')}"
+
+    # Add test names if present
+    if baseline_result.get('test_name') and baseline_result['test_name'].strip():
+        baseline_label = f"[{baseline_result['test_name']}] {baseline_label}"
+    if compare_result.get('test_name') and compare_result['test_name'].strip():
+        compare_label = f"[{compare_result['test_name']}] {compare_label}"
+
     labels = [baseline_label, compare_label]
 
     for idx, result in enumerate(comparison_results):

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/2_🖥️_Server_Metrics.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/2_🖥️_Server_Metrics.py
@@ -214,66 +214,169 @@ if current_section == "📈 Performance Plots":
         col1, col2, col3 = st.columns(3)
 
         with col1:
-            selected_platform = st.selectbox("Platform", platforms)
+            selected_platforms = st.multiselect(
+                "Platform",
+                platforms,
+                default=platforms,
+                key="platform_filter_server"
+            )
 
         with col2:
-            selected_model = st.selectbox("Model", models)
+            selected_models = st.multiselect(
+                "Model",
+                models,
+                default=models,
+                key="model_filter_server"
+            )
 
         with col3:
-            selected_workload = st.selectbox("Workload", workloads)
+            selected_workloads = st.multiselect(
+                "Workload",
+                workloads,
+                default=workloads,
+                key="workload_filter_server"
+            )
 
         col4, col5, col6 = st.columns(3)
 
         with col4:
-            selected_cores = st.selectbox("Cores", cores)
+            selected_cores_list = st.multiselect(
+                "Core Count",
+                cores,
+                default=cores,
+                key="cores_filter_server"
+            )
 
         with col5:
-            selected_version = st.selectbox("vLLM Version", versions)
+            selected_versions = st.multiselect(
+                "vLLM Version",
+                versions,
+                default=versions,
+                key="version_filter_server"
+            )
 
         with col6:
-            selected_guidellm_version = st.selectbox("GuideLLM Version", guidellm_versions)
+            selected_guidellm_versions = st.multiselect(
+                "GuideLLM Version",
+                guidellm_versions,
+                default=guidellm_versions,
+                key="guidellm_version_filter_server"
+            )
+
+        # Test name filter (separate row if any tests have custom names)
+        test_names = sorted(set(r.get('test_name', '') for r in results if r.get('test_name', '').strip()))
+        if test_names:
+            st.markdown("**Test Name Filter:**")
+            selected_test_names = st.multiselect(
+                "Custom Test Names",
+                test_names,
+                default=test_names,
+                key="test_name_filter_server_managed",
+                help="Filter by custom test names (if provided during test run)"
+            )
+        else:
+            selected_test_names = []
 
         # Filter results (before test run selection)
         filtered_pre = [
             r for r in results
-            if r.get('platform') == selected_platform
-            and r.get('model') == selected_model
-            and r.get('workload') == selected_workload
-            and r.get('cores') == selected_cores
-            and r.get('vllm_version') == selected_version
-            and r.get('guidellm_version') == selected_guidellm_version
+            if r.get('platform') in selected_platforms
+            and r.get('model') in selected_models
+            and r.get('workload') in selected_workloads
+            and r.get('cores') in selected_cores_list
+            and r.get('vllm_version') in selected_versions
+            and r.get('guidellm_version') in selected_guidellm_versions
         ]
+
+        # Apply test name filter if user has deselected some names
+        if test_names and selected_test_names != test_names:
+            filtered_pre = [r for r in filtered_pre if r.get('test_name', '') in selected_test_names]
 
     else:  # external mode
         # External mode filters
         col1, col2, col3 = st.columns(3)
 
         with col1:
-            selected_endpoint = st.selectbox("Endpoint URL", endpoints)
+            selected_endpoints = st.multiselect(
+                "Endpoint URL",
+                endpoints,
+                default=endpoints,
+                key="endpoint_filter_server"
+            )
 
         with col2:
-            selected_model = st.selectbox("Model", models)
+            selected_models = st.multiselect(
+                "Model",
+                models,
+                default=models,
+                key="model_filter_server_ext"
+            )
 
         with col3:
-            selected_workload = st.selectbox("Workload", workloads)
+            selected_workloads = st.multiselect(
+                "Workload",
+                workloads,
+                default=workloads,
+                key="workload_filter_server_ext"
+            )
 
         col4, col5, col6 = st.columns(3)
 
         with col4:
-            selected_version = st.selectbox("vLLM Version", versions)
+            selected_versions = st.multiselect(
+                "vLLM Version",
+                versions,
+                default=versions,
+                key="version_filter_server_ext"
+            )
 
         with col5:
-            selected_guidellm_version = st.selectbox("GuideLLM Version", guidellm_versions)
+            selected_guidellm_versions = st.multiselect(
+                "GuideLLM Version",
+                guidellm_versions,
+                default=guidellm_versions,
+                key="guidellm_version_filter_server_ext"
+            )
+
+        with col6:
+            # Model source (auto-detected vs specified)
+            sources = sorted(set(r.get('model_source', 'specified') for r in results))
+            selected_sources = st.multiselect(
+                "Model Source",
+                sources,
+                default=sources,
+                key="source_filter_server_ext",
+                help="'auto-detected' = model discovered from endpoint, 'specified' = model explicitly provided"
+            )
+
+        # Test name filter (separate row if any tests have custom names)
+        test_names = sorted(set(r.get('test_name', '') for r in results if r.get('test_name', '').strip()))
+        if test_names:
+            st.markdown("**Test Name Filter:**")
+            selected_test_names = st.multiselect(
+                "Custom Test Names",
+                test_names,
+                default=test_names,
+                key="test_name_filter_server_external",
+                help="Filter by custom test names (if provided during test run)"
+            )
+        else:
+            selected_test_names = []
 
         # Filter results (before test run selection)
         filtered_pre = [
             r for r in results
-            if r.get('vllm_endpoint_url') == selected_endpoint
-            and r.get('model') == selected_model
-            and r.get('workload') == selected_workload
-            and r.get('vllm_version') == selected_version
-            and r.get('guidellm_version') == selected_guidellm_version
+            if r.get('vllm_endpoint_url') in selected_endpoints
+            and r.get('model') in selected_models
+            and r.get('workload') in selected_workloads
+            and r.get('vllm_version') in selected_versions
+            and r.get('guidellm_version') in selected_guidellm_versions
+            and r.get('model_source', 'specified') in selected_sources
         ]
+
+        # Apply test name filter if user has deselected some names
+        if test_names and selected_test_names != test_names:
+            filtered_pre = [r for r in filtered_pre if r.get('test_name', '') in selected_test_names]
 
     if not filtered_pre:
         st.warning("No results match the selected filters")
@@ -772,47 +875,47 @@ elif current_section == "⚖️ Compare Configurations":
 
         if test_mode == 'managed':
             # Managed mode filters
-            baseline_platform = st.selectbox("Platform", platforms, key="baseline_platform")
+            baseline_platform = st.selectbox("Platform", platforms, key="baseline_platform_cmp")
             baseline_filtered = [r for r in results if r.get('platform') == baseline_platform]
 
             baseline_models = sorted(set(r.get('model', 'unknown') for r in baseline_filtered))
-            baseline_model = st.selectbox("Model", baseline_models, key="baseline_model")
+            baseline_model = st.selectbox("Model", baseline_models, key="baseline_model_cmp")
             baseline_filtered = [r for r in baseline_filtered if r.get('model') == baseline_model]
 
             baseline_workloads = sorted(set(r.get('workload', 'unknown') for r in baseline_filtered))
-            baseline_workload = st.selectbox("Workload", baseline_workloads, key="baseline_workload")
+            baseline_workload = st.selectbox("Workload", baseline_workloads, key="baseline_workload_cmp")
             baseline_filtered = [r for r in baseline_filtered if r.get('workload') == baseline_workload]
 
             baseline_cores_list = sorted(set(r.get('cores', 'N/A') for r in baseline_filtered), key=lambda x: (isinstance(x, str), x))
-            baseline_cores_sel = st.selectbox("Cores", baseline_cores_list, key="baseline_cores")
+            baseline_cores_sel = st.selectbox("Cores", baseline_cores_list, key="baseline_cores_cmp")
             baseline_filtered = [r for r in baseline_filtered if r.get('cores') == baseline_cores_sel]
 
             baseline_versions = sorted(set(r.get('vllm_version', 'unknown') for r in baseline_filtered))
-            baseline_version = st.selectbox("vLLM Version", baseline_versions, key="baseline_version")
+            baseline_version = st.selectbox("vLLM Version", baseline_versions, key="baseline_version_cmp")
             baseline_filtered = [r for r in baseline_filtered if r.get('vllm_version') == baseline_version]
 
             baseline_guidellm_versions = sorted(set(r.get('guidellm_version', 'unknown') for r in baseline_filtered))
-            baseline_guidellm_version = st.selectbox("GuideLLM Version", baseline_guidellm_versions, key="baseline_guidellm_version")
+            baseline_guidellm_version = st.selectbox("GuideLLM Version", baseline_guidellm_versions, key="baseline_guidellm_version_cmp")
             baseline_filtered = [r for r in baseline_filtered if r.get('guidellm_version') == baseline_guidellm_version]
         else:  # external mode
             # External mode filters
-            baseline_endpoint = st.selectbox("Endpoint URL", endpoints, key="baseline_endpoint")
+            baseline_endpoint = st.selectbox("Endpoint URL", endpoints, key="baseline_endpoint_cmp")
             baseline_filtered = [r for r in results if r.get('vllm_endpoint_url') == baseline_endpoint]
 
             baseline_models = sorted(set(r.get('model', 'unknown') for r in baseline_filtered))
-            baseline_model = st.selectbox("Model", baseline_models, key="baseline_model")
+            baseline_model = st.selectbox("Model", baseline_models, key="baseline_model_cmp")
             baseline_filtered = [r for r in baseline_filtered if r.get('model') == baseline_model]
 
             baseline_workloads = sorted(set(r.get('workload', 'unknown') for r in baseline_filtered))
-            baseline_workload = st.selectbox("Workload", baseline_workloads, key="baseline_workload")
+            baseline_workload = st.selectbox("Workload", baseline_workloads, key="baseline_workload_cmp")
             baseline_filtered = [r for r in baseline_filtered if r.get('workload') == baseline_workload]
 
             baseline_versions = sorted(set(r.get('vllm_version', 'unknown') for r in baseline_filtered))
-            baseline_version = st.selectbox("vLLM Version", baseline_versions, key="baseline_version")
+            baseline_version = st.selectbox("vLLM Version", baseline_versions, key="baseline_version_cmp")
             baseline_filtered = [r for r in baseline_filtered if r.get('vllm_version') == baseline_version]
 
             baseline_guidellm_versions = sorted(set(r.get('guidellm_version', 'unknown') for r in baseline_filtered))
-            baseline_guidellm_version = st.selectbox("GuideLLM Version", baseline_guidellm_versions, key="baseline_guidellm_version_ext")
+            baseline_guidellm_version = st.selectbox("GuideLLM Version", baseline_guidellm_versions, key="baseline_guidellm_version_ext_cmp")
             baseline_filtered = [r for r in baseline_filtered if r.get('guidellm_version') == baseline_guidellm_version]
 
         # Get available test runs for this configuration
@@ -837,47 +940,47 @@ elif current_section == "⚖️ Compare Configurations":
 
         if test_mode == 'managed':
             # Managed mode filters
-            compare_platform = st.selectbox("Platform", platforms, key="compare_platform")
+            compare_platform = st.selectbox("Platform", platforms, key="compare_platform_cmp")
             compare_filtered = [r for r in results if r.get('platform') == compare_platform]
 
             compare_models = sorted(set(r.get('model', 'unknown') for r in compare_filtered))
-            compare_model = st.selectbox("Model", compare_models, key="compare_model")
+            compare_model = st.selectbox("Model", compare_models, key="compare_model_cmp")
             compare_filtered = [r for r in compare_filtered if r.get('model') == compare_model]
 
             compare_workloads = sorted(set(r.get('workload', 'unknown') for r in compare_filtered))
-            compare_workload = st.selectbox("Workload", compare_workloads, key="compare_workload")
+            compare_workload = st.selectbox("Workload", compare_workloads, key="compare_workload_cmp")
             compare_filtered = [r for r in compare_filtered if r.get('workload') == compare_workload]
 
             compare_cores_list = sorted(set(r.get('cores', 'N/A') for r in compare_filtered), key=lambda x: (isinstance(x, str), x))
-            compare_cores_sel = st.selectbox("Cores", compare_cores_list, key="compare_cores")
+            compare_cores_sel = st.selectbox("Cores", compare_cores_list, key="compare_cores_cmp")
             compare_filtered = [r for r in compare_filtered if r.get('cores') == compare_cores_sel]
 
             compare_versions = sorted(set(r.get('vllm_version', 'unknown') for r in compare_filtered))
-            compare_version = st.selectbox("vLLM Version", compare_versions, key="compare_version")
+            compare_version = st.selectbox("vLLM Version", compare_versions, key="compare_version_cmp")
             compare_filtered = [r for r in compare_filtered if r.get('vllm_version') == compare_version]
 
             compare_guidellm_versions = sorted(set(r.get('guidellm_version', 'unknown') for r in compare_filtered))
-            compare_guidellm_version = st.selectbox("GuideLLM Version", compare_guidellm_versions, key="compare_guidellm_version")
+            compare_guidellm_version = st.selectbox("GuideLLM Version", compare_guidellm_versions, key="compare_guidellm_version_cmp")
             compare_filtered = [r for r in compare_filtered if r.get('guidellm_version') == compare_guidellm_version]
         else:  # external mode
             # External mode filters
-            compare_endpoint = st.selectbox("Endpoint URL", endpoints, key="compare_endpoint")
+            compare_endpoint = st.selectbox("Endpoint URL", endpoints, key="compare_endpoint_cmp")
             compare_filtered = [r for r in results if r.get('vllm_endpoint_url') == compare_endpoint]
 
             compare_models = sorted(set(r.get('model', 'unknown') for r in compare_filtered))
-            compare_model = st.selectbox("Model", compare_models, key="compare_model")
+            compare_model = st.selectbox("Model", compare_models, key="compare_model_cmp")
             compare_filtered = [r for r in compare_filtered if r.get('model') == compare_model]
 
             compare_workloads = sorted(set(r.get('workload', 'unknown') for r in compare_filtered))
-            compare_workload = st.selectbox("Workload", compare_workloads, key="compare_workload")
+            compare_workload = st.selectbox("Workload", compare_workloads, key="compare_workload_cmp")
             compare_filtered = [r for r in compare_filtered if r.get('workload') == compare_workload]
 
             compare_versions = sorted(set(r.get('vllm_version', 'unknown') for r in compare_filtered))
-            compare_version = st.selectbox("vLLM Version", compare_versions, key="compare_version")
+            compare_version = st.selectbox("vLLM Version", compare_versions, key="compare_version_cmp")
             compare_filtered = [r for r in compare_filtered if r.get('vllm_version') == compare_version]
 
             compare_guidellm_versions = sorted(set(r.get('guidellm_version', 'unknown') for r in compare_filtered))
-            compare_guidellm_version = st.selectbox("GuideLLM Version", compare_guidellm_versions, key="compare_guidellm_version_ext")
+            compare_guidellm_version = st.selectbox("GuideLLM Version", compare_guidellm_versions, key="compare_guidellm_version_ext_cmp")
             compare_filtered = [r for r in compare_filtered if r.get('guidellm_version') == compare_guidellm_version]
 
         # Get available test runs for this configuration

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/2_🖥️_Server_Metrics.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/2_🖥️_Server_Metrics.py
@@ -100,6 +100,7 @@ def load_vllm_metrics(base_dir: str):
                         data['model'] = metadata.get('model', 'unknown')
                         data['workload'] = metadata.get('workload', 'unknown')
                         data['test_run_id'] = metadata.get('test_run_id', 'unknown')
+                        data['test_name'] = metadata.get('test_name', '')
                         data['cores'] = metadata.get('core_count', 'N/A')
                         data['backend'] = metadata.get('backend', 'unknown')
                         data['vllm_version'] = metadata.get('vllm_version', 'unknown')

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/2_🖥️_Server_Metrics.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/2_🖥️_Server_Metrics.py
@@ -275,7 +275,7 @@ if current_section == "📈 Performance Plots":
                 help="Filter by custom test names (if provided during test run)"
             )
         else:
-            selected_test_names = []
+            selected_test_names = None
 
         # Filter results (before test run selection)
         filtered_pre = [
@@ -288,8 +288,8 @@ if current_section == "📈 Performance Plots":
             and r.get('guidellm_version') in selected_guidellm_versions
         ]
 
-        # Apply test name filter if user has deselected some names
-        if test_names and selected_test_names != test_names:
+        # Apply test name filter if available (None means no filter, empty list means no results)
+        if selected_test_names is not None:
             filtered_pre = [r for r in filtered_pre if r.get('test_name', '') in selected_test_names]
 
     else:  # external mode
@@ -374,8 +374,8 @@ if current_section == "📈 Performance Plots":
             and r.get('model_source', 'specified') in selected_sources
         ]
 
-        # Apply test name filter if user has deselected some names
-        if test_names and selected_test_names != test_names:
+        # Apply test name filter if available (None means no filter, empty list means no results)
+        if selected_test_names is not None:
             filtered_pre = [r for r in filtered_pre if r.get('test_name', '') in selected_test_names]
 
     if not filtered_pre:
@@ -410,7 +410,7 @@ if current_section == "📈 Performance Plots":
         cols[3].metric("Cores", test_data.get('cores', 'N/A'))
         cols[4].metric("Backend", test_data.get('backend', 'N/A'))
         cols[5].metric("GuideLLM", test_data.get('guidellm_version', 'N/A'))
-        cols[6].metric("Test Run ID", test_data.get('test_run_id', 'N/A')[:8])
+        cols[6].metric("Test Run ID", test_data.get('test_run_id', 'N/A')[-12:] if len(test_data.get('test_run_id', 'N/A')) >= 12 else test_data.get('test_run_id', 'N/A'))
     else:  # external mode
         cols = st.columns(6)
         endpoint_url = test_data.get('vllm_endpoint_url', 'N/A')
@@ -421,7 +421,7 @@ if current_section == "📈 Performance Plots":
         cols[2].metric("Workload", test_data.get('workload', 'N/A'))
         cols[3].metric("Backend", test_data.get('backend', 'N/A'))
         cols[4].metric("GuideLLM", test_data.get('guidellm_version', 'N/A'))
-        cols[5].metric("Test Run ID", test_data.get('test_run_id', 'N/A')[:8])
+        cols[5].metric("Test Run ID", test_data.get('test_run_id', 'N/A')[-12:] if len(test_data.get('test_run_id', 'N/A')) >= 12 else test_data.get('test_run_id', 'N/A'))
 
     # Collection info
     collection_info = test_data.get('collection_info', {})
@@ -921,7 +921,7 @@ elif current_section == "⚖️ Compare Configurations":
         # Get available test runs for this configuration
         if baseline_filtered:
             baseline_test_run_options = {
-                f"{r.get('test_run_id', 'unknown')[:8]} | {r.get('backend', 'unknown')}": r
+                f"{r.get('test_run_id', 'unknown')[-12:] if len(r.get('test_run_id', 'unknown')) >= 12 else r.get('test_run_id', 'unknown')} | {r.get('backend', 'unknown')}": r
                 for r in baseline_filtered
             }
 
@@ -1221,7 +1221,7 @@ elif current_section == "⚖️ Compare Configurations":
         row = {
             'Backend': result.get('backend', 'unknown'),
             'Version': result.get('vllm_version', 'unknown'),
-            'Test Run ID': result.get('test_run_id', 'unknown')[:8],
+            'Test Run ID': result.get('test_run_id', 'unknown')[-12:] if len(result.get('test_run_id', 'unknown')) >= 12 else result.get('test_run_id', 'unknown'),
             'Avg Cache %': f"{cache_avg:.1f}",
             'Avg Running': f"{running_avg:.2f}",
             'Avg Waiting': f"{waiting_avg:.2f}"


### PR DESCRIPTION
Allow users to assign custom names to benchmark tests for easier identification and comparison. Test run IDs now support an optional custom name prefix (e.g., "baseline-v1-20260423-143022").

Changes:
- Add test_name parameter to llm-benchmark-auto.yml and llm-core-sweep-auto.yml
- Generate test_run_id as {test_name}-{timestamp} when test_name is provided
- Store test_name in test-metadata.json for all tests
- Add test_name field to Streamlit dashboard data loading
- Add "Custom Test Names" filter in all three dashboard pages
- Update ansible.md with usage guide and best practices

Usage:
  ansible-playbook llm-benchmark-auto.yml \ -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \ -e "workload_type=chat" \ -e "requested_cores=16" \ -e "test_name=baseline-v1"

Backward compatible: tests without test_name work as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a test_name parameter to produce readable run IDs and group runs.
  * Dashboard adds a "Custom Test Names" filter and shows test names in charts, labels, and tables for clearer comparisons.

* **Documentation**
  * Added usage examples, validation rules (1–30 chars; alphanumerics and hyphens), best-practice naming guidance, and note about default timestamp-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->