### PR TITLE
chore: update faraday to >= 2.14.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,6 @@ gem 'github-pages', group: :jekyll_plugins
 
 # Required for Ruby 3.0+
 gem 'webrick'
+
+# Security update for faraday
+gem 'faraday', '>= 2.14.3'


### PR DESCRIPTION
Add explicit version constraint for faraday gem to address security vulnerabilities in earlier versions.