### PR TITLE
feat: add model pre-download to eliminate startup delays

### DIFF
--- a/automation/test-execution/ansible/inventory/group_vars/dut/main.yml
+++ b/automation/test-execution/ansible/inventory/group_vars/dut/main.yml
@@ -24,7 +24,13 @@
 use_persistent_cache: false
 
 # Model cache directory (HuggingFace cache location)
-model_cache_dir: /var/lib/vllm-models
+# IMPORTANT: Choose a location with:
+#   - Sufficient free space (50GB+ for small models, 200GB+ for large models)
+#   - Write permissions for Ansible user
+#   - Fast storage (NVMe/SSD) for best performance
+# Recommended: /mnt/nvme/hf-cache, /data/hf-cache, or ~/vllm-models
+# Avoid: /var/lib (small partition), /tmp (ephemeral)
+model_cache_dir: /var/lib/vllm-models  # Default - override with appropriate location
 
 # Log directory for vLLM container logs
 log_dir: /tmp/vllm-logs

--- a/automation/test-execution/ansible/inventory/group_vars/dut/main.yml
+++ b/automation/test-execution/ansible/inventory/group_vars/dut/main.yml
@@ -36,9 +36,18 @@ log_dir: /tmp/vllm-logs
 # Only applies when use_persistent_cache: true
 
 # Container image for model downloads
-# Default: quay.io/vllm-cpu-perf-eval/model-downloader:latest
-# model_downloader_image: quay.io/vllm-cpu-perf-eval/model-downloader:latest
+# Pinned to SHA digest for immutability and reproducibility
+model_downloader_image: quay.io/vllm-cpu-perf-eval/model-downloader@sha256:ef8bf0075415a18be6757e8a72fdfc88ed3d967b2744f1663991126884af6dc2
 
 # Force model re-download even if already cached
 # Default: false
 # force_model_download: false
+
+# Minimum free disk space (GB) required before download
+# Default: 50
+# model_download_min_space_gb: 50
+
+# Network resilience: retry configuration
+# Default: 3 retries with 30 second delay
+# model_download_retries: 3
+# model_download_retry_delay: 30

--- a/automation/test-execution/ansible/inventory/group_vars/dut/main.yml
+++ b/automation/test-execution/ansible/inventory/group_vars/dut/main.yml
@@ -5,8 +5,40 @@
 # Settings specific to the DUT host group
 # These override the global settings in group_vars/all/
 
-# Optional: Mount directories for persistent caching
-# Set use_persistent_cache to false to disable volume mounts
+# ============================================================================
+# Model Caching and Pre-Download Configuration
+# ============================================================================
+# Model pre-download eliminates download delays at vLLM startup time
+# Models are downloaded using the model-downloader container before vLLM starts
+#
+# Benefits:
+#   - Faster test execution (no download wait time on repeated runs)
+#   - More reliable tests (network issues won't interrupt running tests)
+#   - Bandwidth savings (download once, use many times)
+#   - Better CI/CD integration (pre-download in setup phase)
+#
+# Note: Pre-download is automatically skipped for external vLLM deployments
+#       (when vllm_mode: external)
+
+# Enable persistent caching (set to true for model pre-download)
 use_persistent_cache: false
+
+# Model cache directory (HuggingFace cache location)
 model_cache_dir: /var/lib/vllm-models
+
+# Log directory for vLLM container logs
 log_dir: /tmp/vllm-logs
+
+# ============================================================================
+# Optional: Model Download Configuration
+# ============================================================================
+# These variables control model pre-download behavior
+# Only applies when use_persistent_cache: true
+
+# Container image for model downloads
+# Default: quay.io/vllm-cpu-perf-eval/model-downloader:latest
+# model_downloader_image: quay.io/vllm-cpu-perf-eval/model-downloader:latest
+
+# Force model re-download even if already cached
+# Default: false
+# force_model_download: false

