### PR TITLE
feat: add disclaimer to all dashboard pages

### DIFF
--- a/automation/test-execution/dashboard-examples/vllm_dashboard/Home.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/Home.py
@@ -39,6 +39,10 @@ st.markdown("""
 # Header
 st.title("🚀 vLLM CPU Performance Dashboards")
 st.markdown("**Comprehensive performance analysis for vLLM CPU benchmarks**")
+
+# Disclaimer
+st.warning("⚠️ **Performance Data Disclaimer** — Red Hat Confidential. Disclosure requires signed NDA. External publication needs approval.")
+
 st.markdown("---")
 
 # Welcome section

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/1_📊_Client_Metrics.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/1_📊_Client_Metrics.py
@@ -1107,6 +1107,9 @@ def render_dashboard():
     st.title("🚀 vLLM CPU Performance Dashboard")
     st.markdown("Comprehensive analysis of vLLM CPU inference performance")
 
+    # Disclaimer
+    st.warning("⚠️ **Performance Data Disclaimer** — Red Hat Confidential. Disclosure requires signed NDA. External publication needs approval.")
+
     # Sidebar configuration
     st.sidebar.header("Configuration")
 

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/2_🖥️_Server_Metrics.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/2_🖥️_Server_Metrics.py
@@ -41,6 +41,9 @@ st.markdown("""
 # Title
 st.title("🖥️ vLLM Server-Side Metrics Analysis")
 
+# Disclaimer
+st.warning("⚠️ **Performance Data Disclaimer** — Red Hat Confidential. Disclosure requires signed NDA. External publication needs approval.")
+
 # Sidebar configuration
 st.sidebar.header("Configuration")
 


### PR DESCRIPTION
Add Red Hat confidential disclaimer banner to Home, Client Metrics, and Server Metrics dashboard pages. The disclaimer warns users that performance data requires NDA and approval for external publication.