### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,6 +12,9 @@ name: Integration Tests
       - main
   workflow_dispatch:  # Allow manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   integration-fast:
     name: Integration Tests (Fast)


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-et/vllm-cpu-perf-eval/security/code-scanning/5](https://github.com/redhat-et/vllm-cpu-perf-eval/security/code-scanning/5)

Add an explicit top-level `permissions` block in `.github/workflows/integration-tests.yml` so all jobs inherit least-privilege token scopes.  
Best single fix without changing functionality: add

```yml
permissions:
  contents: read
```

directly under the trigger section (`on:` block) and before `jobs:`. This is sufficient for the shown workflow behavior (checkout, install deps, run tests, upload artifacts) and satisfies CodeQL’s requirement to explicitly limit `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD security by adding explicit read-only permissions restrictions to GitHub Actions workflows for integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->