--- a/automation/test-execution/ansible/roles/vllm_server/tasks/MODEL_PREDOWNLOAD.md
+++ b/automation/test-execution/ansible/roles/vllm_server/tasks/MODEL_PREDOWNLOAD.md
@@ -1,0 +1,176 @@
+# Model Pre-Download Documentation
+
+## Overview
+
+Models are automatically pre-downloaded to the persistent cache **before** vLLM starts, eliminating download delays during container initialization.
+
+## Why Use the Container Instead of CLI?
+
+The model pre-download uses the `quay.io/vllm-cpu-perf-eval/model-downloader` container rather than installing `huggingface-cli` directly on the DUT for several important reasons:
+
+### 1. **Restricted DUT Environments**
+- DUT systems may have restricted package installation capabilities
+- Cannot assume pip/Python package management is available
+- Production systems often prohibit direct package installation for security/compliance
+
+### 2. **Consistent Tooling**
+- Container provides versioned, immutable tooling
+- Same download behavior across all DUT environments
+- No dependency conflicts with host system packages
+
+### 3. **Infrastructure Alignment**
+- All other components (vLLM, benchmarks) already run in containers
+- Maintains architectural consistency
+- Leverages existing container runtime infrastructure
+
+### 4. **Isolation**
+- Download dependencies isolated from host system
+- No risk of polluting DUT system packages
+- Clean separation of concerns
+
+## When Model Pre-Download Runs
+
+The model pre-download task (`download-model.yml`) runs when:
+
+- ✅ `use_persistent_cache: true` is set
+- ✅ vLLM is running locally on DUT (not external mode)
+- ✅ Model is not already cached or `force_model_download: true`
+
+The task is **automatically skipped** when:
+
+- ❌ `use_persistent_cache: false` (no caching)
+- ❌ `vllm_mode: external` (vLLM running elsewhere - handled by playbook-level `end_play`)
+- ❌ Model already exists in cache (unless `force_model_download: true`)
+
+## Configuration Variables
+
+### Required Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `test_model` | HuggingFace model ID | `meta-llama/Llama-3.1-8B-Instruct` |
+| `model_cache_dir` | Persistent cache directory | `/mnt/storage/hf-cache` |
+| `use_persistent_cache` | Enable persistent caching | `true` |
+| `hf_token` | HuggingFace token (for gated models) | `hf_xxx...` |
+
+### Optional Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `model_downloader_image` | `quay.io/vllm-cpu-perf-eval/model-downloader:latest` | Container image for downloads |
+| `force_model_download` | `false` | Force re-download even if cached |
+
+## How It Works
+
+### 1. Cache Check
+```yaml
+- Check if model exists: {{ model_cache_dir }}/models--{{ test_model | replace('/', '--') }}
+- Display cache status
+- Skip download if cached (unless force_model_download: true)
+```
+
+### 2. Download Execution
+```yaml
+- Pull model-downloader container image
+- Run container with:
+  - Volume: {{ model_cache_dir }}:/root/.cache/huggingface:rw
+  - Env: MODEL_NAME={{ test_model }}
+  - Env: HF_TOKEN={{ hf_token }}
+  - Command: /usr/local/bin/download_model.py {{ test_model }}
+```
+
+### 3. Verification
+```yaml
+- Verify model cache exists after download
+- Fail with helpful error message if download unsuccessful
+```
+
+## Cache Directory Structure
+
+HuggingFace uses the following cache structure:
+
+```
+{{ model_cache_dir }}/
+├── models--meta-llama--Llama-3.1-8B-Instruct/
+│   ├── snapshots/
+│   │   └── <commit-hash>/
+│   │       ├── config.json
+│   │       ├── tokenizer.json
+│   │       ├── model-*.safetensors
+│   │       └── ...
+│   └── refs/
+├── models--ibm-granite--granite-embedding-278m-multilingual/
+│   └── ...
+└── ...
+```
+
+## Benefits
+
+- ✅ **Faster test execution** - No download wait time on repeated runs
+- ✅ **More reliable tests** - Network issues won't interrupt running tests
+- ✅ **Bandwidth savings** - Download once, use many times
+- ✅ **Better CI/CD integration** - Pre-download in setup phase
+- ✅ **Support for offline testing** - Models cached before network disconnection
+
+## Troubleshooting
+
+### Download Fails
+
+**Check:**
+1. `HF_TOKEN` is valid (required for gated models like Llama)
+2. Model ID is correct: `{{ test_model }}`
+3. Network connectivity to `huggingface.co`
+4. Available disk space in `{{ model_cache_dir }}`
+
+**View download logs:**
+```bash
+journalctl -u podman -f | grep model-downloader
+```
+
+### Model Not Found After Download
+
+**Verify cache structure:**
+```bash
+ls -la {{ model_cache_dir }}/models--{{ test_model | replace('/', '--') }}
+```
+
+**Force re-download:**
+```bash
+ansible-playbook ... -e force_model_download=true
+```
+
+### Permission Issues
+
+**Ensure cache directory has correct permissions:**
+```bash
+chmod 755 {{ model_cache_dir }}
+```
+
+## Example Playbook Usage
+
+```yaml
+- name: Run vLLM benchmarks with pre-downloaded models
+  hosts: dut
+  vars:
+    use_persistent_cache: true
+    model_cache_dir: /mnt/nvme/hf-cache
+    test_model: meta-llama/Llama-3.1-8B-Instruct
+    hf_token: "{{ lookup('env', 'HF_TOKEN') }}"
+  roles:
+    - vllm_server
+```
+
+## Integration Points
+
+The model pre-download is integrated into:
+
+- [`start-llm.yml`](start-llm.yml) - LLM generative model workflows
+- [`start-embedding.yml`](start-embedding.yml) - Embedding model workflows
+
+Both include the download task after directory creation and before vLLM container startup.
+
+## Related Files
+
+- [`download-model.yml`](download-model.yml) - Main download task
+- [`/container-images/model-downloader/`](/container-images/model-downloader/) - Container source code
+- [`/container-images/model-downloader/download_model.py`](/container-images/model-downloader/download_model.py) - Download script

