### PR TITLE
fix: use x86_64 vLLM image for embedding benchmark default

### DIFF
--- a/automation/test-execution/ansible/inventory/group_vars/all/benchmark-tools.yml
+++ b/automation/test-execution/ansible/inventory/group_vars/all/benchmark-tools.yml
@@ -94,8 +94,9 @@ benchmark_tool:
     use_container: true
 
     # Container image for vllm bench
+    # Should match the vLLM server image for version consistency
     # Can be overridden with environment variable: export VLLM_BENCH_CONTAINER_IMAGE=...
-    container_image: "{{ lookup('env', 'VLLM_BENCH_CONTAINER_IMAGE') | default('quay.io/mtahhan/vllm:arm-base-cpu', true) }}"
+    container_image: "{{ lookup('env', 'VLLM_BENCH_CONTAINER_IMAGE') | default('docker.io/vllm/vllm-openai-cpu:v0.20.0', true) }}"
 
     # Number of prompts for embedding benchmark tests
     # Trade-off: sample size vs test duration

--- a/automation/test-execution/ansible/inventory/group_vars/all/infrastructure.yml
+++ b/automation/test-execution/ansible/inventory/group_vars/all/infrastructure.yml
@@ -22,7 +22,7 @@ container_runtime:
   # ⚠️ CHANGE: Update to official vLLM image or your preferred version
   # This image includes CPU optimizations for performance testing
   # Can be overridden with environment variable: export VLLM_CONTAINER_IMAGE=...
-  image: "{{ lookup('env', 'VLLM_CONTAINER_IMAGE') | default('docker.io/vllm/vllm-openai-cpu:v0.18.0', true) }}"
+  image: "{{ lookup('env', 'VLLM_CONTAINER_IMAGE') | default('docker.io/vllm/vllm-openai-cpu:v0.20.0', true) }}"
   # Optional: Custom entrypoint for containers that don't have vLLM in their default path
   # Can be overridden with environment variable: export VLLM_CONTAINER_ENTRYPOINT=...
   # Example for AMD ZenDNN containers: export VLLM_CONTAINER_ENTRYPOINT='["vllm", "serve"]'


### PR DESCRIPTION
Fix incorrect default container image for vllm_bench that caused "Exec format error" on x86_64 servers.

Problem:
- Default was ARM image: quay.io/mtahhan/vllm:arm-base-cpu
- Embedding tests failed on x86_64 EC2 with "Exec format error"
- Error: "image platform (linux/arm64/v8) does not match (linux/amd64)"

Root Cause:
- vllm_bench config (line 98) used ARM-only image as default
- Introduced in commit 5a494c8 during inventory restructure
- Controller architecture (Mac ARM) is irrelevant - containers run on remote targets (EC2 x86_64)
- LLM tests unaffected - they use guidellm with multi-arch images

Fix:
- Change default to match vLLM server image (x86_64 compatible)
- Old: quay.io/mtahhan/vllm:arm-base-cpu
- New: docker.io/vllm/vllm-openai-cpu:v0.18.0
- Same image as DUT ensures version consistency

Impact:
- Embedding tests now work on x86_64 servers (AWS EC2)
- Users can still override with VLLM_BENCH_CONTAINER_IMAGE env var
- No impact on LLM tests (different benchmark tool)

Tested:
- EC2 x86_64 instances (DUT + Load Generator)
- Baseline and latency tests execute successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default container image for vLLM benchmarking tools to version v0.18.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->