### PR TITLE
chore: update activesupport to >= 7.2.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ gem 'github-pages', group: :jekyll_plugins
 # Required for Ruby 3.0+
 gem 'webrick'
 
+# Security update for activesupport
+gem 'activesupport', '>= 7.2.3.1'
+
 # Security update for concurrent-ruby
 gem 'concurrent-ruby', '>= 1.3.7'
 


### PR DESCRIPTION
Add explicit version constraint for activesupport gem to address multiple security vulnerabilities in earlier versions.

Fixes Dependabot alerts:
- #4: Possible DoS in number helpers
- #3: Possible XSS in SafeBuffer#%
- #2: Possible ReDoS in number_to_delimited