--- a/automation/test-execution/ansible/roles/vllm_server/tasks/download-model.yml
+++ b/automation/test-execution/ansible/roles/vllm_server/tasks/download-model.yml
@@ -1,0 +1,88 @@
+---
+# Pre-download HuggingFace models to persistent cache
+# Avoids downloading models at vLLM startup time
+#
+# Uses model-downloader container for isolated, reproducible downloads:
+#   - DUT may have restricted package installation (no pip install)
+#   - Ensures consistent, versioned tooling across different DUT environments
+#   - Isolates download dependencies from host system
+#   - Aligns with existing containerized infrastructure pattern
+#
+# This task is automatically skipped for external vLLM deployments
+# (handled by playbook-level end_play when vllm_mode == 'external')
+
+- name: Ensure model cache directory exists
+  ansible.builtin.file:
+    path: "{{ model_cache_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Check if model already exists in cache
+  ansible.builtin.stat:
+    path: "{{ model_cache_dir }}/models--{{ test_model | replace('/', '--') }}"
+  register: model_cache_exists
+
+- name: Display model cache status
+  ansible.builtin.debug:
+    msg:
+      - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      - "Model Cache Check"
+      - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      - "Model: {{ test_model }}"
+      - "Cache Directory: {{ model_cache_dir }}"
+      - "Cache Status: {{ '✓ Already cached' if model_cache_exists.stat.exists else '✗ Not cached - will download' }}"
+      - "Force Download: {{ force_model_download | default(false) }}"
+      - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+- name: Pull model-downloader container image
+  containers.podman.podman_image:
+    name: "{{ model_downloader_image | default('quay.io/vllm-cpu-perf-eval/model-downloader:latest') }}"
+    state: present
+  when: not model_cache_exists.stat.exists or (force_model_download | default(false) | bool)
+
+- name: Download model using model-downloader container
+  containers.podman.podman_container:
+    name: "model-downloader-{{ test_model | replace('/', '-') }}"
+    image: "{{ model_downloader_image | default('quay.io/vllm-cpu-perf-eval/model-downloader:latest') }}"
+    state: started
+    detach: false
+    rm: true
+    volumes:
+      - "{{ model_cache_dir }}:/root/.cache/huggingface:rw"
+    env:
+      MODEL_NAME: "{{ test_model }}"
+      HF_TOKEN: "{{ hf_token }}"
+    command: "/usr/local/bin/download_model.py {{ test_model }}"
+  when: not model_cache_exists.stat.exists or (force_model_download | default(false) | bool)
+  register: model_download_result
+  no_log: true  # Prevent HF_TOKEN from appearing in logs
+
+- name: Display download completion
+  ansible.builtin.debug:
+    msg:
+      - "✓ Model Download Complete"
+      - "Model: {{ test_model }}"
+      - "Location: {{ model_cache_dir }}/models--{{ test_model | replace('/', '--') }}"
+  when: model_download_result is changed
+
+- name: Verify model cache exists after download
+  ansible.builtin.stat:
+    path: "{{ model_cache_dir }}/models--{{ test_model | replace('/', '--') }}"
+  register: model_cache_verify
+  when: not model_cache_exists.stat.exists or (force_model_download | default(false) | bool)
+
+- name: Fail if model download unsuccessful
+  ansible.builtin.fail:
+    msg: |
+      ❌ Model download failed or incomplete!
+
+      Expected location: {{ model_cache_dir }}/models--{{ test_model | replace('/', '--') }}
+
+      Check:
+        - HF_TOKEN is valid (required for gated models)
+        - Model ID is correct: {{ test_model }}
+        - Network connectivity to huggingface.co
+        - Available disk space in {{ model_cache_dir }}
+  when:
+    - (not model_cache_exists.stat.exists or (force_model_download | default(false) | bool))
+    - not model_cache_verify.stat.exists

