### PR TITLE
Fix embedding benchmark controller portability issues

### DIFF
--- a/automation/test-execution/ansible/embedding-benchmark.yml
+++ b/automation/test-execution/ansible/embedding-benchmark.yml
@@ -52,6 +52,14 @@
         msg: "Embedding Models test suite not yet supported. Use llm-benchmark-concurrent-load.yml instead."
       when: not (allow_unsupported_tests | default(false) | bool)
 
+- name: Initialize embedding benchmark run metadata
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Generate test run ID
+      ansible.builtin.set_fact:
+        test_run_id: "{{ lookup('pipe', 'date +%Y%m%d-%H%M%S') }}"
+
     - name: Display test run information
       ansible.builtin.debug:
         msg:
@@ -89,8 +97,8 @@
         method: GET
         status_code: 200
       register: health_check_result
-      retries: "{{ health_check.timeout // health_check.interval }}"
-      delay: "{{ health_check.interval }}"
+      retries: "{{ (health_check.timeout | int) // (health_check.interval | int) }}"
+      delay: "{{ health_check.interval | int }}"
       until: health_check_result.status == 200
 
     - name: Display vLLM server status

--- a/automation/test-execution/ansible/roles/benchmark_embedding/tasks/baseline.yml
+++ b/automation/test-execution/ansible/roles/benchmark_embedding/tasks/baseline.yml
@@ -101,9 +101,9 @@
   ansible.builtin.debug:
     msg:
       - "Maximum RPS achieved: {{ max_rps }}"
-      - "25% rate: {{ (max_rps * 0.25) | round(2) }}"
-      - "50% rate: {{ (max_rps * 0.50) | round(2) }}"
-      - "75% rate: {{ (max_rps * 0.75) | round(2) }}"
+      - "25% rate: {{ ((max_rps | float) * 0.25) | round(2) }}"
+      - "50% rate: {{ ((max_rps | float) * 0.50) | round(2) }}"
+      - "75% rate: {{ ((max_rps | float) * 0.75) | round(2) }}"
 
 - name: "Baseline Test - 25% Load - Containerized"
   ansible.builtin.command:
@@ -119,7 +119,7 @@
       --dataset-name random
       --random-input-len 512
       --num-prompts {{ num_prompts }}
-      --request-rate {{ (max_rps * 0.25) | round(2) }}
+      --request-rate {{ ((max_rps | float) * 0.25) | round(2) }}
       --endpoint /v1/embeddings
       --save-result
       --result-filename {{ bench_config.results_dir }}/{{ model_name | replace('/', '__') }}/baseline/sweep-25pct.json
@@ -137,7 +137,7 @@
       --dataset-name random
       --random-input-len 512
       --num-prompts {{ num_prompts }}
-      --request-rate {{ (max_rps * 0.25) | round(2) }}
+      --request-rate {{ ((max_rps | float) * 0.25) | round(2) }}
       --endpoint /v1/embeddings
       --save-result
       --result-filename {{ bench_config.results_dir }}/{{ model_name | replace('/', '__') }}/baseline/sweep-25pct.json
@@ -158,7 +158,7 @@
       --dataset-name random
       --random-input-len 512
       --num-prompts {{ num_prompts }}
-      --request-rate {{ (max_rps * 0.50) | round(2) }}
+      --request-rate {{ ((max_rps | float) * 0.50) | round(2) }}
       --endpoint /v1/embeddings
       --save-result
       --result-filename {{ bench_config.results_dir }}/{{ model_name | replace('/', '__') }}/baseline/sweep-50pct.json
@@ -176,7 +176,7 @@
       --dataset-name random
       --random-input-len 512
       --num-prompts {{ num_prompts }}
-      --request-rate {{ (max_rps * 0.50) | round(2) }}
+      --request-rate {{ ((max_rps | float) * 0.50) | round(2) }}
       --endpoint /v1/embeddings
       --save-result
       --result-filename {{ bench_config.results_dir }}/{{ model_name | replace('/', '__') }}/baseline/sweep-50pct.json
@@ -197,7 +197,7 @@
       --dataset-name random
       --random-input-len 512
       --num-prompts {{ num_prompts }}
-      --request-rate {{ (max_rps * 0.75) | round(2) }}
+      --request-rate {{ ((max_rps | float) * 0.75) | round(2) }}
       --endpoint /v1/embeddings
       --save-result
       --result-filename {{ bench_config.results_dir }}/{{ model_name | replace('/', '__') }}/baseline/sweep-75pct.json
@@ -215,7 +215,7 @@
       --dataset-name random
       --random-input-len 512
       --num-prompts {{ num_prompts }}
-      --request-rate {{ (max_rps * 0.75) | round(2) }}
+      --request-rate {{ ((max_rps | float) * 0.75) | round(2) }}
       --endpoint /v1/embeddings
       --save-result
       --result-filename {{ bench_config.results_dir }}/{{ model_name | replace('/', '__') }}/baseline/sweep-75pct.json


### PR DESCRIPTION
## Summary

This PR fixes controller portability issues found while validating the embedding benchmark workflow from both macOS and Ubuntu/Linux controllers.

## Changes

- Add embedding benchmark `test_run_id` initialization before result collection
- Cast `health_check.timeout` and `health_check.interval` to integers before retry calculation
- Cast `max_rps` to float before calculating 25%, 50%, and 75% derived load rates
- Preserve test run metadata output for easier debugging

## Validation

Validated on Ubuntu/Linux controller:

- `scenario=baseline`
- `scenario=latency`
- IBM Granite embedding model
- Result synchronization completed successfully
- DUT logs and system metrics collected successfully
- Baseline generated:
  - `sweep-inf.json`
  - `sweep-25pct.json`
  - `sweep-50pct.json`
  - `sweep-75pct.json`

Also revalidated on macOS controller where the existing fallback fetch path continues to recover from the known `synchronize` issue.

## Notes

This does not address the separate embedding core sweep gap. `embedding-core-sweep.yml` is still referenced in docs but not present in the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved embedding benchmark testing infrastructure with enhanced metadata initialization and test run tracking capabilities.
  * Refined load testing request rate calculations for increased accuracy in baseline performance measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->