### PR TITLE
feat: add custom entrypoint support for AMD ZenDNN containers

### DIFF
--- a/automation/test-execution/ansible/ansible.md
+++ b/automation/test-execution/ansible/ansible.md
@@ -482,9 +482,9 @@ ansible-playbook llm-benchmark-auto.yml \
 
 AMD ZenDNN containers require special configuration for NUMA pinning. The automation automatically detects AMD ZenDNN containers and applies:
 
-- **CPU Pinning**: Applied via `cpuset_cpus` (e.g., `96-127` for NUMA node 1)  
-- **Thread Affinity**: `VLLM_CPU_OMP_THREADS_BIND` env var set to match cpuset (required for ZenDNN)  
-- **Memory Binding**: Skipped (ZenDNN libnuma requires visibility to all NUMA nodes)  
+- **CPU Pinning**: Applied via `cpuset_cpus` (e.g., `96-127` for NUMA node 1)
+- **Thread Affinity**: `VLLM_CPU_OMP_THREADS_BIND` env var set to match cpuset (required for ZenDNN)
+- **Memory Binding**: Skipped (ZenDNN libnuma requires visibility to all NUMA nodes)
 - **Memory Affinity**: Achieved naturally via CPU locality
 
 You can use socket pinning parameters normally - the automation handles AMD-specific requirements:

--- a/automation/test-execution/ansible/ansible.md
+++ b/automation/test-execution/ansible/ansible.md
@@ -113,10 +113,14 @@ export HF_TOKEN=hf_xxxxx  # If using gated models like Llama
 export VLLM_CONTAINER_IMAGE=docker.io/vllm/vllm-openai-cpu:v0.18.0
 export GUIDELLM_CONTAINER_IMAGE=ghcr.io/vllm-project/guidellm:v0.6.0
 
+# Health check timeout (optional - default: 600s)
+export VLLM_HEALTH_TIMEOUT=600
+
 # Custom entrypoint (optional - only needed for containers without vLLM in default path)
 # Example for AMD ZenDNN containers:
 export VLLM_CONTAINER_IMAGE=docker.io/amdih/zendnn_zentorch:vllm_v0.18.0_zentorch_v5.2.1_rhel9.5_r5.2.1
 export VLLM_CONTAINER_ENTRYPOINT='["vllm", "serve"]'
+export VLLM_HEALTH_TIMEOUT=1200  # AMD ZenDNN needs longer startup time
 ```
 
 The inventory automatically uses these variables with sensible defaults.
@@ -433,6 +437,10 @@ Set these environment variables before running your playbooks:
 # AMD ZenDNN optimized vLLM container
 export VLLM_CONTAINER_IMAGE=docker.io/amdih/zendnn_zentorch:vllm_v0.18.0_zentorch_v5.2.1_rhel9.5_r5.2.1
 export VLLM_CONTAINER_ENTRYPOINT='["vllm", "serve"]'
+
+# AMD ZenDNN containers have longer initialization time
+# Increase health check timeout (default: 600s, AMD recommended: 900-1200s)
+export VLLM_HEALTH_TIMEOUT=1200
 ```
 
 **Available AMD ZenDNN Container Versions:**