--- a/automation/test-execution/ansible/roles/vllm_server/tasks/download-model.yml
+++ b/automation/test-execution/ansible/roles/vllm_server/tasks/download-model.yml
@@ -17,6 +17,40 @@
     state: directory
     mode: "0755"
 
+- name: Verify cache directory is writable
+  ansible.builtin.tempfile:
+    state: file
+    path: "{{ model_cache_dir }}"
+    prefix: ".write-test-"
+  register: write_test
+  failed_when: false
+
+- name: Clean up write test file
+  ansible.builtin.file:
+    path: "{{ write_test.path }}"
+    state: absent
+  when: write_test is succeeded
+
+- name: Fail if cache directory is not writable
+  ansible.builtin.fail:
+    msg: |
+      ❌ Cache directory is not writable!
+
+      Location: {{ model_cache_dir }}
+      Error: {{ write_test.msg | default('Permission denied') }}
+
+      Common issues:
+        - Directory requires elevated permissions (consider using /mnt, /data, or ~/cache)
+        - SELinux/AppArmor blocking access (check audit logs)
+        - Filesystem mounted read-only
+        - Insufficient permissions for Ansible user
+
+      Recommendation: Choose a writable location with sufficient space:
+        - Fast local storage: /mnt/nvme/hf-cache or /data/hf-cache
+        - User directory: ~/vllm-models or ~/.cache/huggingface
+        - Shared storage: /mnt/storage/hf-cache (ensure writable)
+  when: write_test is failed
+
 - name: Check if model already exists in cache
   ansible.builtin.stat:
     path: "{{ model_cache_dir }}/hub/models--{{ test_model | replace('/', '--') }}"

--- a/automation/test-execution/ansible/roles/vllm_server/tasks/download-model.yml
+++ b/automation/test-execution/ansible/roles/vllm_server/tasks/download-model.yml
@@ -19,7 +19,7 @@
 
 - name: Check if model already exists in cache
   ansible.builtin.stat:
-    path: "{{ model_cache_dir }}/models--{{ test_model | replace('/', '--') }}"
+    path: "{{ model_cache_dir }}/hub/models--{{ test_model | replace('/', '--') }}"
   register: model_cache_exists
 
 - name: Display model cache status
@@ -47,11 +47,13 @@
     state: started
     detach: false
     rm: true
+    user: "0"  # Run as root to avoid permission issues with mounted volume
     volumes:
-      - "{{ model_cache_dir }}:/root/.cache/huggingface:rw"
+      - "{{ model_cache_dir }}:/cache:z"  # :z for SELinux relabeling (shared)
     env:
       MODEL_NAME: "{{ test_model }}"
       HF_TOKEN: "{{ hf_token }}"
+      HF_HOME: "/cache"
     command: "/usr/local/bin/download_model.py {{ test_model }}"
   when: not model_cache_exists.stat.exists or (force_model_download | default(false) | bool)
   register: model_download_result
@@ -62,12 +64,12 @@
     msg:
       - "✓ Model Download Complete"
       - "Model: {{ test_model }}"
-      - "Location: {{ model_cache_dir }}/models--{{ test_model | replace('/', '--') }}"
+      - "Location: {{ model_cache_dir }}/hub/models--{{ test_model | replace('/', '--') }}"
   when: model_download_result is changed
 
 - name: Verify model cache exists after download
   ansible.builtin.stat:
-    path: "{{ model_cache_dir }}/models--{{ test_model | replace('/', '--') }}"
+    path: "{{ model_cache_dir }}/hub/models--{{ test_model | replace('/', '--') }}"
   register: model_cache_verify
   when: not model_cache_exists.stat.exists or (force_model_download | default(false) | bool)
 
@@ -76,7 +78,7 @@
     msg: |
       ❌ Model download failed or incomplete!
 
