### PR TITLE
containers: update vllm image and quay repo

### DIFF
--- a/.github/workflows/build-model-downloader.yml
+++ b/.github/workflows/build-model-downloader.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   IMAGE_REGISTRY: quay.io
-  IMAGE_REPOSITORY: octo-et/vllm-cpu-perf-eval
+  IMAGE_REPOSITORY: vllm-cpu-perf-eval/model-downloader
   IMAGE_TAG: model-downloader
 
 jobs:
@@ -34,12 +34,11 @@ jobs:
 
       - name: Log in to Quay.io
         if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/container/'))
-        uses: docker/login-action@v3
+        uses: redhat-actions/podman-login@v1
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ secrets.REDHAT_REGISTRY_USERNAME }}
           password: ${{ secrets.REDHAT_REGISTRY_PASSWORD }}
-
       - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v5
@@ -51,7 +50,7 @@ jobs:
             type=raw,value=${{ env.IMAGE_TAG }}-{{date 'YYYYMMDD'}}
 
       - name: Build container image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./container-images/model-downloader
           push: false

--- a/container-images/model-downloader/Dockerfile
+++ b/container-images/model-downloader/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi10/python-312-minimal:10.2-1779803286
 
-LABEL maintainer="octo-et"
+LABEL maintainer="vllm-cpu-perf-eval"
 LABEL description="HuggingFace model downloader for vLLM CPU performance evaluation"
 LABEL version="1.0"
 

--- a/container-images/model-downloader/README.md
+++ b/container-images/model-downloader/README.md
@@ -16,10 +16,10 @@ Lightweight container for downloading HuggingFace models to a cache volume for v
 cd container-images/model-downloader
 
 # Build
-podman build -t quay.io/octo-et/vllm-cpu-perf-eval:model-downloader .
+podman build -t quay.io/vllm-cpu-perf-eval/model-downloader:latest .
 
 # Push to quay.io
-podman push quay.io/octo-et/vllm-cpu-perf-eval:model-downloader
+podman push quay.io/vllm-cpu-perf-eval/model-downloader:latest
 ```
 
 ## Usage
@@ -33,7 +33,7 @@ podman run --rm \
   -v /path/to/models:/models \
   -e MODEL_NAME=TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
   -e LOCAL_DIR=/models \
-  quay.io/octo-et/vllm-cpu-perf-eval:model-downloader
+  quay.io/vllm-cpu-perf-eval/model-downloader:latest
 ```
 
 ### Direct cache download
@@ -43,7 +43,7 @@ Downloads to HuggingFace cache inside the container volume:
 ```bash
 podman run --rm \
   -v hf-cache:/root/.cache/huggingface \
-  quay.io/octo-et/vllm-cpu-perf-eval:model-downloader \
+  quay.io/vllm-cpu-perf-eval/model-downloader:latest \
   /usr/local/bin/download_model.py TinyLlama/TinyLlama-1.1B-Chat-v1.0
 ```
 
@@ -53,7 +53,7 @@ Or using environment variable:
 podman run --rm \
   -v hf-cache:/root/.cache/huggingface \
   -e MODEL_NAME=TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
-  quay.io/octo-et/vllm-cpu-perf-eval:model-downloader
+  quay.io/vllm-cpu-perf-eval/model-downloader:latest
 ```
 
 ### With HuggingFace token (for gated models)
@@ -64,7 +64,7 @@ podman run --rm \
   -e MODEL_NAME=meta-llama/Llama-3.1-8B-Instruct \
   -e LOCAL_DIR=/models \
   -e HF_TOKEN=hf_your_token_here \
-  quay.io/octo-et/vllm-cpu-perf-eval:model-downloader
+  quay.io/vllm-cpu-perf-eval/model-downloader:latest
 ```
 
 ### Download to specific directory
@@ -74,7 +74,7 @@ Using command line:
 ```bash
 podman run --rm \
   -v /var/models:/models \
-  quay.io/octo-et/vllm-cpu-perf-eval:model-downloader \
+  quay.io/vllm-cpu-perf-eval/model-downloader:latest \
   /usr/local/bin/download_model.py \
   TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
   --local-dir /models
@@ -88,6 +88,6 @@ Used by `roles/common/tasks/preload-model.yml` for automatic model pre-caching.
 
 - **Base Image**: `registry.access.redhat.com/ubi10/python-312-minimal:10.2-1779803286`
 - **Size**: ~200MB
-- **Registry**: `quay.io/octo-et/vllm-cpu-perf-eval:model-downloader`
+- **Registry**: `quay.io/vllm-cpu-perf-eval/model-downloader:latest`
 - **Python**: 3.12
 - **Dependencies**: `huggingface_hub`

--- a/container-images/model-downloader/build.sh
+++ b/container-images/model-downloader/build.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-IMAGE="quay.io/octo-et/vllm-cpu-perf-eval:model-downloader"
+IMAGE="quay.io/vllm-cpu-perf-eval/model-downloader:latest"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "🔨 Building model-downloader container..."

--- a/container-images/model-downloader/download_model.py
+++ b/container-images/model-downloader/download_model.py
@@ -15,7 +15,7 @@ Usage:
 Container usage:
     # Using command line argument
     podman run --rm -v hf-cache:/root/.cache/huggingface \\
-      quay.io/octo-et/vllm-cpu-perf-eval:model-downloader \\
+      quay.io/vllm-cpu-perf-eval/model-downloader:latest \\
       /usr/local/bin/download_model.py TinyLlama/TinyLlama-1.1B-Chat-v1.0
 
     # Using environment variable
@@ -23,7 +23,7 @@ Container usage:
       -v /path/to/models:/models \\
       -e MODEL_NAME=TinyLlama/TinyLlama-1.1B-Chat-v1.0 \\
       -e LOCAL_DIR=/models \\
-      quay.io/octo-et/vllm-cpu-perf-eval:model-downloader
+      quay.io/vllm-cpu-perf-eval/model-downloader:latest
 """
 
 import os


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image repository from the previous location to the new registry location at `quay.io/vllm-cpu-perf-eval/model-downloader:latest`
  * Updated build configuration and maintainer metadata to reflect the new repository ownership
  * Updated documentation with the new image tag and usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->