@@ -448,6 +456,7 @@ Check [AMD Infinity Hub](https://www.amd.com/en/developer/resources/infinity-hub
 # 1. Configure AMD container
 export VLLM_CONTAINER_IMAGE=docker.io/amdih/zendnn_zentorch:vllm_v0.18.0_zentorch_v5.2.1_rhel9.5_r5.2.1
 export VLLM_CONTAINER_ENTRYPOINT='["vllm", "serve"]'
+export VLLM_HEALTH_TIMEOUT=1200  # AMD ZenDNN needs longer startup time
 
 # 2. Set your infrastructure
 export DUT_HOSTNAME=amd-epyc-server.example.com

--- a/automation/test-execution/ansible/ansible.md
+++ b/automation/test-execution/ansible/ansible.md
@@ -112,6 +112,11 @@ export HF_TOKEN=hf_xxxxx  # If using gated models like Llama
 # Container images (optional - defaults are provided)
 export VLLM_CONTAINER_IMAGE=docker.io/vllm/vllm-openai-cpu:v0.18.0
 export GUIDELLM_CONTAINER_IMAGE=ghcr.io/vllm-project/guidellm:v0.6.0
+
+# Custom entrypoint (optional - only needed for containers without vLLM in default path)
+# Example for AMD ZenDNN containers:
+export VLLM_CONTAINER_IMAGE=docker.io/amdih/zendnn_zentorch:vllm_v0.18.0_zentorch_v5.2.1_rhel9.5_r5.2.1
+export VLLM_CONTAINER_ENTRYPOINT='["vllm", "serve"]'
 ```
 
 The inventory automatically uses these variables with sensible defaults.
@@ -409,6 +414,84 @@ Results include:
 
 See [Results Documentation](../../../results/results.md) for more details on
 result organization and analysis.
+
+## Platform-Specific Configurations
+
+### Testing vLLM-CPU on AMD Platforms (ZenDNN)
+
+AMD provides optimized vLLM containers with ZenDNN (Zen Deep Neural Network) and ZenTorch acceleration for improved performance on AMD EPYC processors. These containers require a custom entrypoint configuration.
+
+**Why a custom entrypoint is needed:**
+
+The AMD ZenDNN containers package vLLM differently than the standard vLLM containers. Instead of having vLLM in the default PATH, you need to explicitly specify `vllm serve` as the entrypoint. Without this, the container will exit with code 127 ("command not found").
+
+**Configuration:**
+
+Set these environment variables before running your playbooks:
+
+```bash
+# AMD ZenDNN optimized vLLM container
+export VLLM_CONTAINER_IMAGE=docker.io/amdih/zendnn_zentorch:vllm_v0.18.0_zentorch_v5.2.1_rhel9.5_r5.2.1
+export VLLM_CONTAINER_ENTRYPOINT='["vllm", "serve"]'
+```
+
+**Available AMD ZenDNN Container Versions:**
+
+- `docker.io/amdih/zendnn_zentorch:vllm_v0.18.0_zentorch_v5.2.1_rhel9.5_r5.2.1` (RHEL 9.5)
+- `docker.io/amdih/zendnn_zentorch:vllm_v0.18.0_zentorch_v5.2.1_ubuntu22.04_r5.2.1` (Ubuntu 22.04)
+
+Check [AMD Infinity Hub](https://www.amd.com/en/developer/resources/infinity-hub.html) for the latest versions.
+
+**Complete Example - AMD Platform Test:**
+
+```bash
+# 1. Configure AMD container
+export VLLM_CONTAINER_IMAGE=docker.io/amdih/zendnn_zentorch:vllm_v0.18.0_zentorch_v5.2.1_rhel9.5_r5.2.1
+export VLLM_CONTAINER_ENTRYPOINT='["vllm", "serve"]'
+
+# 2. Set your infrastructure
+export DUT_HOSTNAME=amd-epyc-server.example.com
+export LOADGEN_HOSTNAME=loadgen-server.example.com
+export HF_TOKEN=hf_xxxxx  # If using gated models
+
+# 3. Run benchmark
+cd automation/test-execution/ansible
+ansible-playbook llm-benchmark-auto.yml \
+  -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \
+  -e "workload_type=chat" \
+  -e "requested_cores=64"
+```
+
+**What gets optimized:**
+
+- **ZenDNN**: AMD's optimized deep learning library for EPYC processors
+- **ZenTorch**: PyTorch integration with ZenDNN for transparent acceleration
+- **NUMA-aware execution**: Leverages AMD EPYC multi-die architecture
+- **AVX-512 & AVX2**: CPU instruction set optimizations
+
+**Verifying ZenDNN is active:**
+
+Check the vLLM server logs for ZenDNN initialization messages:
+
+```bash
+# View logs from the DUT after starting a test
+ssh ${DUT_HOSTNAME} "podman logs vllm-server 2>&1 | grep -i zendnn"
+```
+
+You should see messages indicating ZenDNN/ZenTorch are loaded.
+
+**Switching back to standard vLLM:**
+
+To use the standard vLLM container, simply unset the environment variables or set them to the default:
+
+```bash
+export VLLM_CONTAINER_IMAGE=docker.io/vllm/vllm-openai-cpu:v0.18.0
+unset VLLM_CONTAINER_ENTRYPOINT
+```
+
+**Technical Details:**
+
+The entrypoint configuration is set in [inventory/group_vars/all/infrastructure.yml](inventory/group_vars/all/infrastructure.yml) and read from the `VLLM_CONTAINER_ENTRYPOINT` environment variable. The framework automatically applies it when starting the container via the [vllm_server role](roles/vllm_server/tasks/start-llm.yml).
 
 ## Directory Structure
 

--- a/automation/test-execution/ansible/ansible.md
+++ b/automation/test-execution/ansible/ansible.md
@@ -478,6 +478,29 @@ ansible-playbook llm-benchmark-auto.yml \
 - **NUMA-aware execution**: Leverages AMD EPYC multi-die architecture
 - **AVX-512 & AVX2**: CPU instruction set optimizations
 
+**NUMA Socket Pinning with AMD ZenDNN:**
+
+AMD ZenDNN containers require special configuration for NUMA pinning. The automation automatically detects AMD ZenDNN containers and applies:
+
+- **CPU Pinning**: Applied via `cpuset_cpus` (e.g., `96-127` for NUMA node 1)  
+- **Thread Affinity**: `VLLM_CPU_OMP_THREADS_BIND` env var set to match cpuset (required for ZenDNN)  
+- **Memory Binding**: Skipped (ZenDNN libnuma requires visibility to all NUMA nodes)  
+- **Memory Affinity**: Achieved naturally via CPU locality
+
+You can use socket pinning parameters normally - the automation handles AMD-specific requirements:
+
+```bash
+-e "vllm_cpu_start=96" \
+-e "vllm_numa_node=1" \
+-e "guidellm_cpus=0-31" \
+-e "guidellm_numa_node=0"
+```
+
+**Why this configuration:**
+- AMD ZenDNN's internal thread affinity requires `VLLM_CPU_OMP_THREADS_BIND` matching the container's CPU set
+- Without this env var, vLLM fails with `sched_setaffinity errno 22`
+- ZenDNN's libnuma needs to see all NUMA nodes, so `cpuset_mems` is omitted
+
 **Verifying ZenDNN is active:**
 
 Check the vLLM server logs for ZenDNN initialization messages:

--- a/automation/test-execution/ansible/inventory/group_vars/all/infrastructure.yml
+++ b/automation/test-execution/ansible/inventory/group_vars/all/infrastructure.yml
@@ -36,7 +36,9 @@ container_runtime:
 
 # Health check configuration
 health_check:
-  timeout: 300                  # Total timeout in seconds
+  # Total timeout in seconds (can be overridden with VLLM_HEALTH_TIMEOUT env var)
+  # AMD ZenDNN containers may need longer startup time (900-1200s recommended)
+  timeout: "{{ lookup('env', 'VLLM_HEALTH_TIMEOUT') | default('600', true) | int }}"
   interval: 5                   # Check interval in seconds
 
 # Test execution options

--- a/automation/test-execution/ansible/inventory/group_vars/all/infrastructure.yml
+++ b/automation/test-execution/ansible/inventory/group_vars/all/infrastructure.yml
@@ -23,6 +23,10 @@ container_runtime:
   # This image includes CPU optimizations for performance testing
   # Can be overridden with environment variable: export VLLM_CONTAINER_IMAGE=...
   image: "{{ lookup('env', 'VLLM_CONTAINER_IMAGE') | default('docker.io/vllm/vllm-openai-cpu:v0.18.0', true) }}"
+  # Optional: Custom entrypoint for containers that don't have vLLM in their default path
+  # Can be overridden with environment variable: export VLLM_CONTAINER_ENTRYPOINT=...
+  # Example for AMD ZenDNN containers: export VLLM_CONTAINER_ENTRYPOINT='["vllm", "serve"]'
+  entrypoint: "{{ lookup('env', 'VLLM_CONTAINER_ENTRYPOINT') | default('', true) }}"
   security_opts:
     - "seccomp=unconfined"
   capabilities:

--- a/automation/test-execution/ansible/roles/benchmark_guidellm/tasks/main.yml
+++ b/automation/test-execution/ansible/roles/benchmark_guidellm/tasks/main.yml
@@ -175,7 +175,7 @@
 
 - name: Build GuideLLM container name with actual NUMA configuration
   ansible.builtin.set_fact:
-    guidellm_container_name: "guidellm-{{ workload_type }}-vllm-numa{{ core_cfg.cpuset_mems }}-loadgen-numa{{ guidellm_cfg.cpuset_mems }}"
+    guidellm_container_name: "guidellm-{{ workload_type }}-{{ core_cfg.name | default(core_cfg.cpuset_cpus | default('auto')) }}-vllm-numa{{ core_cfg.cpuset_mems }}-loadgen-numa{{ guidellm_cfg.cpuset_mems }}"
   when: use_guidellm_container | bool
 
 - name: Start GuideLLM benchmark container

--- a/automation/test-execution/ansible/roles/benchmark_guidellm/tasks/main.yml
+++ b/automation/test-execution/ansible/roles/benchmark_guidellm/tasks/main.yml
@@ -173,9 +173,14 @@
     - vllm_api_key | length > 0
   no_log: true
 
+- name: Build GuideLLM container name with actual NUMA configuration
+  ansible.builtin.set_fact:
+    guidellm_container_name: "guidellm-{{ workload_type }}-vllm-numa{{ core_cfg.cpuset_mems }}-loadgen-numa{{ guidellm_cfg.cpuset_mems }}"
+  when: use_guidellm_container | bool
+
 - name: Start GuideLLM benchmark container
   containers.podman.podman_container:
-    name: "guidellm-{{ workload_type }}-{{ core_cfg.name }}"
+    name: "{{ guidellm_container_name }}"
     image: "{{ guidellm_cfg.container_image }}"
     state: started
     rm: false  # Don't auto-remove so we can check exit code
@@ -188,14 +193,14 @@
     env: "{{ guidellm_env }}"
     log_driver: journald
     log_opt:
-      tag: "guidellm-{{ workload_type }}-{{ core_cfg.name }}"
+      tag: "{{ guidellm_container_name }}"
   register: guidellm_container
   when: use_guidellm_container | bool
   no_log: true  # Prevent HF_TOKEN from appearing in logs
 
 - name: Set monitoring command based on connection type
   ansible.builtin.set_fact:
-    monitor_cmd: "{{ 'sudo podman logs -f guidellm-' + workload_type + '-' + core_cfg.name if ansible_connection == 'local' else 'ssh ' + ansible_user + '@' + ansible_host + ' sudo podman logs -f guidellm-' + workload_type + '-' + core_cfg.name }}"
+    monitor_cmd: "{{ 'sudo podman logs -f ' + guidellm_container_name if ansible_connection == 'local' else 'ssh ' + ansible_user + '@' + ansible_host + ' sudo podman logs -f ' + guidellm_container_name }}"
   when: use_guidellm_container | bool
 
 - name: Calculate wait timeout based on profile and number of benchmarks
@@ -225,7 +230,6 @@
     guidellm_expected_seconds: "{{ guidellm_max_seconds | default(guidellm_cfg.max_seconds | default(600)) | int }}"
     guidellm_poll_seconds: 30
     guidellm_last_progress_message: ""
-    guidellm_container_name: "guidellm-{{ workload_type }}-{{ core_cfg.name }}"
   when: use_guidellm_container | bool
 
 - name: Set controller-side benchmark progress log directory (containerized)
@@ -236,7 +240,7 @@
 - name: Set controller-side benchmark progress log file (containerized)
   ansible.builtin.set_fact:
     guidellm_progress_log_file: >-
-      {{ guidellm_progress_log_dir }}/{{ test_model | replace('/', '__') }}-{{ workload_type }}-{{ core_cfg.name }}-progress.log
+      {{ guidellm_progress_log_dir }}/{{ test_model | replace('/', '__') }}-{{ workload_type }}-{{ guidellm_container_name }}-progress.log
   when: use_guidellm_container | bool
 
 - name: Ensure controller-side benchmark progress log directory exists
@@ -310,7 +314,7 @@
 
 - name: Get container exit details
   ansible.builtin.shell:
-    cmd: "podman inspect {{ ('guidellm-' ~ workload_type ~ '-' ~ core_cfg.name) | quote }} --format '{''{ .State.ExitCode }''}' || echo 1"
+    cmd: "podman inspect {{ guidellm_container_name | quote }} --format '{''{ .State.ExitCode }''}' || echo 1"
   args:
     executable: /bin/bash
   register: container_exit_code
@@ -320,7 +324,7 @@
 
 - name: Capture container logs on failure
   ansible.builtin.shell:
-    cmd: "podman logs {{ ('guidellm-' ~ workload_type ~ '-' ~ core_cfg.name) | quote }} 2>&1 | tail -100"
+    cmd: "podman logs {{ guidellm_container_name | quote }} 2>&1 | tail -100"
   args:
     executable: /bin/bash
   register: guidellm_failure_logs
@@ -342,7 +346,7 @@
 
 - name: Stream GuideLLM container logs directly to file
   ansible.builtin.shell:
-    cmd: "podman logs {{ ('guidellm-' ~ workload_type ~ '-' ~ core_cfg.name) | quote }} > {{ guidellm_log_file.path | quote }} 2>&1"
+    cmd: "podman logs {{ guidellm_container_name | quote }} > {{ guidellm_log_file.path | quote }} 2>&1"
   args:
     executable: /bin/bash
   changed_when: false
@@ -370,7 +374,7 @@
 
 - name: Remove completed container
   containers.podman.podman_container:
-    name: "guidellm-{{ workload_type }}-{{ core_cfg.name }}"
+    name: "{{ guidellm_container_name }}"
     state: absent
   when:
     - use_guidellm_container | bool

--- a/automation/test-execution/ansible/roles/vllm_server/tasks/start-embedding.yml
+++ b/automation/test-execution/ansible/roles/vllm_server/tasks/start-embedding.yml
@@ -85,6 +85,7 @@
     cpuset_mems: "{{ core_cfg.cpuset_mems }}"
     volumes: "{{ [model_cache_dir + ':/root/.cache/huggingface:rw', log_dir + ':/var/log/vllm:rw'] if (use_persistent_cache | default(false) | bool) else [] }}"
     env: "{{ vllm_env_vars }}"
+    entrypoint: "{{ container_cfg.entrypoint | trim if (container_cfg.entrypoint is defined and container_cfg.entrypoint | trim | length > 0) else omit }}"
     command: >
       --model {{ test_model }}
       --host {{ vllm_server.host }}
@@ -114,6 +115,7 @@
     cap_add: "{{ container_cfg.capabilities | default([]) }}"
     volumes: "{{ [model_cache_dir + ':/root/.cache/huggingface:rw', log_dir + ':/var/log/vllm:rw'] if (use_persistent_cache | default(false) | bool) else [] }}"
     env: "{{ vllm_env_vars }}"
+    entrypoint: "{{ container_cfg.entrypoint | trim if (container_cfg.entrypoint is defined and container_cfg.entrypoint | trim | length > 0) else omit }}"
     command: >
       --model {{ test_model }}
       --host {{ vllm_server.host }}

--- a/automation/test-execution/ansible/roles/vllm_server/tasks/start-llm.yml
+++ b/automation/test-execution/ansible/roles/vllm_server/tasks/start-llm.yml
@@ -283,6 +283,7 @@
     cpuset_mems: "{{ core_cfg.cpuset_mems }}"
     volumes: "{{ [model_cache_dir + ':/root/.cache/huggingface:rw', log_dir + ':/var/log/vllm:rw'] if (use_persistent_cache | default(false) | bool) else [] }}"
     env: "{{ vllm_env_vars }}"
+    entrypoint: "{{ container_cfg.entrypoint if (container_cfg.entrypoint is defined and container_cfg.entrypoint | length > 0) else omit }}"
     command: "{{ vllm_cmd }}"
     log_driver: journald
     log_opt:

--- a/automation/test-execution/ansible/roles/vllm_server/tasks/start-llm.yml
+++ b/automation/test-execution/ansible/roles/vllm_server/tasks/start-llm.yml
@@ -178,6 +178,18 @@
     - core_cfg.omp_threads_bind is not none
   no_log: true  # Prevent HF_TOKEN from appearing in logs
 
+- name: Detect AMD ZenDNN container for OMP binding
+  ansible.builtin.set_fact:
+    is_zendnn_container_early: "{{ 'zendnn' in (container_cfg.image | lower) or 'zentorch' in (container_cfg.image | lower) }}"
+
+- name: Add VLLM_CPU_OMP_THREADS_BIND for AMD ZenDNN containers (required for thread affinity)
+  ansible.builtin.set_fact:
+    vllm_env_vars: "{{ vllm_env_vars | combine({'VLLM_CPU_OMP_THREADS_BIND': core_cfg.cpuset_cpus}) }}"
+  when:
+    - is_zendnn_container_early
+    - core_cfg.cpuset_cpus is defined
+  no_log: true  # Prevent HF_TOKEN from appearing in logs
+
 - name: Build base vLLM arguments from workload
   ansible.builtin.set_fact:
     vllm_base_args: "{{ workload_cfg.vllm_args | default([]) }}"
@@ -267,6 +279,22 @@
       - "  Max Model Len: {{ effective_max_model_len }} (required min: {{ required_min_len }})"
       - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
+- name: Detect AMD ZenDNN container
+  ansible.builtin.set_fact:
+    is_zendnn_container: "{{ 'zendnn' in (container_cfg.image | lower) or 'zentorch' in (container_cfg.image | lower) }}"
+
+- name: Display AMD ZenDNN configuration
+  ansible.builtin.debug:
+    msg:
+      - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      - "AMD ZenDNN Container Detected"
+      - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      - "CPU Pinning: {{ core_cfg.cpuset_cpus }}"
+      - "NUMA Memory Binding: Disabled (ZenDNN requires access to all nodes)"
+      - "Thread Affinity: VLLM_CPU_OMP_THREADS_BIND={{ core_cfg.cpuset_cpus }}"
+      - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  when: is_zendnn_container
+
 - name: Start vLLM LLM server
   containers.podman.podman_container:
     name: "{{ vllm_container_name }}"
@@ -280,7 +308,7 @@
     security_opt: "{{ container_cfg.security_opts | default([]) }}"
     cap_add: "{{ container_cfg.capabilities | default([]) }}"
     cpuset_cpus: "{{ core_cfg.cpuset_cpus }}"
-    cpuset_mems: "{{ core_cfg.cpuset_mems }}"
+    cpuset_mems: "{{ omit if is_zendnn_container else core_cfg.cpuset_mems }}"
     volumes: "{{ [model_cache_dir + ':/root/.cache/huggingface:rw', log_dir + ':/var/log/vllm:rw'] if (use_persistent_cache | default(false) | bool) else [] }}"
     env: "{{ vllm_env_vars }}"
     entrypoint: "{{ container_cfg.entrypoint if (container_cfg.entrypoint is defined and container_cfg.entrypoint | length > 0) else omit }}"

--- a/automation/test-execution/ansible/roles/vllm_server/tasks/start-llm.yml
+++ b/automation/test-execution/ansible/roles/vllm_server/tasks/start-llm.yml
@@ -311,7 +311,7 @@
     cpuset_mems: "{{ omit if is_zendnn_container else core_cfg.cpuset_mems }}"
     volumes: "{{ [model_cache_dir + ':/root/.cache/huggingface:rw', log_dir + ':/var/log/vllm:rw'] if (use_persistent_cache | default(false) | bool) else [] }}"
     env: "{{ vllm_env_vars }}"
-    entrypoint: "{{ container_cfg.entrypoint if (container_cfg.entrypoint is defined and container_cfg.entrypoint | length > 0) else omit }}"
+    entrypoint: "{{ container_cfg.entrypoint | trim if (container_cfg.entrypoint is defined and container_cfg.entrypoint | trim | length > 0) else omit }}"
     command: "{{ vllm_cmd }}"
     log_driver: journald
     log_opt:

--- a/docs/ansible/test-execution.md
+++ b/docs/ansible/test-execution.md
@@ -215,6 +215,62 @@ ansible-playbook llm-benchmark-concurrent-load.yml \
   -e "skip_phase_3=true"
 ```
 
+## Platform-Specific Configurations
+
+### AMD EPYC with ZenDNN
+
+AMD provides optimized vLLM containers with ZenDNN (Zen Deep Neural Network) and
+ZenTorch for improved performance on AMD EPYC processors.
+
+**Why custom configuration is needed:**
+
+AMD ZenDNN containers require an explicit entrypoint (`vllm serve`) because the
+vLLM executable is not in the default PATH.
+
+**Setup:**
+
+```bash
+# AMD ZenDNN optimized container
+export VLLM_CONTAINER_IMAGE=docker.io/amdih/zendnn_zentorch:vllm_v0.18.0_zentorch_v5.2.1_rhel9.5_r5.2.1
+export VLLM_CONTAINER_ENTRYPOINT='["vllm", "serve"]'
+
+# Run benchmark
+ansible-playbook llm-benchmark-auto.yml \
+  -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \
+  -e "workload_type=chat" \
+  -e "requested_cores=64"
+```
+
+**Available versions:**
+
+- RHEL 9.5: `docker.io/amdih/zendnn_zentorch:vllm_v0.18.0_zentorch_v5.2.1_rhel9.5_r5.2.1`
+- Ubuntu 22.04: `docker.io/amdih/zendnn_zentorch:vllm_v0.18.0_zentorch_v5.2.1_ubuntu22.04_r5.2.1`
+
+**What gets optimized:**
+
+- ZenDNN: AMD's optimized deep learning library
+- ZenTorch: PyTorch integration with ZenDNN
+- NUMA-aware execution for AMD EPYC multi-die architecture
+- AVX-512 & AVX2 CPU instruction optimizations
+
+**Verify ZenDNN is active:**
+
+```bash
+# Check logs for ZenDNN initialization
+ssh <dut-hostname> "podman logs vllm-server 2>&1 | grep -i zendnn"
+```
+
+**Switch back to standard vLLM:**
+
+```bash
+export VLLM_CONTAINER_IMAGE=docker.io/vllm/vllm-openai-cpu:v0.18.0
+unset VLLM_CONTAINER_ENTRYPOINT
+```
+
+For complete details, see the [AMD ZenDNN
+section](https://github.com/redhat-et/vllm-cpu-perf-eval/blob/main/automation/test-execution/ansible/ansible.md#testing-vllm-cpu-on-amd-platforms-zendnn)
+in the full Ansible guide.
+
 ## Results
 
 Test results are saved to `results/llm/<model>/<test-run-id>/`:

--- a/docs/ansible/test-execution.md
+++ b/docs/ansible/test-execution.md
@@ -254,6 +254,16 @@ ansible-playbook llm-benchmark-auto.yml \
 - NUMA-aware execution for AMD EPYC multi-die architecture
 - AVX-512 & AVX2 CPU instruction optimizations
 
+**NUMA Pinning:**
+
+AMD ZenDNN containers use CPU pinning with special thread affinity configuration:
+- CPU pinning via `cpuset_cpus`
+- Thread affinity via `VLLM_CPU_OMP_THREADS_BIND` environment variable
+- Memory binding skipped (ZenDNN libnuma requires access to all nodes)
+
+Socket pinning parameters work normally - the automation detects AMD containers
+and applies the correct configuration automatically.
+
 **Verify ZenDNN is active:**
 
 ```bash

--- a/docs/ansible/test-execution.md
+++ b/docs/ansible/test-execution.md
@@ -233,6 +233,7 @@ vLLM executable is not in the default PATH.
 # AMD ZenDNN optimized container
 export VLLM_CONTAINER_IMAGE=docker.io/amdih/zendnn_zentorch:vllm_v0.18.0_zentorch_v5.2.1_rhel9.5_r5.2.1
 export VLLM_CONTAINER_ENTRYPOINT='["vllm", "serve"]'
+export VLLM_HEALTH_TIMEOUT=1200  # Longer startup time for ZenDNN
 
 # Run benchmark
 ansible-playbook llm-benchmark-auto.yml \


### PR DESCRIPTION
Add support for custom container entrypoints to enable AMD ZenDNN optimized vLLM containers, which require explicit "vllm serve" entrypoint.

Changes:
- infrastructure.yml: Add VLLM_CONTAINER_ENTRYPOINT env var support
- start-llm.yml: Add entrypoint parameter to podman_container task
- ansible.md: Add comprehensive AMD ZenDNN platform configuration guide
- test-execution.md: Add AMD EPYC/ZenDNN section to GitHub Pages docs

Usage:
``` 
export VLLM_CONTAINER_IMAGE=docker.io/amdih/zendnn_zentorch:vllm_v0.18.0_zentorch_v5.2.1_rhel9.5_r5.2.1
 export VLLM_CONTAINER_ENTRYPOINT='["vllm", "serve"]'
export VLLM_HEALTH_TIMEOUT=1200 #ZenDNN vLLM takes much longer to startup
```
This enables AMD EPYC users to leverage ZenDNN and ZenTorch optimizations for improved vLLM performance without modifying playbooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable container entrypoint and a VLLM health-timeout environment variable with a longer default.

* **Documentation**
  * AMD EPYC ZenDNN guide: supported images, benchmark example, NUMA/thread-affinity guidance, startup verification, and steps to revert to the standard container.
  * Documented entrypoint customization and extended startup timeout.

* **Bug Fixes**
  * Consistent container naming and startup behavior to reduce conflicts and improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->