-      Expected location: {{ model_cache_dir }}/models--{{ test_model | replace('/', '--') }}
+      Expected location: {{ model_cache_dir }}/hub/models--{{ test_model | replace('/', '--') }}
 
       Check:
         - HF_TOKEN is valid (required for gated models)

--- a/automation/test-execution/ansible/roles/vllm_server/tasks/download-model.yml
+++ b/automation/test-execution/ansible/roles/vllm_server/tasks/download-model.yml
@@ -34,16 +34,36 @@
       - "Force Download: {{ force_model_download | default(false) }}"
       - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
+- name: Check available disk space
+  ansible.builtin.shell: df -BG "{{ model_cache_dir }}" | tail -1 | awk '{print $4}' | sed 's/G//'
+  register: available_space
+  changed_when: false
+  when: not model_cache_exists.stat.exists or (force_model_download | default(false) | bool)
+
+- name: Fail if insufficient disk space
+  ansible.builtin.fail:
+    msg: |
+      ❌ Insufficient disk space for model download!
+
+      Available: {{ available_space.stdout }}GB
+      Required: {{ model_download_min_space_gb | default(50) }}GB (configurable via model_download_min_space_gb)
+      Location: {{ model_cache_dir }}
+
+      Please free up disk space before continuing.
+  when:
+    - not model_cache_exists.stat.exists or (force_model_download | default(false) | bool)
+    - available_space.stdout | int < (model_download_min_space_gb | default(50))
+
 - name: Pull model-downloader container image
   containers.podman.podman_image:
-    name: "{{ model_downloader_image | default('quay.io/vllm-cpu-perf-eval/model-downloader:latest') }}"
+    name: "{{ model_downloader_image | default('quay.io/vllm-cpu-perf-eval/model-downloader@sha256:ef8bf0075415a18be6757e8a72fdfc88ed3d967b2744f1663991126884af6dc2') }}"
     state: present
   when: not model_cache_exists.stat.exists or (force_model_download | default(false) | bool)
 
 - name: Download model using model-downloader container
   containers.podman.podman_container:
     name: "model-downloader-{{ test_model | replace('/', '-') }}"
-    image: "{{ model_downloader_image | default('quay.io/vllm-cpu-perf-eval/model-downloader:latest') }}"
+    image: "{{ model_downloader_image | default('quay.io/vllm-cpu-perf-eval/model-downloader@sha256:ef8bf0075415a18be6757e8a72fdfc88ed3d967b2744f1663991126884af6dc2') }}"
     state: started
     detach: false
     rm: true
@@ -57,6 +77,9 @@
     command: "/usr/local/bin/download_model.py {{ test_model }}"
   when: not model_cache_exists.stat.exists or (force_model_download | default(false) | bool)
   register: model_download_result
+  retries: "{{ model_download_retries | default(3) }}"
+  delay: "{{ model_download_retry_delay | default(30) }}"
+  until: model_download_result is succeeded
   no_log: true  # Prevent HF_TOKEN from appearing in logs
 
 - name: Display download completion

--- a/automation/test-execution/ansible/roles/vllm_server/tasks/start-embedding.yml
+++ b/automation/test-execution/ansible/roles/vllm_server/tasks/start-embedding.yml
@@ -21,6 +21,11 @@
     - {path: "{{ log_dir }}", mode: "0755"}
   when: use_persistent_cache | default(false) | bool
 
+- name: Pre-download model to cache
+  ansible.builtin.include_tasks:
+    file: download-model.yml
+  when: use_persistent_cache | default(false) | bool
+
 - name: Get workload configuration
   ansible.builtin.set_fact:
     workload_cfg: "{{ test_configs.embedding }}"
@@ -146,4 +151,4 @@
 - name: Wait for vLLM initialization
   ansible.builtin.pause:
     seconds: 15
-    prompt: "Waiting for vLLM to download model and initialize..."
+    prompt: "Waiting for vLLM to initialize (model already cached)..."

--- a/automation/test-execution/ansible/roles/vllm_server/tasks/start-llm.yml
+++ b/automation/test-execution/ansible/roles/vllm_server/tasks/start-llm.yml
@@ -21,6 +21,11 @@
     - {path: "{{ log_dir }}", mode: "0755"}
   when: use_persistent_cache | default(false) | bool
 
+- name: Pre-download model to cache
+  ansible.builtin.include_tasks:
+    file: download-model.yml
+  when: use_persistent_cache | default(false) | bool
+
 - name: Get workload and core configuration
   ansible.builtin.set_fact:
     workload_cfg: "{{ test_configs[workload_type] }}"
