### PR TITLE
fix: include unmapped tasks in MTEB domain filtering

### DIFF
--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/3_📊_Embedding_Metrics.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/3_📊_Embedding_Metrics.py
@@ -1064,6 +1064,16 @@ def plot_mteb_quality_metrics(df: pd.DataFrame):
                    'STSBenchmark', 'SICKRelatedness']
     }
 
+    # Identify unmapped tasks (tasks in data but not in any domain)
+    all_mapped_tasks = set()
+    for tasks in task_domains.values():
+        all_mapped_tasks.update(tasks)
+    unmapped_tasks = [t for t in benchmark_filtered_tasks if t not in all_mapped_tasks]
+
+    # Add unmapped tasks to synthetic "Other" domain if any exist
+    if unmapped_tasks:
+        task_domains['Other'] = unmapped_tasks
+
     # Create domain filter
     st.markdown("### 🏷️ Task Selection")
     col1, col2 = st.columns([1, 2])


### PR DESCRIPTION
Add synthetic "Other" domain for tasks not mapped to any predefined domain category, ensuring all valid tasks in the data are visible and selectable by default rather than being silently dropped during domain filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the Embedding Metrics dashboard to display previously unmapped MTEB benchmark tasks. Unmapped tasks now appear in a new "Other" category within the domain and task selection interface, improving coverage and visibility of available benchmarks in the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->