### PR TITLE
Make embedding benchmark lengths configurable

### DIFF
--- a/automation/test-execution/ansible/README.md
+++ b/automation/test-execution/ansible/README.md
@@ -339,6 +339,25 @@ Benefits of the bash approach:
 - Simpler error handling and recovery
 - More flexibility for complex sweep patterns
 
+## Embedding Length Overrides
+
+The embedding benchmark workflow defaults to:
+
+- `embedding_max_model_len=512`
+- `embedding_random_input_len=512`
+
+These defaults work for larger embedding models such as IBM Granite embedding models.
+
+Some smaller-context embedding models, for example `sentence-transformers/all-MiniLM-L6-v2`, support lower maximum context lengths and may fail during vLLM startup if the default values are used.
+
+For these models, override the embedding lengths explicitly:
+
+```bash
+ansible-playbook -i inventory/hosts.yml embedding-benchmark.yml \
+  -e "test_model=sentence-transformers/all-MiniLM-L6-v2" \
+  -e "embedding_max_model_len=256" \
+  -e "embedding_random_input_len=256"
+
 ## Extensibility for Embedding Tests
 
 To extend for embedding tests:

--- a/automation/test-execution/ansible/roles/benchmark_embedding/tasks/baseline.yml
+++ b/automation/test-execution/ansible/roles/benchmark_embedding/tasks/baseline.yml
@@ -26,7 +26,7 @@
       --backend openai-embeddings
       --model {{ model_name }}
       --dataset-name random
-      --random-input-len 512
+      --random-input-len {{ embedding_random_input_len | default(512) }}
       --num-prompts {{ num_prompts }}
       --request-rate inf
       --endpoint /v1/embeddings
@@ -45,7 +45,7 @@
       --backend openai-embeddings
       --model {{ model_name }}
       --dataset-name random
-      --random-input-len 512
+      --random-input-len {{ embedding_random_input_len | default(512) }}
       --num-prompts {{ num_prompts }}
       --request-rate inf
       --endpoint /v1/embeddings
@@ -117,7 +117,7 @@
       --backend openai-embeddings
       --model {{ model_name }}
       --dataset-name random
-      --random-input-len 512
+      --random-input-len {{ embedding_random_input_len | default(512) }}
       --num-prompts {{ num_prompts }}
       --request-rate {{ (max_rps * 0.25) | round(2) }}
       --endpoint /v1/embeddings
@@ -135,7 +135,7 @@
       --backend openai-embeddings
       --model {{ model_name }}
       --dataset-name random
-      --random-input-len 512
+      --random-input-len {{ embedding_random_input_len | default(512) }}
       --num-prompts {{ num_prompts }}
       --request-rate {{ (max_rps * 0.25) | round(2) }}
       --endpoint /v1/embeddings
@@ -156,7 +156,7 @@
       --backend openai-embeddings
       --model {{ model_name }}
       --dataset-name random
-      --random-input-len 512
+      --random-input-len {{ embedding_random_input_len | default(512) }}
       --num-prompts {{ num_prompts }}
       --request-rate {{ (max_rps * 0.50) | round(2) }}
       --endpoint /v1/embeddings
@@ -174,7 +174,7 @@
       --backend openai-embeddings
       --model {{ model_name }}
       --dataset-name random
-      --random-input-len 512
+      --random-input-len {{ embedding_random_input_len | default(512) }}
       --num-prompts {{ num_prompts }}
       --request-rate {{ (max_rps * 0.50) | round(2) }}
       --endpoint /v1/embeddings
@@ -195,7 +195,7 @@
       --backend openai-embeddings
       --model {{ model_name }}
       --dataset-name random
-      --random-input-len 512
+      --random-input-len {{ embedding_random_input_len | default(512) }}
       --num-prompts {{ num_prompts }}
       --request-rate {{ (max_rps * 0.75) | round(2) }}
       --endpoint /v1/embeddings
@@ -213,7 +213,7 @@
       --backend openai-embeddings
       --model {{ model_name }}
       --dataset-name random
-      --random-input-len 512
+      --random-input-len {{ embedding_random_input_len | default(512) }}
       --num-prompts {{ num_prompts }}
       --request-rate {{ (max_rps * 0.75) | round(2) }}
       --endpoint /v1/embeddings

--- a/automation/test-execution/ansible/roles/vllm_server/tasks/start-embedding.yml
+++ b/automation/test-execution/ansible/roles/vllm_server/tasks/start-embedding.yml
@@ -91,7 +91,7 @@
       --host {{ vllm_server.host }}
       --port {{ vllm_server.port }}
       --dtype bfloat16
-      --max-model-len 512
+      --max-model-len {{ embedding_max_model_len | default(512) }}
     log_driver: journald
     log_opt:
       tag: "vllm-embedding-{{ core_cfg.cores | default('auto') }}c"
@@ -121,7 +121,7 @@
       --host {{ vllm_server.host }}
       --port {{ vllm_server.port }}
       --dtype bfloat16
-      --max-model-len 512
+      --max-model-len {{ embedding_max_model_len | default(512) }}
     log_driver: journald
     log_opt:
       tag: "vllm-embedding-auto"


### PR DESCRIPTION
## Summary

Adds configurable embedding benchmark length parameters to support smaller-context embedding models without modifying playbook source files.

## Changes

- Replaced hardcoded embedding server:
  - `--max-model-len 512`
  with:
  - `{{ embedding_max_model_len | default(512) }}`

- Replaced hardcoded benchmark client:
  - `--random-input-len 512`
  with:
  - `{{ embedding_random_input_len | default(512) }}`

- Added README documentation describing:
  - default embedding benchmark behavior
  - override usage for smaller-context embedding models
  - working MiniLM example

## Validation

Validated successfully with:

### Default workflow
- IBM Granite embedding benchmark
- Existing default behavior preserved (`512` defaults)

### Smaller-context model workflow
- `sentence-transformers/all-MiniLM-L6-v2`
- Validated successfully using:
  - `embedding_max_model_len=256`
  - `embedding_random_input_len=256`

Both workflows successfully generated:
- `sweep-inf.json`
- `sweep-25pct.json`
- `sweep-50pct.json`
- `sweep-75pct.json`

## Notes

This change was introduced after root-causing MiniLM startup failures caused by the embedding server hardcoding `--max-model-len 512`, while MiniLM only supports `max_position_embeddings=256`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Embedding Length Overrides" section with guidance and usage examples for configurable benchmark parameters

* **Chores**
  * Made embedding configuration parameters overridable across automation tasks while preserving existing defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->