@@ -339,4 +344,4 @@
 - name: Wait for vLLM initialization (longer for LLM models)
   ansible.builtin.pause:
     seconds: 20
-    prompt: "Waiting for vLLM to download model and initialize (this may take a while for large models)..."
+    prompt: "Waiting for vLLM to initialize (model already cached)..."

--- a/docs/ansible/model-predownload.md
+++ b/docs/ansible/model-predownload.md
@@ -4,6 +4,21 @@
 
 Models are automatically pre-downloaded to the persistent cache **before** vLLM starts, eliminating download delays during container initialization.
 
+## Container Image Pinning
+
+The model-downloader image is pinned to a specific SHA digest (`@sha256:...`) rather than a version tag for maximum immutability and reproducibility:
+
+- **SHA digests are immutable** - Once published, they can never change
+- **Prevents supply chain attacks** - Tags like `:latest` can be overwritten; digests cannot
+- **Exact reproducibility** - Same digest always pulls identical image bits
+- **Production best practice** - Recommended by Kubernetes and security guidelines
+
+To update to a newer image, query the registry and update the SHA:
+```bash
+curl -sL "https://quay.io/api/v1/repository/vllm-cpu-perf-eval/model-downloader/tag/?onlyActiveTags=true" | \
+  python3 -m json.tool | grep -A2 '"name": "latest"' | grep manifest_digest
+```
+
 ## Why Use the Container Instead of CLI?
 
 The model pre-download uses the `quay.io/vllm-cpu-perf-eval/model-downloader` container rather than installing `huggingface-cli` directly on the DUT for several important reasons:
@@ -57,29 +72,41 @@ The task is **automatically skipped** when:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `model_downloader_image` | `quay.io/vllm-cpu-perf-eval/model-downloader:latest` | Container image for downloads |
+| `model_downloader_image` | `quay.io/vllm-cpu-perf-eval/model-downloader@sha256:ef8bf007...` | Container image for downloads (pinned to SHA digest for immutability) |
 | `force_model_download` | `false` | Force re-download even if cached |
+| `model_download_min_space_gb` | `50` | Minimum free disk space (GB) required before download |
+| `model_download_retries` | `3` | Number of retry attempts for failed downloads |
+| `model_download_retry_delay` | `30` | Delay in seconds between retry attempts |
 
 ## How It Works
 
 ### 1. Cache Check
 ```yaml
-- Check if model exists: {{ model_cache_dir }}/models--{{ test_model | replace('/', '--') }}
+- Check if model exists: {{ model_cache_dir }}/hub/models--{{ test_model | replace('/', '--') }}
 - Display cache status
 - Skip download if cached (unless force_model_download: true)
 ```
 
-### 2. Download Execution
+### 2. Disk Space Check
 ```yaml
-- Pull model-downloader container image
-- Run container with:
-  - Volume: {{ model_cache_dir }}:/root/.cache/huggingface:rw
-  - Env: MODEL_NAME={{ test_model }}
-  - Env: HF_TOKEN={{ hf_token }}
-  - Command: /usr/local/bin/download_model.py {{ test_model }}
+- Check available disk space in {{ model_cache_dir }}
+- Fail if available space < {{ model_download_min_space_gb }}GB (default: 50GB)
+- Prevents partial downloads due to disk exhaustion
 ```
 
-### 3. Verification
+### 3. Download Execution
+```yaml
+- Pull model-downloader container image (pinned to SHA digest for immutability)
+- Run container with:
+  - Volume: {{ model_cache_dir }}:/cache:z (SELinux compatible)
+  - Env: MODEL_NAME={{ test_model }}
+  - Env: HF_TOKEN={{ hf_token }}
+  - Env: HF_HOME=/cache
+  - Command: /usr/local/bin/download_model.py {{ test_model }}
+- Retry logic: Up to 3 attempts with 30s delay between retries
+```
+
+### 4. Verification
 ```yaml
 - Verify model cache exists after download
 - Fail with helpful error message if download unsuccessful
@@ -91,17 +118,18 @@ HuggingFace uses the following cache structure:
 
 ```
 {{ model_cache_dir }}/
