### PR TITLE
feat: add socket pinning support for NUMA affinity control

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,8 @@ nav_links:
     url: /
   - title: Getting Started
     url: /docs/getting-started
+  - title: Ansible Automation
+    url: /docs/ansible/test-execution
   - title: Methodology
     url: /docs/methodology/overview
   - title: Test Suites

--- a/automation/test-execution/ansible/README.md
+++ b/automation/test-execution/ansible/README.md
@@ -252,6 +252,78 @@ results/llm/
 > in this environment. See [GuideLLM issue #627](https://github.com/vllm-project/guidellm/issues/627).
 > JSON and CSV formats are fully functional.
 
+## Advanced Features
+
+### Socket Pinning (NUMA Affinity)
+
+Socket pinning allows you to isolate vLLM server and GuideLLM load generator to different CPU sockets/NUMA nodes. This is useful for:
+- Minimizing performance interference between server and load generator
+- Testing cross-NUMA bandwidth impact
+- Running on dedicated sockets in multi-tenant systems
+
+#### Socket Pinning Configuration
+
+Socket pinning is controlled by four optional parameters:
+
+**vLLM Server Socket Pinning:**
+- `vllm_cpu_start`: CPU ID to start allocation from (e.g., 64 for socket 1)
+- `vllm_numa_node`: NUMA node to allocate from (e.g., 1 for socket 1)
+
+**GuideLLM Load Generator Socket Pinning:**
+- `guidellm_cpus`: CPU range for load generator (e.g., "0-31")
+- `guidellm_numa_node`: NUMA node for load generator memory (e.g., 0)
+
+#### Example: vLLM on Socket 1, GuideLLM on Socket 0
+
+Assume a 2-socket system:
+- Socket 0: Cores 0-31 (NUMA node 0)
+- Socket 1: Cores 64-95 (NUMA node 1)
+
+```bash
+# Single test with socket separation
+ansible-playbook llm-benchmark-auto.yml \
+  -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \
+  -e "workload_type=chat" \
+  -e "requested_cores=32" \
+  -e "vllm_cpu_start=64" \
+  -e "vllm_numa_node=1" \
+  -e "guidellm_cpus=0-31" \
+  -e "guidellm_numa_node=0"
+```
+
+```bash
+# Concurrent load test with socket separation
+ansible-playbook llm-benchmark-concurrent-load.yml \
+  -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \
+  -e "base_workload=chat" \
+  -e "requested_cores=32" \
+  -e "vllm_cpu_start=64" \
+  -e "vllm_numa_node=1" \
+  -e "guidellm_cpus=0-31" \
+  -e "guidellm_numa_node=0"
+```
+
+#### Determining Your System's Socket Layout
+
+```bash
+# Show NUMA topology
+lscpu | grep NUMA
+
+# Show cores per NUMA node
+numactl --hardware
+
+# Example output:
+# node 0 cpus: 0 1 2 ... 31
+# node 1 cpus: 64 65 66 ... 95
+```
+
+#### Notes
+
+- Socket pinning requires `vllm_numa_node` to be set; `vllm_cpu_start` is optional
+- When using socket pinning with single NUMA node, `tensor_parallel` must equal 1
+- The automation will validate that requested cores fit within the specified socket
+- Without socket pinning parameters, the automation uses default multi-NUMA allocation
+
 ## Design Decisions
 
 ### Why Bash Orchestration Instead of Pure Ansible?
@@ -277,8 +349,9 @@ To extend for embedding tests:
 
 ## Recent Improvements
 
-1. **Localhost Configuration** - Fixed sudo password errors on delegated tasks
-2. **Log Collection** - GuideLLM logs now copied to final results
-3. **Duration Extraction** - Test duration added to metadata (HH:MM:SS and seconds)
-4. **Per-Benchmark Timings** - Detailed timing data for each benchmark iteration
-5. **Core Sweep Orchestration** - Bash wrapper for reliable multi-configuration testing
+1. **Socket Pinning** - Support for pinning vLLM and GuideLLM to separate NUMA nodes/sockets
+2. **Localhost Configuration** - Fixed sudo password errors on delegated tasks
+3. **Log Collection** - GuideLLM logs now copied to final results
+4. **Duration Extraction** - Test duration added to metadata (HH:MM:SS and seconds)
+5. **Per-Benchmark Timings** - Detailed timing data for each benchmark iteration
+6. **Core Sweep Orchestration** - Bash wrapper for reliable multi-configuration testing

--- a/automation/test-execution/ansible/ansible.md
+++ b/automation/test-execution/ansible/ansible.md
@@ -641,6 +641,91 @@ When tests have custom names, Streamlit dashboards automatically display a "Cust
 
 **Backward compatibility:** Tests without `test_name` work as before (timestamp-only IDs).
 
+### Socket Pinning (NUMA Affinity)
+
+Socket pinning allows you to isolate vLLM server and GuideLLM load generator to different CPU sockets/NUMA nodes, minimizing performance interference.
+
+**Supported Playbooks:**
+- ✅ `llm-benchmark-auto.yml`
+- ✅ `llm-benchmark-concurrent-load.yml`
+
+**Parameters:**
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `vllm_cpu_start` | CPU ID to start vLLM allocation from | `64` (for socket 1) |
+| `vllm_numa_node` | NUMA node for vLLM (required for socket pinning) | `1` |
+| `guidellm_cpus` | CPU range for load generator | `"0-31"` |
+| `guidellm_numa_node` | NUMA node for load generator | `0` |
+
+**Determine Your System's Socket Layout:**
+
+```bash
+# Show NUMA topology
+lscpu | grep NUMA
+
+# Show cores per NUMA node
+numactl --hardware
+
+# Example output:
+# node 0 cpus: 0 1 2 ... 31
+# node 1 cpus: 64 65 66 ... 95
+```
+
+**Example: vLLM on Socket 1, GuideLLM on Socket 0**
+
+Assuming a 2-socket system:
+- Socket 0: Cores 0-31 (NUMA node 0)
+- Socket 1: Cores 64-95 (NUMA node 1)
+
+```bash
+# Single test with socket separation
+ansible-playbook llm-benchmark-auto.yml \
+  -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \
+  -e "workload_type=chat" \
+  -e "requested_cores=32" \
+  -e "vllm_cpu_start=64" \
+  -e "vllm_numa_node=1" \
+  -e "guidellm_cpus=0-31" \
+  -e "guidellm_numa_node=0"
+```
+
+```bash
+# Concurrent load test with socket separation
+ansible-playbook llm-benchmark-concurrent-load.yml \
+  -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \
+  -e "base_workload=chat" \
+  -e "requested_cores=32" \
+  -e "vllm_cpu_start=64" \
+  -e "vllm_numa_node=1" \
+  -e "guidellm_cpus=0-31" \
+  -e "guidellm_numa_node=0"
+```
+
+**Validation:**
+
+```bash
+# Verify vLLM container pinning
+podman ps | grep vllm
+podman inspect <container-id> | grep -A 2 cpuset
+# Expected: "CpusetCpus": "64-95", "CpusetMems": "1"
+
+# Verify GuideLLM container pinning
+podman ps | grep guidellm
+podman inspect <container-id> | grep -A 2 cpuset
+# Expected: "CpusetCpus": "0-31", "CpusetMems": "0"
+```
+
+**Use Cases:**
+- **Minimize Interference**: Eliminate CPU contention between server and load generator
+- **Test Cross-NUMA Performance**: Measure impact of cross-socket memory access
+- **Multi-Tenant Systems**: Isolate benchmarks from other workloads
+
+**Notes:**
+- Socket pinning requires `vllm_numa_node` to be set
+- When pinning to single NUMA node, `tensor_parallel` must equal 1
+- The automation validates requested cores fit within specified socket
+
 ## Troubleshooting
 
 ### Connection Issues

--- a/automation/test-execution/ansible/filter_plugins/cpu_utils.py
+++ b/automation/test-execution/ansible/filter_plugins/cpu_utils.py
@@ -436,7 +436,7 @@ def extract_size_value(size_str):
 # Valid tensor parallelism values (powers of 2, capped at 8)
 VALID_TP_VALUES = [1, 2, 4, 8]
 
-def allocate_cores_multi_numa(numa_topology, requested_cores, requested_tp=None):
+def allocate_cores_multi_numa(numa_topology, requested_cores, requested_tp=None, cpu_start=None, numa_node_override=None):
     """
     Multi-NUMA core allocation with automatic tensor parallelism calculation.
 
@@ -444,10 +444,15 @@ def allocate_cores_multi_numa(numa_topology, requested_cores, requested_tp=None)
     single-node capacity. Auto-calculates optimal TP value (powers of 2, max 8)
     or validates user-provided TP.
 
+    Socket pinning support: Use cpu_start and numa_node_override to pin vLLM
+    to a specific socket (e.g., socket 1 with cpu_start=64, numa_node=1).
+
     Args:
         numa_topology: Topology dict with nodes inventory and allocation policy
         requested_cores: Total physical cores to allocate
         requested_tp: Optional user override for tensor parallelism (must be valid)
+        cpu_start: Optional CPU offset to start allocation from (for socket pinning)
+        numa_node_override: Optional NUMA node to allocate from (for socket pinning)
 
     Returns:
         dict: Allocation configuration with:
@@ -465,6 +470,7 @@ def allocate_cores_multi_numa(numa_topology, requested_cores, requested_tp=None)
     Examples:
         64 cores on 3-node system → TP=2, 32 cores from 2 nodes
         96 cores on 6-node system → TP=4, 24 cores from 4 nodes
+        Pin to socket 1: cpu_start=64, numa_node_override=1
     """
     # Validate input
     if not isinstance(numa_topology, dict):
@@ -473,7 +479,7 @@ def allocate_cores_multi_numa(numa_topology, requested_cores, requested_tp=None)
     if not isinstance(requested_cores, int) or requested_cores <= 0:
         raise AnsibleFilterError(f"requested_cores must be positive integer, got {requested_cores}")
 
-    # Validate requested_tp if provided
+    # Normalize requested_tp
     if requested_tp is not None:
         # Handle Ansible's omit type - treat as None for auto-calculation
         if str(type(requested_tp).__name__) == '_OmitType':
@@ -493,6 +499,30 @@ def allocate_cores_multi_numa(numa_topology, requested_cores, requested_tp=None)
                 raise AnsibleFilterError(
                     f"Invalid tensor_parallel: {requested_tp}. Valid values: {VALID_TP_VALUES}"
                 )
+
+    # Normalize cpu_start (for socket pinning)
+    if cpu_start is not None:
+        if str(type(cpu_start).__name__) == '_OmitType' or cpu_start == '' or cpu_start == 'None':
+            cpu_start = None
+        else:
+            try:
+                cpu_start = int(cpu_start)
+                if cpu_start < 0:
+                    raise AnsibleFilterError(f"cpu_start must be non-negative, got {cpu_start}")
+            except (ValueError, TypeError) as e:
+                raise AnsibleFilterError(f"Invalid cpu_start: {cpu_start}. Expected integer. Error: {e}")
+
+    # Normalize numa_node_override (for socket pinning)
+    if numa_node_override is not None:
+        if str(type(numa_node_override).__name__) == '_OmitType' or numa_node_override == '' or numa_node_override == 'None':
+            numa_node_override = None
+        else:
+            try:
+                numa_node_override = int(numa_node_override)
+                if numa_node_override < 0:
+                    raise AnsibleFilterError(f"numa_node_override must be non-negative, got {numa_node_override}")
+            except (ValueError, TypeError) as e:
+                raise AnsibleFilterError(f"Invalid numa_node_override: {numa_node_override}. Expected integer. Error: {e}")
 
     # Extract nodes and policy
     nodes = numa_topology.get('nodes', [])
@@ -524,16 +554,74 @@ def allocate_cores_multi_numa(numa_topology, requested_cores, requested_tp=None)
     if not available_nodes:
         raise AnsibleFilterError("No available NUMA nodes for workload allocation")
 
-    # If user provided TP, use it; otherwise auto-calculate
-    if requested_tp is not None:
-        result = allocate_with_fixed_tp(available_nodes, requested_cores, requested_tp)
+    # Handle socket pinning mode
+    if numa_node_override is not None:
+        # Socket pinning: allocate from specific NUMA node
+        result = allocate_with_socket_pinning(
+            normalized_nodes,
+            requested_cores,
+            numa_node_override,
+            cpu_start,
+            requested_tp
+        )
     else:
-        result = allocate_with_auto_tp(available_nodes, requested_cores)
+        # Normal multi-NUMA allocation
+        if requested_tp is not None:
+            result = allocate_with_fixed_tp(available_nodes, requested_cores, requested_tp, cpu_start)
+        else:
+            result = allocate_with_auto_tp(available_nodes, requested_cores, cpu_start)
 
     return result
 
 
-def allocate_with_auto_tp(available_nodes, requested_cores):
+def allocate_with_socket_pinning(all_nodes, requested_cores, numa_node, cpu_start, requested_tp):
+    """
+    Allocate cores from a specific NUMA node (socket pinning).
+
+    Args:
+        all_nodes: List of all NUMA node dicts
+        requested_cores: Total cores to allocate
+        numa_node: NUMA node to allocate from
+        cpu_start: CPU offset to start allocation from (optional)
+        requested_tp: Tensor parallelism (must be 1 for single-node allocation)
+
+    Returns:
+        dict: Allocation configuration
+
+    Raises:
+        AnsibleFilterError: If allocation not possible on specified node
+    """
+    # Find the target NUMA node
+    target_node = None
+    for node in all_nodes:
+        if int(node['id']) == numa_node:
+            target_node = node
+            break
+
+    if target_node is None:
+        available_node_ids = [int(n['id']) for n in all_nodes]
+        raise AnsibleFilterError(
+            f"NUMA node {numa_node} not found. Available nodes: {available_node_ids}"
+        )
+
+    # Validate TP for single-node allocation
+    if requested_tp is not None and requested_tp != 1:
+        raise AnsibleFilterError(
+            f"Socket pinning to single NUMA node requires TP=1, got TP={requested_tp}"
+        )
+
+    # Check if node has enough cores
+    node_capacity = int(target_node['physical_cores'])
+    if requested_cores > node_capacity:
+        raise AnsibleFilterError(
+            f"NUMA node {numa_node} has only {node_capacity} cores, cannot allocate {requested_cores}"
+        )
+
+    # Build allocation using the specified node
+    return build_allocation([target_node], requested_cores, 1, cpu_start)
+
+
+def allocate_with_auto_tp(available_nodes, requested_cores, cpu_start=None):
     """
     Auto-calculate optimal TP and allocate cores across NUMA nodes.
 
@@ -543,6 +631,7 @@ def allocate_with_auto_tp(available_nodes, requested_cores):
     Args:
         available_nodes: List of available NUMA node dicts
         requested_cores: Total cores to allocate
+        cpu_start: Optional CPU offset to start allocation from
 
     Returns:
         dict: Allocation configuration
@@ -575,7 +664,7 @@ def allocate_with_auto_tp(available_nodes, requested_cores):
             selected_nodes = sorted_nodes[:tp]
             # Verify each selected node has sufficient capacity
             if all(n['physical_cores'] >= cores_per_node for n in selected_nodes):
-                return build_allocation(selected_nodes, cores_per_node, tp)
+                return build_allocation(selected_nodes, cores_per_node, tp, cpu_start)
 
     # No valid allocation found - generate helpful error
     valid_allocations = calculate_valid_allocations(available_nodes)
@@ -588,7 +677,7 @@ def allocate_with_auto_tp(available_nodes, requested_cores):
     )
 
 
-def allocate_with_fixed_tp(available_nodes, requested_cores, tp):
+def allocate_with_fixed_tp(available_nodes, requested_cores, tp, cpu_start=None):
     """
     Allocate cores with user-specified TP value.
 
@@ -596,6 +685,7 @@ def allocate_with_fixed_tp(available_nodes, requested_cores, tp):
         available_nodes: List of available NUMA node dicts
         requested_cores: Total cores to allocate
         tp: User-specified tensor parallelism
+        cpu_start: Optional CPU offset to start allocation from
 
     Returns:
         dict: Allocation configuration
@@ -639,10 +729,10 @@ def allocate_with_fixed_tp(available_nodes, requested_cores, tp):
 
     # Build allocation from eligible nodes
     selected_nodes = eligible_nodes[:tp]
-    return build_allocation(selected_nodes, cores_per_node, tp)
+    return build_allocation(selected_nodes, cores_per_node, tp, cpu_start)
 
 
-def build_allocation(selected_nodes, cores_per_node, tp):
+def build_allocation(selected_nodes, cores_per_node, tp, cpu_start=None):
     """
     Build final allocation configuration with CPU pinning and OMP binding.
 
@@ -650,6 +740,7 @@ def build_allocation(selected_nodes, cores_per_node, tp):
         selected_nodes: List of NUMA node dicts to use
         cores_per_node: Cores to allocate from each node
         tp: Tensor parallelism value
+        cpu_start: Optional CPU offset to start allocation from (for socket pinning)
 
     Returns:
         dict: Complete allocation configuration
@@ -666,6 +757,16 @@ def build_allocation(selected_nodes, cores_per_node, tp):
 
         # Expand CPU range string to list of CPU IDs
         all_physical_cpus = expand_cpu_range(physical_cpus_str)
+
+        # Apply CPU offset if specified (for socket pinning)
+        if cpu_start is not None:
+            # Filter CPUs >= cpu_start from this node
+            all_physical_cpus = [cpu for cpu in all_physical_cpus if cpu >= cpu_start]
+            if len(all_physical_cpus) < cores_per_node:
+                raise AnsibleFilterError(
+                    f"Not enough CPUs >= {cpu_start} on NUMA node {node['id']}: "
+                    f"need {cores_per_node}, found {len(all_physical_cpus)}"
+                )
 
         # Take first N physical cores
         allocated_cpus = all_physical_cpus[:cores_per_node]

--- a/automation/test-execution/ansible/inventory/group_vars/all/benchmark-tools.yml
+++ b/automation/test-execution/ansible/inventory/group_vars/all/benchmark-tools.yml
@@ -21,8 +21,10 @@ benchmark_tool:
 
     # CPU allocation (only applies to containerized mode)
     # Load generator CPU allocation
-    cpuset_cpus: "16-31"
-    cpuset_mems: "0"
+    # Can be overridden with -e "guidellm_cpus=0-31" and -e "guidellm_numa_node=0"
+    # For socket separation: set guidellm_cpus and guidellm_numa_node to different socket
+    cpuset_cpus: "{{ guidellm_cpus | default('16-31') }}"
+    cpuset_mems: "{{ guidellm_numa_node | default('0') }}"
 
     # ========================================================================
     # Benchmark Profile Configuration

--- a/automation/test-execution/ansible/llm-benchmark-auto.yml
+++ b/automation/test-execution/ansible/llm-benchmark-auto.yml
@@ -10,6 +10,15 @@
 #     -e "workload_type=summarization" \
 #     -e "requested_cores=16"
 #     -e "requested_tensor_parallel=2"  # optional, auto-calculated if not specified (valid: 1, 2, 4, 8)
+#
+# Socket Pinning (optional):
+#   # Pin vLLM to socket 1 (cores 64-95, NUMA node 1)
+#   -e "vllm_cpu_start=64" \
+#   -e "vllm_numa_node=1" \
+#
+#   # Pin GuideLLM to socket 0 (cores 0-31, NUMA node 0)
+#   -e "guidellm_cpus=0-31" \
+#   -e "guidellm_numa_node=0"
 
 - name: "Auto-Configured LLM Test - Setup"
   hosts: localhost
@@ -122,7 +131,28 @@
         - test_name is defined
         - test_name | length > 0
 
-    - name: Generate test run ID
+    - name: Validate vllm_cpu_start if provided
+      ansible.builtin.assert:
+        that:
+          - vllm_cpu_start | int >= 0
+        fail_msg: "vllm_cpu_start must be a non-negative integer, got: {{ vllm_cpu_start }}"
+      when: vllm_cpu_start is defined
+
+    - name: Validate vllm_numa_node if provided
+      ansible.builtin.assert:
+        that:
+          - vllm_numa_node | int >= 0
+        fail_msg: "vllm_numa_node must be a non-negative integer, got: {{ vllm_numa_node }}"
+      when: vllm_numa_node is defined
+
+    - name: Validate guidellm_numa_node if provided
+      ansible.builtin.assert:
+        that:
+          - guidellm_numa_node | int >= 0
+        fail_msg: "guidellm_numa_node must be a non-negative integer, got: {{ guidellm_numa_node }}"
+      when: guidellm_numa_node is defined
+
+    - name: Generate test run ID if not provided
       ansible.builtin.set_fact:
         test_run_id: "{{ (test_name is defined and test_name | length > 0) | ternary((lookup('pipe', 'date +%Y%m%d-%H%M%S') ~ '-' ~ test_name), lookup('pipe', 'date +%Y%m%d-%H%M%S')) }}"
       when: test_run_id is not defined
@@ -297,6 +327,8 @@
     requested_tensor_parallel: "{{ hostvars['localhost']['requested_tensor_parallel'] | default(omit) }}"
     requested_omp_threads: "{{ hostvars['localhost']['requested_omp_threads'] | default(omit) }}"
     requested_omp_bind: "{{ hostvars['localhost']['requested_omp_bind'] | default(omit) }}"
+    vllm_cpu_start: "{{ hostvars['localhost']['vllm_cpu_start'] | default(None) }}"
+    vllm_numa_node: "{{ hostvars['localhost']['vllm_numa_node'] | default(None) }}"
 
   pre_tasks:
     - name: End play if in external mode

--- a/automation/test-execution/ansible/llm-benchmark-auto.yml
+++ b/automation/test-execution/ansible/llm-benchmark-auto.yml
@@ -152,10 +152,20 @@
         fail_msg: "guidellm_numa_node must be a non-negative integer, got: {{ guidellm_numa_node }}"
       when: guidellm_numa_node is defined
 
-    - name: Generate test run ID if not provided
+    - name: Generate test run ID (with custom name)
       ansible.builtin.set_fact:
-        test_run_id: "{{ (test_name is defined and test_name | length > 0) | ternary((lookup('pipe', 'date +%Y%m%d-%H%M%S') ~ '-' ~ test_name), lookup('pipe', 'date +%Y%m%d-%H%M%S')) }}"
-      when: test_run_id is not defined
+        test_run_id: "{{ lookup('pipe', 'date +%Y%m%d-%H%M%S') }}-{{ test_name }}"
+      when:
+        - test_run_id is not defined
+        - test_name is defined
+        - test_name | length > 0
+
+    - name: Generate test run ID (timestamp only)
+      ansible.builtin.set_fact:
+        test_run_id: "{{ lookup('pipe', 'date +%Y%m%d-%H%M%S') }}"
+      when:
+        - test_run_id is not defined
+        - test_name is not defined or test_name | length == 0
 
     - name: Handle external endpoint model detection/validation
       when: vllm_mode == 'external'

--- a/automation/test-execution/ansible/llm-benchmark-concurrent-load.yml
+++ b/automation/test-execution/ansible/llm-benchmark-concurrent-load.yml
@@ -36,6 +36,18 @@
 #     -e "skip_phase_2=true" \
 #     -e "skip_phase_3=true"
 #
+# Socket Pinning (optional):
+#   # Pin vLLM to socket 1 (cores 64-95, NUMA node 1)
+#   # Pin GuideLLM to socket 0 (cores 0-31, NUMA node 0)
+#   ansible-playbook llm-benchmark-concurrent-load.yml \
+#     -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \
+#     -e "base_workload=chat" \
+#     -e "requested_cores=32" \
+#     -e "vllm_cpu_start=64" \
+#     -e "vllm_numa_node=1" \
+#     -e "guidellm_cpus=0-31" \
+#     -e "guidellm_numa_node=0"
+#
 # ============================================================================
 
 - name: Concurrent Load Testing - Configuration
@@ -95,6 +107,27 @@
         requested_cores: 0
       when:
         - vllm_mode == 'external'
+
+    - name: Validate vllm_cpu_start if provided
+      ansible.builtin.assert:
+        that:
+          - vllm_cpu_start | int >= 0
+        fail_msg: "vllm_cpu_start must be a non-negative integer, got: {{ vllm_cpu_start }}"
+      when: vllm_cpu_start is defined
+
+    - name: Validate vllm_numa_node if provided
+      ansible.builtin.assert:
+        that:
+          - vllm_numa_node | int >= 0
+        fail_msg: "vllm_numa_node must be a non-negative integer, got: {{ vllm_numa_node }}"
+      when: vllm_numa_node is defined
+
+    - name: Validate guidellm_numa_node if provided
+      ansible.builtin.assert:
+        that:
+          - guidellm_numa_node | int >= 0
+        fail_msg: "guidellm_numa_node must be a non-negative integer, got: {{ guidellm_numa_node }}"
+      when: guidellm_numa_node is defined
 
     - name: Normalize core configuration input
       ansible.builtin.set_fact:
@@ -163,6 +196,10 @@
     workload_type: "{{ base_workload }}"
     vllm_caching_mode: "baseline"
     requested_cores: "{{ effective_requested_cores }}"
+    vllm_cpu_start: "{{ vllm_cpu_start | default(omit) }}"
+    vllm_numa_node: "{{ vllm_numa_node | default(omit) }}"
+    guidellm_cpus: "{{ guidellm_cpus | default(omit) }}"
+    guidellm_numa_node: "{{ guidellm_numa_node | default(omit) }}"
   when: not (skip_phase_1 | default(false) | bool)
 
 - name: Phase 1 Complete
@@ -187,6 +224,10 @@
     workload_type: "{{ base_workload }}_var"
     vllm_caching_mode: "baseline"
     requested_cores: "{{ effective_requested_cores }}"
+    vllm_cpu_start: "{{ vllm_cpu_start | default(omit) }}"
+    vllm_numa_node: "{{ vllm_numa_node | default(omit) }}"
+    guidellm_cpus: "{{ guidellm_cpus | default(omit) }}"
+    guidellm_numa_node: "{{ guidellm_numa_node | default(omit) }}"
   when:
     - not (skip_phase_2 | default(false) | bool)
     - (base_workload + '_var') in ['chat_var', 'code_var', 'summarization_var']
@@ -226,6 +267,10 @@
     workload_type: "{{ base_workload }}_var"
     vllm_caching_mode: "production"
     requested_cores: "{{ effective_requested_cores }}"
+    vllm_cpu_start: "{{ vllm_cpu_start | default(omit) }}"
+    vllm_numa_node: "{{ vllm_numa_node | default(omit) }}"
+    guidellm_cpus: "{{ guidellm_cpus | default(omit) }}"
+    guidellm_numa_node: "{{ guidellm_numa_node | default(omit) }}"
   when:
     - not (skip_phase_3 | default(false) | bool)
     - (base_workload + '_var') in ['chat_var', 'code_var', 'summarization_var']

--- a/automation/test-execution/ansible/roles/common/tasks/allocate-cores-from-count.yml
+++ b/automation/test-execution/ansible/roles/common/tasks/allocate-cores-from-count.yml
@@ -15,6 +15,26 @@
       - numa_topology.nodes is defined
     fail_msg: "Missing required variables: requested_cores and numa_topology must be set"
 
+- name: Validate vllm_cpu_start if provided
+  ansible.builtin.assert:
+    that:
+      - vllm_cpu_start | int >= 0
+    fail_msg: "vllm_cpu_start must be non-negative, got: {{ vllm_cpu_start }}"
+  when:
+    - vllm_cpu_start is defined
+    - vllm_cpu_start != None
+    - vllm_cpu_start != omit
+
+- name: Validate vllm_numa_node if provided
+  ansible.builtin.assert:
+    that:
+      - vllm_numa_node | int >= 0
+    fail_msg: "vllm_numa_node must be non-negative, got: {{ vllm_numa_node }}"
+  when:
+    - vllm_numa_node is defined
+    - vllm_numa_node != None
+    - vllm_numa_node != omit
+
 - name: Validate requested_tensor_parallel if provided
   ansible.builtin.assert:
     that:
@@ -30,9 +50,14 @@
   ansible.builtin.set_fact:
     _tensor_parallel_value: "{{ requested_tensor_parallel if (requested_tensor_parallel is defined and requested_tensor_parallel != omit and requested_tensor_parallel != None and requested_tensor_parallel != '') else None }}"
 
+- name: Set socket pinning values for allocation
+  ansible.builtin.set_fact:
+    _vllm_cpu_start_value: "{{ vllm_cpu_start if (vllm_cpu_start is defined and vllm_cpu_start != omit and vllm_cpu_start != None and vllm_cpu_start != '') else None }}"
+    _vllm_numa_node_value: "{{ vllm_numa_node if (vllm_numa_node is defined and vllm_numa_node != omit and vllm_numa_node != None and vllm_numa_node != '') else None }}"
+
 - name: Allocate cores using multi-NUMA algorithm
   ansible.builtin.set_fact:
-    core_allocation_result: "{{ numa_topology | allocate_cores_multi_numa(requested_cores | int, _tensor_parallel_value) }}"
+    core_allocation_result: "{{ numa_topology | allocate_cores_multi_numa(requested_cores | int, _tensor_parallel_value, _vllm_cpu_start_value, _vllm_numa_node_value) }}"
 
 - name: Build auto-allocated core configuration
   ansible.builtin.set_fact:

--- a/docs/ansible/test-execution.md
+++ b/docs/ansible/test-execution.md
@@ -1,0 +1,296 @@
+---
+layout: default
+title: Ansible Test Execution
+---
+
+## Ansible Test Execution Guide
+
+Automated testing framework for vLLM performance evaluation with NUMA-aware CPU
+optimization.
+
+> **📚 Complete Reference:** For full details on all playbooks, roles, and
+> configuration options, see the [Ansible automation
+> guide](https://github.com/redhat-et/vllm-cpu-perf-eval/blob/main/automation/test-execution/ansible/ansible.md)
+> in the repository.
+
+## Quick Start
+
+### Prerequisites
+
+**Control Machine (where you run Ansible):**
+
+```bash
+# Install Ansible
+pip install ansible-core
+
+# Navigate to ansible directory
+cd automation/test-execution/ansible
+
+# Install required collections
+ansible-galaxy collection install -r requirements.yml
+```
+
+**Test Hosts (DUT and Load Generator):**
+
+- OS: Ubuntu 22.04+, RHEL 9+, or Fedora 38+
+- SSH access with sudo privileges
+- Python 3.8+
+
+### Run Your First Test
+
+```bash
+# Simple LLM benchmark
+ansible-playbook llm-benchmark-auto.yml \
+  -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \
+  -e "workload_type=chat" \
+  -e "requested_cores=16"
+```
+
+## Available Playbooks
+
+### LLM Testing
+
+| Playbook | Purpose | Configuration |
+|----------|---------|---------------|
+| `llm-benchmark-auto.yml` | Single LLM test | Auto (core count) |
+| `llm-benchmark-concurrent-load.yml` | 3-phase concurrent load test | Auto |
+| `llm-core-sweep-auto.yml` | Multi-core sweep | Auto |
+
+### Platform Setup
+
+| Playbook | Purpose |
+|----------|---------|
+| `setup-platform.yml` | Install packages, configure performance settings |
+| `health-check.yml` | Verify system readiness |
+
+## Test Configuration
+
+### Basic Parameters
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `test_model` | HuggingFace model ID | `meta-llama/Llama-3.2-1B-Instruct` |
+| `workload_type` | Test workload | `chat`, `code`, `summarization` |
+| `requested_cores` | CPU cores for vLLM | `16`, `32`, `64` |
+
+### Optional Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `requested_tensor_parallel` | Tensor parallelism | Auto-calculated |
+| `guidellm_profile` | Benchmark profile | `concurrent` |
+| `guidellm_rate` | Concurrency levels | `[1,2,4,8,16,32]` |
+| `guidellm_max_seconds` | Test duration (seconds) | `600` |
+
+## Advanced Features
+
+### Socket Pinning (NUMA Affinity)
+
+Socket pinning isolates vLLM server and GuideLLM load generator to different
+CPU sockets/NUMA nodes, minimizing performance interference.
+
+**Supported Playbooks:**
+
+- ✅ `llm-benchmark-auto.yml`
+- ✅ `llm-benchmark-concurrent-load.yml`
+
+**Parameters:**
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `vllm_cpu_start` | CPU ID to start vLLM allocation | `64` (socket 1) |
+| `vllm_numa_node` | NUMA node for vLLM | `1` |
+| `guidellm_cpus` | CPU range for load generator | `"0-31"` |
+| `guidellm_numa_node` | NUMA node for load generator | `0` |
+
+**Determine System Socket Layout:**
+
+```bash
+# Show NUMA topology
+lscpu | grep NUMA
+
+# Show cores per NUMA node
+numactl --hardware
+
+# Example output:
+# node 0 cpus: 0 1 2 ... 31
+# node 1 cpus: 64 65 66 ... 95
+```
+
+**Example: vLLM on Socket 1, GuideLLM on Socket 0**
+
+Assuming 2-socket system:
+
+- Socket 0: Cores 0-31 (NUMA node 0)
+- Socket 1: Cores 64-95 (NUMA node 1)
+
+```bash
+# Single test with socket separation
+ansible-playbook llm-benchmark-auto.yml \
+  -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \
+  -e "workload_type=chat" \
+  -e "requested_cores=32" \
+  -e "vllm_cpu_start=64" \
+  -e "vllm_numa_node=1" \
+  -e "guidellm_cpus=0-31" \
+  -e "guidellm_numa_node=0"
+```
+
+```bash
+# Concurrent load test with socket separation
+ansible-playbook llm-benchmark-concurrent-load.yml \
+  -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \
+  -e "base_workload=chat" \
+  -e "requested_cores=32" \
+  -e "vllm_cpu_start=64" \
+  -e "vllm_numa_node=1" \
+  -e "guidellm_cpus=0-31" \
+  -e "guidellm_numa_node=0"
+```
+
+**Validation:**
+
+```bash
+# Verify vLLM container pinning
+podman ps | grep vllm
+podman inspect <container-id> | grep -A 2 cpuset
+# Expected: "CpusetCpus": "64-95", "CpusetMems": "1"
+
+# Verify GuideLLM container pinning
+podman ps | grep guidellm
+podman inspect <container-id> | grep -A 2 cpuset
+# Expected: "CpusetCpus": "0-31", "CpusetMems": "0"
+```
+
+**Use Cases:**
+
+- **Minimize Interference**: Eliminate CPU contention between server and load
+  generator
+- **Test Cross-NUMA Performance**: Measure impact of cross-socket memory access
+- **Multi-Tenant Systems**: Isolate benchmarks from other workloads
+
+**Notes:**
+
+- Socket pinning requires `vllm_numa_node` to be set
+- When pinning to single NUMA node, `tensor_parallel` must equal 1
+- The automation validates requested cores fit within specified socket
+
+### 3-Phase Concurrent Load Testing
+
+The concurrent load test runs three phases to evaluate different scenarios:
+
+**Phase 1: Baseline (Fixed Tokens, No Caching)**
+
+- Fixed input/output token counts
+- Prefix caching disabled
+- Establishes baseline performance
+
+**Phase 2: Realistic (Variable Tokens, No Caching)**
+
+- Variable token counts (realistic traffic)
+- Prefix caching disabled
+- Tests production-like variability
+
+**Phase 3: Production (Variable Tokens, With Caching)**
+
+- Variable token counts
+- Prefix caching enabled
+- Tests production configuration
+
+**Example:**
+
+```bash
+# Run all 3 phases
+ansible-playbook llm-benchmark-concurrent-load.yml \
+  -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \
+  -e "base_workload=chat" \
+  -e "requested_cores=32"
+
+# Run only Phase 1 (baseline)
+ansible-playbook llm-benchmark-concurrent-load.yml \
+  -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \
+  -e "base_workload=chat" \
+  -e "requested_cores=16" \
+  -e "skip_phase_2=true" \
+  -e "skip_phase_3=true"
+```
+
+## Results
+
+Test results are saved to `results/llm/<model>/<test-run-id>/`:
+
+```text
+results/llm/meta-llama__Llama-3.2-1B-Instruct/20240428-120000/
+├── benchmarks.json          # GuideLLM benchmark results
+├── benchmarks.csv           # CSV format
+├── test-metadata.json       # Test configuration
+├── vllm-metrics.log         # vLLM server metrics
+└── guidellm.log             # Load generator logs
+```
+
+## Workload Types
+
+### Baseline Workloads (Fixed Tokens)
+
+| Workload | Input Tokens | Output Tokens | Use Case |
+|----------|--------------|---------------|----------|
+| `chat` | 1024 | 256 | Conversational AI |
+| `code` | 1024 | 512 | Code generation |
+| `summarization` | 2048 | 256 | Document summarization |
+| `rag` | 2048 | 512 | RAG applications |
+
+### Variable Workloads (Realistic Traffic)
+
+| Workload | Token Range | Use Case |
+|----------|-------------|----------|
+| `chat_var` | ISL: 256-2048, OSL: 64-512 | Production chat |
+| `code_var` | ISL: 512-2048, OSL: 128-1024 | Production code gen |
+| `summarization_var` | ISL: 1024-4096, OSL: 64-512 | Production summarization |
+
+## Troubleshooting
+
+### Connection Issues
+
+```bash
+# Test SSH connectivity
+ansible -i inventory/hosts.yml all -m ping
+
+# Verbose output
+ansible -i inventory/hosts.yml all -m ping -vvv
+```
+
+### vLLM Won't Start
+
+```bash
+# Check container logs
+podman logs <container-id>
+
+# Check if port is in use
+ss -tlnp | grep 8000
+```
+
+### HuggingFace Token
+
+For gated models (Llama, Mistral):
+
+```bash
+# Set token as environment variable
+export HF_TOKEN=your_token_here
+
+# Or configure in inventory
+vim inventory/group_vars/all/credentials.yml
+```
+
+## Next Steps
+
+- [Understanding Metrics](../methodology/metrics.md) - Metrics definitions
+- [Platform Setup](../platform-setup/x86/intel/deterministic-benchmarking.md) -
+  Intel Xeon tuning
+- [Complete Ansible Guide](https://github.com/redhat-et/vllm-cpu-perf-eval/blob/main/automation/test-execution/ansible/ansible.md) -
+  Full reference
+
+## Reference
+
+- [Ansible Documentation](https://docs.ansible.com/)
+- [GuideLLM](https://github.com/vllm-project/guidellm)
+- [vLLM](https://github.com/vllm-project/vllm)

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -118,8 +118,10 @@ pre-commit run --all-files
 | methodology/metrics.md | ✅ Complete | 2024-02-08 |
 | methodology/reporting.md | ✅ Complete | 2024-02-08 |
 | platform-setup/x86/intel/deterministic-benchmarking.md | ✅ Complete | (current) |
+| ansible/test-execution.md | ✅ Complete | 2026-04-28 |
 | containers/* | 📝 Planned | - |
-| ansible/* | 📝 Planned | - |
+| ansible/distributed-testing.md | 📝 Planned | - |
+| ansible/playbook-reference.md | 📝 Planned | - |
 | getting-started/* | 📝 Planned | - |
 | reference/* | 📝 Planned | - |
 


### PR DESCRIPTION
Add socket pinning capability to isolate vLLM server and GuideLLM load generator to different CPU sockets/NUMA nodes. This minimizes performance interference and enables cross-NUMA benchmarking scenarios.

Changes:
- Core allocation: Enhanced allocate_cores_multi_numa() filter to support cpu_start offset and numa_node_override for single-socket allocation
- Playbooks: Added socket pinning parameters (vllm_cpu_start, vllm_numa_node, guidellm_cpus, guidellm_numa_node) to llm-benchmark-auto.yml and llm-benchmark-concurrent-load.yml
- GuideLLM config: Made cpuset_cpus and cpuset_mems dynamic in benchmark-tools.yml
- Documentation: Added comprehensive socket pinning guide to ansible.md, README.md, and new docs/ansible/test-execution.md for GitHub Pages
- Site navigation: Added Ansible Automation link to _config.yml

Socket pinning enables:
- Minimizing CPU contention between server and load generator
- Testing cross-NUMA memory bandwidth impact
- Isolating benchmarks in multi-tenant systems

Example usage:
  ansible-playbook llm-benchmark-auto.yml \ -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \ -e "workload_type=chat" \ -e "requested_cores=32" \ -e "vllm_cpu_start=64" \ -e "vllm_numa_node=1" \ -e "guidellm_cpus=0-31" \ -e "guidellm_numa_node=0"