-├── models--meta-llama--Llama-3.1-8B-Instruct/
-│   ├── snapshots/
-│   │   └── <commit-hash>/
-│   │       ├── config.json
-│   │       ├── tokenizer.json
-│   │       ├── model-*.safetensors
-│   │       └── ...
-│   └── refs/
-├── models--ibm-granite--granite-embedding-278m-multilingual/
-│   └── ...
-└── ...
+└── hub/
+    ├── models--meta-llama--Llama-3.1-8B-Instruct/
+    │   ├── snapshots/
+    │   │   └── <commit-hash>/
+    │   │       ├── config.json
+    │   │       ├── tokenizer.json
+    │   │       ├── model-*.safetensors
+    │   │       └── ...
+    │   └── refs/
+    ├── models--ibm-granite--granite-embedding-278m-multilingual/
+    │   └── ...
+    └── ...
 ```
 
 ## Benefits
@@ -111,6 +139,8 @@ HuggingFace uses the following cache structure:
 - ✅ **Bandwidth savings** - Download once, use many times
 - ✅ **Better CI/CD integration** - Pre-download in setup phase
 - ✅ **Support for offline testing** - Models cached before network disconnection
+- ✅ **Automatic retry logic** - Transient network failures are automatically retried
+- ✅ **Disk space protection** - Pre-flight checks prevent partial downloads
 
 ## Troubleshooting
 
@@ -131,12 +161,24 @@ journalctl -u podman -f | grep model-downloader
 
 **Verify cache structure:**
 ```bash
-ls -la {{ model_cache_dir }}/models--{{ test_model | replace('/', '--') }}
+ls -la {{ model_cache_dir }}/hub/models--{{ test_model | replace('/', '--') }}
 ```
 
 **Force re-download:**
 ```bash
 ansible-playbook ... -e force_model_download=true
+```
+
+### Disk Space Issues
+
+**Check available space:**
+```bash
+df -h {{ model_cache_dir }}
+```
+
+**Adjust minimum space requirement:**
+```bash
+ansible-playbook ... -e model_download_min_space_gb=100
 ```
 
 ### Permission Issues
@@ -164,13 +206,13 @@ chmod 755 {{ model_cache_dir }}
 
 The model pre-download is integrated into:
 
-- [`start-llm.yml`](start-llm.yml) - LLM generative model workflows
-- [`start-embedding.yml`](start-embedding.yml) - Embedding model workflows
+- [`start-llm.yml`](../../automation/test-execution/ansible/roles/vllm_server/tasks/start-llm.yml) - LLM generative model workflows
+- [`start-embedding.yml`](../../automation/test-execution/ansible/roles/vllm_server/tasks/start-embedding.yml) - Embedding model workflows
 
 Both include the download task after directory creation and before vLLM container startup.
 
 ## Related Files
 
-- [`download-model.yml`](download-model.yml) - Main download task
+- [`download-model.yml`](../../automation/test-execution/ansible/roles/vllm_server/tasks/download-model.yml) - Main download task
 - [`/container-images/model-downloader/`](/container-images/model-downloader/) - Container source code
 - [`/container-images/model-downloader/download_model.py`](/container-images/model-downloader/download_model.py) - Download script

--- a/docs/ansible/model-predownload.md
+++ b/docs/ansible/model-predownload.md
@@ -64,7 +64,7 @@ The task is **automatically skipped** when:
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `test_model` | HuggingFace model ID | `meta-llama/Llama-3.1-8B-Instruct` |
-| `model_cache_dir` | Persistent cache directory | `/mnt/storage/hf-cache` |
+| `model_cache_dir` | Persistent cache directory (see [Choosing a Cache Location](#choosing-a-cache-location)) | `/mnt/nvme/hf-cache` |
 | `use_persistent_cache` | Enable persistent caching | `true` |
 | `hf_token` | HuggingFace token (for gated models) | `hf_xxx...` |
 
@@ -77,6 +77,68 @@ The task is **automatically skipped** when:
 | `model_download_min_space_gb` | `50` | Minimum free disk space (GB) required before download |
 | `model_download_retries` | `3` | Number of retry attempts for failed downloads |
 | `model_download_retry_delay` | `30` | Delay in seconds between retry attempts |
+
+## Choosing a Cache Location
+
+The `model_cache_dir` location is critical for performance and reliability. **Avoid system directories like `/var/lib`** which may have limited space or restricted permissions.
+
+### Recommended Locations
+
+#### 1. Fast Local Storage (Best Performance)
+```yaml
+model_cache_dir: /mnt/nvme/hf-cache     # NVMe SSD
+model_cache_dir: /data/hf-cache         # Dedicated data partition
+```
+- ✅ Fastest model loading times
+- ✅ Best for repeated benchmarks
+- ⚠️ May not persist across node reprovisioning
+
+#### 2. Shared/Network Storage (Best for Multi-Node)
+```yaml
+model_cache_dir: /mnt/storage/hf-cache  # NFS, CIFS, or distributed FS
+```
+- ✅ Share models across multiple DUT nodes
+- ✅ Download once, use everywhere
+- ⚠️ Slower than local storage
+- ⚠️ Check permissions (NFS uid mapping, CIFS credentials)
+
+#### 3. User Home Directory (Development/Testing)
+```yaml
+model_cache_dir: ~/vllm-models          # Expands to user's home
+model_cache_dir: ~/.cache/huggingface   # Standard HF location
+```
+- ✅ No elevated permissions needed
+- ✅ Good for development/testing
+- ⚠️ Limited space on some systems
+- ⚠️ Not shared across users
+
+### Space Requirements
+
+| Model Size | Minimum Free Space | Recommended |
+|------------|-------------------|-------------|
+| Small (< 3B params) | 10 GB | 20 GB |
+| Medium (7-13B params) | 30 GB | 50 GB |
+| Large (30-70B params) | 80 GB | 150 GB |
+| Very Large (70B+ params) | 150 GB | 200 GB |
+
+### Permission Requirements
+
+The directory must be:
+- **Writable** by the Ansible user
+- **Accessible** to containers (SELinux: use `:z` mount option, automatically applied)
+- **Sufficient space** for models + 20% overhead
+
+The playbook automatically:
+1. Creates the directory if it doesn't exist
+2. Verifies write permissions before download
+3. Checks available disk space
+
+### What to Avoid
+
+❌ `/var/lib/vllm-models` - System directory, often small partition
+❌ `/tmp` - May be cleared on reboot, often limited size
+❌ `/` or `/root` - Root filesystem should stay small
+❌ Read-only mounts - Obviously won't work
 
 ## How It Works
 
@@ -183,9 +245,43 @@ ansible-playbook ... -e model_download_min_space_gb=100
 
 ### Permission Issues
 
-**Ensure cache directory has correct permissions:**
+**Error: "Cache directory is not writable"**
+
+This indicates the Ansible user cannot write to the cache directory.
+
+**Quick fixes:**
 ```bash
-chmod 755 {{ model_cache_dir }}
+# Option 1: Use a user-owned directory
+model_cache_dir: ~/vllm-models
+
+# Option 2: Change ownership (if you have sudo)
+sudo chown -R $USER:$USER {{ model_cache_dir }}
+sudo chmod 755 {{ model_cache_dir }}
+
+# Option 3: Use a different location
+model_cache_dir: /mnt/data/hf-cache  # Or wherever you have write access
+```
+
+**SELinux issues (RHEL/Fedora):**
+```bash
+# Check SELinux denials
+sudo ausearch -m avc -ts recent | grep podman
+
+# If needed, set SELinux context (usually automatic with :z flag)
+sudo semanage fcontext -a -t container_file_t "{{ model_cache_dir }}(/.*)?"
+sudo restorecon -Rv {{ model_cache_dir }}
+```
+
+**NFS permission issues:**
+```bash
+# Verify NFS export allows write access
+showmount -e <nfs-server>
+
+# Check mount options include 'rw'
+mount | grep {{ model_cache_dir }}
+
+# May need to adjust NFS export options on server:
+# /export/hf-cache *(rw,sync,no_root_squash,no_subtree_check)
 ```
 
 ## Example Playbook Usage


### PR DESCRIPTION
Implements model pre-download using the model-downloader container before vLLM starts, eliminating repeated downloads and improving test execution reliability. Models are cached to persistent storage and reused across runs.

Key features:
- Automatic cache check before download
- Uses containerized downloader for DUT environment compatibility
- Skips pre-download for external vLLM deployments
- Configurable via use_persistent_cache and force_model_download

Benefits:
- Faster test execution (no download wait on repeated runs)
- More reliable tests (network issues won't interrupt running tests)
- Bandwidth savings (download once, use many times)
- Better CI/CD integration (pre-download in setup phase)

Addresses: https://github.com/redhat-et/vllm-cpu-perf-eval/issues/35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added model pre-download capability with persistent caching support
  * Configurable cache management: directory location, retry attempts, and minimum disk space requirements

* **Documentation**
  * New guide for model pre-download workflow, configuration options, and troubleshooting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->