### PR TITLE
Feat results in place

### DIFF
--- a/automation/test-execution/ansible/embedding-benchmark.yml
+++ b/automation/test-execution/ansible/embedding-benchmark.yml
@@ -414,6 +414,37 @@
         mode: pull
         recursive: true
 
+- name: "Phase 4c - Display Results Summary"
+  hosts: localhost
+  gather_facts: false
+  vars:
+    test_run_id: "{{ hostvars['localhost']['test_run_id'] }}"
+    _lg_host: "{{ groups['load_generator'][0] | default('') }}"
+    _detected: >-
+      {{ hostvars[_lg_host]['detected_model'] | default('')
+         if _lg_host | length > 0 else '' }}
+    model_name: >-
+      {{ _detected if _detected | length > 0
+         else test_model | default('RedHatAI/granite-embedding-english-r2') }}
+
+  tasks:
+    - name: Display embedding benchmark results summary
+      ansible.builtin.command:
+        cmd: >-
+          python3 {{ playbook_dir }}/../scripts/conversion/view_results.py
+          {{ playbook_dir }}/../../../results/embedding/{{ model_name | replace('/', '__') }}/{{ test_run_id }}/
+      register: results_summary
+      changed_when: false
+      failed_when: false
+      when: show_results | default(false) | bool
+
+    - name: Show results summary output
+      ansible.builtin.debug:
+        msg: "{{ results_summary.stdout_lines }}"
+      when:
+        - show_results | default(false) | bool
+        - results_summary.stdout_lines is defined
+
 - name: "Phase 4 - Collect Logs from DUT"
   hosts: dut
   become: true

--- a/automation/test-execution/ansible/llm-benchmark-auto.yml
+++ b/automation/test-execution/ansible/llm-benchmark-auto.yml
@@ -725,6 +725,27 @@
         - timing_extraction.stdout_lines is defined
         - is_core_sweep is not defined or not is_core_sweep
 
+    - name: Display benchmark results summary
+      ansible.builtin.command:
+        cmd: >-
+          python3 {{ playbook_dir }}/../scripts/conversion/view_results.py
+          {{ hostvars['localhost']['local_results_base'] }}/{{ actual_model | replace('/', '__') }}/{{ workload_type }}-{{ test_run_id }}/{{ core_configuration.name }}/
+      delegate_to: localhost
+      register: results_summary
+      changed_when: false
+      failed_when: false
+      when:
+        - show_results | default(false) | bool
+        - is_core_sweep is not defined or not is_core_sweep
+
+    - name: Show results summary output
+      ansible.builtin.debug:
+        msg: "{{ results_summary.stdout_lines }}"
+      when:
+        - show_results | default(false) | bool
+        - is_core_sweep is not defined or not is_core_sweep
+        - results_summary.stdout_lines is defined
+
     - name: Display results location (standalone run)
       ansible.builtin.debug:
         msg:

--- a/automation/test-execution/ansible/llm-benchmark.yml
+++ b/automation/test-execution/ansible/llm-benchmark.yml
@@ -158,6 +158,24 @@
         msg: "{{ timing_extraction.stdout_lines }}"
       when: timing_extraction.stdout_lines is defined
 
+    - name: Display benchmark results summary
+      ansible.builtin.command:
+        cmd: >-
+          python3 {{ playbook_dir }}/../scripts/conversion/view_results.py
+          {{ hostvars['localhost']['local_results_base'] }}/{{ test_model | replace('/', '__') }}/{{ workload_type }}-{{ test_run_id }}/{{ core_configuration.name }}/
+      delegate_to: localhost
+      register: results_summary
+      changed_when: false
+      failed_when: false
+      when: show_results | default(false) | bool
+
+    - name: Show results summary output
+      ansible.builtin.debug:
+        msg: "{{ results_summary.stdout_lines }}"
+      when:
+        - show_results | default(false) | bool
+        - results_summary.stdout_lines is defined
+
 - name: "Phase 4 - Collect Logs from DUT"
   hosts: dut
   become: true

--- a/automation/test-execution/ansible/view-results.yml
+++ b/automation/test-execution/ansible/view-results.yml
@@ -42,7 +42,7 @@
     - name: Resolve results path
       ansible.builtin.set_fact:
         resolved_path: >-
-          {{ results_path if results_path is abs
+          {{ results_path if results_path.startswith('/')
              else (playbook_dir ~ '/../../../' ~ results_path) }}
 
     - name: Check results path exists

--- a/automation/test-execution/ansible/view-results.yml
+++ b/automation/test-execution/ansible/view-results.yml
@@ -1,0 +1,73 @@
+---
+# Display benchmark results in the terminal
+# Supports LLM (GuideLLM) and embedding (vllm bench serve) results
+#
+# Usage:
+#   ansible-playbook view-results.yml \
+#     -e "results_path=results/llm/model__name/workload-runid/config/"
+#
+#   ansible-playbook view-results.yml \
+#     -e "results_path=results/embedding/model__name/runid/"
+#
+#   # Suppress metadata header
+#   ansible-playbook view-results.yml \
+#     -e "results_path=..." -e "no_header=true"
+
+- name: "View Benchmark Results"
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Validate results_path is provided
+      ansible.builtin.assert:
+        that:
+          - results_path is defined
+          - results_path | length > 0
+        fail_msg: |
+          Missing required variable: results_path
+
+          Usage:
+            ansible-playbook view-results.yml \
+              -e "results_path=<path/to/results/directory>"
+
+          Examples:
+            # LLM results
+            ansible-playbook view-results.yml \
+              -e "results_path=results/llm/TinyLlama__TinyLlama-1.1B-Chat-v1.0/chat-20260428-124238/32cores-numa3-tp1/"
+
+            # Embedding results
+            ansible-playbook view-results.yml \
+              -e "results_path=results/embedding/BAAI__bge-small-en-v1.5/20260710-143022/"
+
+    - name: Resolve results path
+      ansible.builtin.set_fact:
+        resolved_path: >-
+          {{ results_path if results_path is abs
+             else (playbook_dir ~ '/../../../' ~ results_path) }}
+
+    - name: Check results path exists
+      ansible.builtin.stat:
+        path: "{{ resolved_path }}"
+      register: results_check
+
+    - name: Fail if results path not found
+      ansible.builtin.fail:
+        msg: "Results path not found: {{ resolved_path }}"
+      when: not results_check.stat.exists
+
+    - name: Build viewer command
+      ansible.builtin.set_fact:
+        viewer_cmd: >-
+          python3 {{ playbook_dir }}/../scripts/conversion/view_results.py
+          {{ '--no-header' if (no_header | default(false) | bool) else '' }}
+          {{ resolved_path }}
+
+    - name: Run results viewer
+      ansible.builtin.command:
+        cmd: "{{ viewer_cmd }}"
+      register: viewer_output
+      changed_when: false
+
+    - name: Display results
+      ansible.builtin.debug:
+        msg: "{{ viewer_output.stdout_lines }}"

--- a/automation/test-execution/scripts/README.md
+++ b/automation/test-execution/scripts/README.md
@@ -10,6 +10,7 @@ scripts/
 │   ├── extract_benchmark_timings.py   # Extract per-benchmark timing data
 │   └── log_to_mlflow.py               # Log results to MLflow tracking
 └── conversion/           # Result conversion utilities
+    ├── view_results.py                # Terminal results viewer (LLM + embedding)
     ├── convert_embedding_results.py   # Convert embedding JSON to CSV
     ├── convert_batch.py               # Batch convert LLM results
     └── convert_single.py              # Convert single LLM result file
@@ -46,6 +47,32 @@ python3 log_to_mlflow.py <benchmarks.json> <metadata.json> \
 - `automation/test-execution/ansible/log-to-mlflow.yml`
 
 ## Conversion Scripts
+
+### view_results.py
+
+Displays benchmark results as a formatted table in the terminal.
+Auto-detects LLM (GuideLLM) vs embedding (vllm bench serve) format.
+
+**Usage:**
+```bash
+# LLM results
+python3 view_results.py <path/to/benchmarks.json>
+python3 view_results.py <path/to/results-directory/>
+
+# Embedding results
+python3 view_results.py <path/to/embedding-test-run-dir/>
+
+# Suppress metadata header
+python3 view_results.py --no-header <path>
+```
+
+**Used by:**
+- `automation/test-execution/ansible/llm-benchmark.yml`
+- `automation/test-execution/ansible/llm-benchmark-auto.yml`
+- `automation/test-execution/ansible/embedding-benchmark.yml`
+
+See [Terminal Results Viewer](../../../docs/terminal-results-viewer.md)
+for full documentation.
 
 ### convert_embedding_results.py
 

--- a/automation/test-execution/scripts/conversion/view_results.py
+++ b/automation/test-execution/scripts/conversion/view_results.py
@@ -1,0 +1,645 @@
+#!/usr/bin/env python3
+"""Terminal viewer for vLLM CPU benchmark results.
+
+Supports both LLM (GuideLLM benchmarks.json) and embedding
+(vllm bench serve sweep-*.json / concurrent-*.json) result
+formats. Auto-detects the format based on directory contents.
+
+No external dependencies -- stdlib only.
+
+Usage:
+    # LLM results (GuideLLM)
+    python3 view_results.py <path/to/benchmarks.json>
+    python3 view_results.py <path/to/results-directory/>
+
+    # Embedding results (vllm bench serve)
+    python3 view_results.py <path/to/embedding-test-run-dir/>
+
+    python3 view_results.py --no-header <path>
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+TABLE_WIDTH = 95
+
+
+# -----------------------------------------------------------
+# Shared helpers
+# -----------------------------------------------------------
+
+def load_json(path):
+    """Load a JSON file, returning None on failure."""
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as e:
+        print(
+            f"Warning: could not load {path}: {e}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def safe_get(d, *keys, default=None):
+    """Traverse nested dicts safely."""
+    for key in keys:
+        if not isinstance(d, dict):
+            return default
+        d = d.get(key)
+        if d is None:
+            return default
+    return d
+
+
+def clean_platform(platform):
+    """Clean platform string for display."""
+    if not platform:
+        return "N/A"
+    name = platform.replace("_", " ")
+    for suffix in [" Core Processor", " C"]:
+        if name.endswith(suffix):
+            name = name[:-len(suffix)]
+    name = name.replace(" R ", " ")
+    return name.strip()
+
+
+def fmt_f(val, decimals=1):
+    """Format float, or '-' if None."""
+    if val is None:
+        return "-"
+    return f"{val:.{decimals}f}"
+
+
+def fmt_i(val):
+    """Format as integer, or '-' if None."""
+    if val is None:
+        return "-"
+    return str(int(round(val)))
+
+
+def fmt_ms(val, from_seconds=False):
+    """Format as integer milliseconds, or '-' if None."""
+    if val is None:
+        return "-"
+    if from_seconds:
+        val = val * 1000
+    return str(int(round(val)))
+
+
+def _extract_date(run_id):
+    """Extract YYYY-MM-DD from a test_run_id string."""
+    if not run_id:
+        return "N/A"
+    for part in run_id.split("-"):
+        if len(part) == 8 and part.isdigit():
+            return (
+                f"{part[:4]}-{part[4:6]}-{part[6:8]}"
+            )
+    if len(run_id) >= 8 and run_id[:8].isdigit():
+        return (
+            f"{run_id[:4]}-{run_id[4:6]}-{run_id[6:8]}"
+        )
+    return "N/A"
+
+
+# -----------------------------------------------------------
+# Format detection
+# -----------------------------------------------------------
+
+def detect_format(path):
+    """Detect result format.
+
+    Returns (format_type, resolved_dir, benchmarks_path|None).
+    format_type: 'llm' or 'embedding'
+    """
+    p = Path(path)
+
+    if p.is_file() and p.name == "benchmarks.json":
+        return "llm", p.parent, p
+
+    if p.is_dir():
+        benchmarks = p / "benchmarks.json"
+        if benchmarks.exists():
+            return "llm", p, benchmarks
+
+        has_baseline = (p / "baseline").is_dir()
+        has_latency = (p / "latency").is_dir()
+        if has_baseline or has_latency:
+            return "embedding", p, None
+
+        has_sweep = list(p.glob("sweep-*.json"))
+        has_conc = list(p.glob("concurrent-*.json"))
+        if has_sweep or has_conc:
+            return "embedding", p, None
+
+    print(
+        f"Error: could not detect result format at {path}",
+        file=sys.stderr,
+    )
+    print(
+        "Expected: benchmarks.json (LLM) "
+        "or baseline/latency subdirs (embedding)",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+# -----------------------------------------------------------
+# LLM results (GuideLLM)
+# -----------------------------------------------------------
+
+def format_llm_header(metadata):
+    """Build the LLM metadata header block."""
+    if metadata is None:
+        metadata = {}
+
+    model = metadata.get("model", "N/A")
+    workload = metadata.get("workload", "N/A")
+    cores = metadata.get("core_count", "N/A")
+    platform = clean_platform(metadata.get("platform"))
+    vllm_ver = metadata.get("vllm_version", "N/A")
+    caching = metadata.get("vllm_caching_mode", "N/A")
+    date = _extract_date(metadata.get("test_run_id", ""))
+
+    bar = "━" * TABLE_WIDTH
+    lines = [
+        bar,
+        " vLLM CPU Benchmark Results — LLM",
+        bar,
+        f" Model:    {model}",
+        (
+            f" Workload: {workload}"
+            f" | Cores: {cores}"
+            f" | Platform: {platform}"
+        ),
+        (
+            f" vLLM: {vllm_ver}"
+            f" | Caching: {caching}"
+            f" | Date: {date}"
+        ),
+        bar,
+    ]
+    return "\n".join(lines)
+
+
+def _ttft(metrics, stat):
+    """Get TTFT metric by stat name."""
+    base = safe_get(
+        metrics, "time_to_first_token_ms", "successful",
+    )
+    if base is None:
+        return None
+    if stat == "median":
+        return base.get("median")
+    return safe_get(base, "percentiles", stat)
+
+
+def _itl(metrics, stat):
+    """Get ITL metric by stat name."""
+    base = safe_get(
+        metrics, "inter_token_latency_ms", "successful",
+    )
+    if base is None:
+        return None
+    if stat == "median":
+        return base.get("median")
+    return safe_get(base, "percentiles", stat)
+
+
+def _lat(metrics, stat):
+    """Get request latency metric by stat name."""
+    base = safe_get(
+        metrics, "request_latency", "successful",
+    )
+    if base is None:
+        return None
+    if stat == "median":
+        return base.get("median")
+    return safe_get(base, "percentiles", stat)
+
+
+def extract_llm_row(benchmark):
+    """Extract metrics from a single GuideLLM benchmark."""
+    config = safe_get(benchmark, "config", default={})
+    strategy = safe_get(config, "strategy", default={})
+    metrics = safe_get(benchmark, "metrics", default={})
+    sched = safe_get(
+        benchmark, "scheduler_metrics", default={},
+    )
+
+    concurrency = (
+        strategy.get("streams")
+        or strategy.get("max_concurrency")
+        or 0
+    )
+
+    return {
+        "conc": concurrency,
+        "tok_s": safe_get(
+            metrics, "tokens_per_second",
+            "successful", "mean",
+        ),
+        "ttft_med": _ttft(metrics, "median"),
+        "ttft_p95": _ttft(metrics, "p95"),
+        "ttft_p99": _ttft(metrics, "p99"),
+        "itl_med": _itl(metrics, "median"),
+        "itl_p95": _itl(metrics, "p95"),
+        "itl_p99": _itl(metrics, "p99"),
+        "lat_med": _lat(metrics, "median"),
+        "lat_p95": _lat(metrics, "p95"),
+        "lat_p99": _lat(metrics, "p99"),
+        "reqs": safe_get(
+            sched, "requests_made", "successful",
+            default=0,
+        ),
+        "errs": safe_get(
+            sched, "requests_made", "errored",
+            default=0,
+        ),
+    }
+
+
+def build_llm_table(rows):
+    """Build the formatted LLM results table."""
+    if not rows:
+        return "No benchmark data found."
+
+    rows.sort(key=lambda r: r["conc"])
+
+    sep = "│"
+    hsep = "─"
+    cross = "┼"
+
+    wc = 5   # Conc
+    wt = 8   # Tok/s
+    wf = 6   # TTFT / ITL sub-columns
+    wl = 7   # Latency sub-columns
+    wr = 5   # Reqs
+    we = 4   # Err
+
+    ttft_w = wf * 3 + 4
+    itl_w = wf * 3 + 4
+    lat_w = wl * 3 + 4
+
+    h1 = (
+        f" {'Conc':>{wc}} {sep} {'Tok/s':>{wt}} {sep}"
+        f" {'TTFT (ms)':^{ttft_w}} {sep}"
+        f" {'ITL (ms)':^{itl_w}} {sep}"
+        f" {'E2E Latency (ms)':^{lat_w}} {sep}"
+        f" {'Reqs':>{wr}} {sep} {'Err':>{we}}"
+    )
+
+    h2 = (
+        f" {'':>{wc}} {sep} {'(mean)':>{wt}} {sep}"
+        f"  {'med':>{wf}}  {'p95':>{wf}}"
+        f"  {'p99':>{wf}} {sep}"
+        f"  {'med':>{wf}}  {'p95':>{wf}}"
+        f"  {'p99':>{wf}} {sep}"
+        f"  {'med':>{wl}}  {'p95':>{wl}}"
+        f"  {'p99':>{wl}} {sep}"
+        f" {'':>{wr}} {sep} {'':>{we}}"
+    )
+
+    def seg(w):
+        return hsep * (w + 2)
+
+    sep_line = (
+        f" {hsep * wc}{cross}{seg(wt)}{cross}"
+        f"{hsep * (ttft_w + 2)}{cross}"
+        f"{hsep * (itl_w + 2)}{cross}"
+        f"{hsep * (lat_w + 2)}{cross}"
+        f"{seg(wr)}{cross}{seg(we)}"
+    )
+
+    lines = [h1, h2, sep_line]
+
+    for r in rows:
+        line = (
+            f" {fmt_i(r['conc']):>{wc}} {sep}"
+            f" {fmt_f(r['tok_s']):>{wt}} {sep}"
+            f"  {fmt_ms(r['ttft_med']):>{wf}}"
+            f"  {fmt_ms(r['ttft_p95']):>{wf}}"
+            f"  {fmt_ms(r['ttft_p99']):>{wf}} {sep}"
+            f"  {fmt_f(r['itl_med']):>{wf}}"
+            f"  {fmt_f(r['itl_p95']):>{wf}}"
+            f"  {fmt_f(r['itl_p99']):>{wf}} {sep}"
+            f"  {fmt_ms(r['lat_med'], True):>{wl}}"
+            f"  {fmt_ms(r['lat_p95'], True):>{wl}}"
+            f"  {fmt_ms(r['lat_p99'], True):>{wl}}"
+            f" {sep}"
+            f" {fmt_i(r['reqs']):>{wr}} {sep}"
+            f" {fmt_i(r['errs']):>{we}}"
+        )
+        lines.append(line)
+
+    return "\n".join(lines)
+
+
+def view_llm(benchmarks_path, result_dir, show_header):
+    """Display LLM benchmark results."""
+    data = load_json(benchmarks_path)
+    if data is None:
+        print(
+            "Error: could not parse benchmarks.json",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    benchmarks = data.get("benchmarks", [])
+    if not benchmarks:
+        print(
+            "No benchmark data found in file.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    output_parts = []
+
+    if show_header:
+        metadata_path = result_dir / "test-metadata.json"
+        metadata = (
+            load_json(metadata_path)
+            if metadata_path.exists()
+            else None
+        )
+        output_parts.append(format_llm_header(metadata))
+        output_parts.append("")
+
+    rows = [extract_llm_row(b) for b in benchmarks]
+    output_parts.append(build_llm_table(rows))
+    output_parts.append("━" * TABLE_WIDTH)
+
+    print("\n".join(output_parts))
+
+
+# -----------------------------------------------------------
+# Embedding results (vllm bench serve)
+# -----------------------------------------------------------
+
+def format_embedding_header(metadata):
+    """Build the embedding metadata header block."""
+    if metadata is None:
+        metadata = {}
+
+    model = metadata.get("model", "N/A")
+    scenario = metadata.get("scenario", "N/A")
+    cores = (
+        metadata.get("requested_cores")
+        or metadata.get("core_count")
+        or "N/A"
+    )
+    if str(cores) in ("None", "null", ""):
+        cores = "N/A"
+    platform = clean_platform(metadata.get("platform"))
+    vllm_ver = metadata.get("vllm_version", "N/A")
+    num_prompts = metadata.get("num_prompts", "N/A")
+    input_len = metadata.get(
+        "embedding_random_input_len", "N/A",
+    )
+    date = _extract_date(
+        metadata.get("test_run_id", ""),
+    )
+
+    bar = "━" * TABLE_WIDTH
+    lines = [
+        bar,
+        " vLLM CPU Benchmark Results — Embedding",
+        bar,
+        f" Model:    {model}",
+        (
+            f" Scenario: {scenario}"
+            f" | Cores: {cores}"
+            f" | Platform: {platform}"
+        ),
+        (
+            f" vLLM: {vllm_ver}"
+            f" | Prompts: {num_prompts}"
+            f" | Input len: {input_len}"
+            f" | Date: {date}"
+        ),
+        bar,
+    ]
+    return "\n".join(lines)
+
+
+def collect_embedding_results(result_dir):
+    """Collect embedding result files.
+
+    Returns list of (test_type, label, data_dict) tuples.
+    """
+    results = []
+
+    for subdir_name in ["baseline", "latency"]:
+        subdir = result_dir / subdir_name
+        if not subdir.is_dir():
+            continue
+        for json_file in sorted(subdir.glob("*.json")):
+            data = load_json(json_file)
+            if data is None:
+                continue
+            stem = json_file.stem
+            if stem.startswith("sweep-"):
+                test_type = "baseline"
+                label = stem.replace("sweep-", "")
+            elif stem.startswith("concurrent-"):
+                test_type = "concurrent"
+                label = stem.replace(
+                    "concurrent-", "",
+                )
+            else:
+                continue
+            results.append((test_type, label, data))
+
+    sweep = list(result_dir.glob("sweep-*.json"))
+    conc = list(result_dir.glob("concurrent-*.json"))
+    for json_file in sorted(sweep + conc):
+        data = load_json(json_file)
+        if data is None:
+            continue
+        stem = json_file.stem
+        if stem.startswith("sweep-"):
+            results.append((
+                "baseline",
+                stem.replace("sweep-", ""),
+                data,
+            ))
+        elif stem.startswith("concurrent-"):
+            results.append((
+                "concurrent",
+                stem.replace("concurrent-", ""),
+                data,
+            ))
+
+    return results
+
+
+def _sort_key_embedding(item):
+    """Sort: baseline first (inf, then pct), then concurrent."""
+    test_type, label, _ = item
+    if test_type == "baseline":
+        if label == "inf":
+            return (0, 0)
+        pct = label.replace("pct", "")
+        try:
+            return (0, int(pct))
+        except ValueError:
+            return (0, 999)
+    else:
+        try:
+            return (1, int(label))
+        except ValueError:
+            return (1, 999)
+
+
+def build_embedding_table(results):
+    """Build the formatted embedding results table."""
+    if not results:
+        return "No embedding data found."
+
+    results.sort(key=_sort_key_embedding)
+
+    sep = "│"
+    hsep = "─"
+    cross = "┼"
+
+    wty = 10  # Type
+    wlb = 8   # Label
+    wrp = 10  # RPS
+    wtk = 12  # Tok/s
+    wla = 10  # Latency sub-columns (x4)
+    wre = 6   # Reqs
+    wdu = 7   # Duration
+
+    lat_w = wla * 4 + 6
+
+    h1 = (
+        f" {'Type':>{wty}} {sep}"
+        f" {'Label':>{wlb}} {sep}"
+        f" {'RPS':>{wrp}} {sep}"
+        f" {'Tok/s':>{wtk}} {sep}"
+        f" {'E2E Latency (ms)':^{lat_w}} {sep}"
+        f" {'Reqs':>{wre}} {sep}"
+        f" {'Dur(s)':>{wdu}}"
+    )
+
+    h2 = (
+        f" {'':>{wty}} {sep} {'':>{wlb}} {sep}"
+        f" {'':>{wrp}} {sep} {'':>{wtk}} {sep}"
+        f"  {'mean':>{wla}}  {'med':>{wla}}"
+        f"  {'std':>{wla}}  {'p99':>{wla}} {sep}"
+        f" {'':>{wre}} {sep} {'':>{wdu}}"
+    )
+
+    def seg(w):
+        return hsep * (w + 2)
+
+    sep_line = (
+        f" {hsep * wty}{cross}{seg(wlb)}{cross}"
+        f"{seg(wrp)}{cross}{seg(wtk)}{cross}"
+        f"{hsep * (lat_w + 2)}{cross}"
+        f"{seg(wre)}{cross}{seg(wdu)}"
+    )
+
+    lines = [h1, h2, sep_line]
+
+    for test_type, label, data in results:
+        rps = data.get("request_throughput")
+        tok_s = data.get("total_token_throughput")
+        mean_lat = data.get("mean_e2el_ms")
+        med_lat = data.get("median_e2el_ms")
+        std_lat = data.get("std_e2el_ms")
+        p99_lat = data.get("p99_e2el_ms")
+        completed = data.get("completed")
+        duration = data.get("duration")
+
+        line = (
+            f" {test_type:>{wty}} {sep}"
+            f" {label:>{wlb}} {sep}"
+            f" {fmt_f(rps, 2):>{wrp}} {sep}"
+            f" {fmt_f(tok_s, 1):>{wtk}} {sep}"
+            f"  {fmt_f(mean_lat, 1):>{wla}}"
+            f"  {fmt_f(med_lat, 1):>{wla}}"
+            f"  {fmt_f(std_lat, 1):>{wla}}"
+            f"  {fmt_f(p99_lat, 1):>{wla}} {sep}"
+            f" {fmt_i(completed):>{wre}} {sep}"
+            f" {fmt_f(duration, 1):>{wdu}}"
+        )
+        lines.append(line)
+
+    return "\n".join(lines)
+
+
+def view_embedding(result_dir, show_header):
+    """Display embedding benchmark results."""
+    results = collect_embedding_results(result_dir)
+    if not results:
+        print(
+            "No embedding result files found.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    output_parts = []
+
+    if show_header:
+        metadata_path = (
+            result_dir / "test-metadata.json"
+        )
+        metadata = (
+            load_json(metadata_path)
+            if metadata_path.exists()
+            else None
+        )
+        output_parts.append(
+            format_embedding_header(metadata),
+        )
+        output_parts.append("")
+
+    output_parts.append(build_embedding_table(results))
+    output_parts.append("━" * TABLE_WIDTH)
+
+    print("\n".join(output_parts))
+
+
+# -----------------------------------------------------------
+# Main
+# -----------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "View vLLM CPU benchmark results "
+            "in the terminal."
+        ),
+    )
+    parser.add_argument(
+        "path",
+        help=(
+            "Path to benchmarks.json, a results "
+            "directory (LLM), or an embedding "
+            "test-run directory"
+        ),
+    )
+    parser.add_argument(
+        "--no-header",
+        action="store_true",
+        help="Suppress the metadata header block",
+    )
+    args = parser.parse_args()
+
+    fmt, result_dir, benchmarks_path = detect_format(
+        args.path,
+    )
+    show_header = not args.no_header
+
+    if fmt == "llm":
+        view_llm(benchmarks_path, result_dir, show_header)
+    elif fmt == "embedding":
+        view_embedding(result_dir, show_header)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dashboards-quickstart.md
+++ b/docs/dashboards-quickstart.md
@@ -27,6 +27,9 @@ open <http://localhost:8501>
 
 **That's it!** No Grafana setup needed for analysis.
 
+> **Tip:** For a quick terminal-only summary without launching a
+> dashboard, see [Terminal Results Viewer](terminal-results-viewer.md).
+
 ## Two Dashboard Systems
 
 ### Streamlit Dashboard (Post-Test Analysis)
@@ -94,15 +97,20 @@ ansible-playbook start-grafana.yml
 
 ## When to Use What
 
+<!-- markdownlint-disable MD013 -->
+
 | Scenario | Use | Why |
 |----------|-----|-----|
+| Quick post-run glance | [Terminal Viewer](terminal-results-viewer.md) | No setup, same terminal |
 | Analyze completed test | Streamlit | Comprehensive post-test analysis |
 | Compare multiple tests | Streamlit | Side-by-side comparison tools |
 | Export data to CSV | Streamlit | Built-in export functionality |
 | Watch long test progress | Grafana | Real-time monitoring |
 | Debug performance issue | Both | Live view + detailed analysis |
-| Quick test (<2 min) | Streamlit only | Not worth Grafana setup |
+| CI/CD pipeline | [Terminal Viewer](terminal-results-viewer.md) | No browser available |
 | External endpoint testing | Streamlit | Client metrics always available |
+
+<!-- markdownlint-enable MD013 -->
 
 ## Testing External Endpoints
 
@@ -154,8 +162,10 @@ cd automation/test-execution/dashboard-examples/vllm_dashboard
 - Efficiency (tokens/sec/core) - managed mode only
 
 **Visualizations:**
-- **Multi-percentile overlay**: Select metric family and view Mean, P50, P95, P99 on same chart
-- **Visual differentiation**: Each percentile uses distinct line style (solid, dashed, dotted, dash-dot)
+- **Multi-percentile overlay**: Select metric family and view
+  Mean, P50, P95, P99 on same chart
+- **Visual differentiation**: Each percentile uses distinct line
+  style (solid, dashed, dotted, dash-dot)
 - Line charts by request rate or concurrency
 - Peak performance summary for selected percentiles
 - CSV export
@@ -216,7 +226,8 @@ Percentile definition: Pxx = the value below which xx% of data points fall
 - Concurrent request handling
 
 **Visualizations:**
-- **Saturation curves**: Throughput and P99 latency vs load level (inf, 75%, 50%, 25%)
+- **Saturation curves**: Throughput and P99 latency vs load
+  level (inf, 75%, 50%, 25%)
 - **Concurrent load analysis**: Performance vs concurrency level
 - **Model comparison**: Side-by-side throughput and latency comparison
 - CSV export
@@ -232,7 +243,8 @@ Unlike LLM models (which generate tokens), embedding models:
 
 **Data Source:**
 - `vllm bench serve` JSON results (`sweep-*.json`, `concurrent-*.json`)
-- **Note**: Currently uses vLLM bench serve. Future versions will also support GuideLLM embedding tests when available.
+- **Note**: Currently uses vLLM bench serve. Future versions
+  will also support GuideLLM embedding tests.
 
 **Best for:**
 - Finding max sustainable throughput
@@ -242,7 +254,8 @@ Unlike LLM models (which generate tokens), embedding models:
 
 **Dashboard Filters:**
 
-The Embedding Metrics dashboard includes comprehensive filtering for multi-dimensional analysis:
+The Embedding Metrics dashboard includes comprehensive
+filtering for multi-dimensional analysis:
 
 1. **Primary Filters** (Row 1)
    - **Models** - Select one or more embedding models to compare
@@ -264,7 +277,8 @@ The Embedding Metrics dashboard includes comprehensive filtering for multi-dimen
 
 **Populating Filter Data:**
 
-Filters show "(no data)" when viewing old test results. To populate all filters, run a new test:
+Filters show "(no data)" when viewing old test results.
+To populate all filters, run a new test:
 
 ```bash
 ansible-playbook -i inventory/hosts.yml embedding-benchmark.yml \
@@ -491,7 +505,9 @@ cd automation/test-execution/dashboard-examples/vllm_dashboard
 
 7. **Validate concurrent request handling** in dashboard
 
-**Note:** Embedding tests use `vllm bench serve` for benchmarking. Future versions will also support GuideLLM embedding tests when available.
+**Note:** Embedding tests use `vllm bench serve` for
+benchmarking. Future versions will also support GuideLLM
+embedding tests when available.
 
 ## Troubleshooting
 
@@ -523,7 +539,8 @@ find results/llm results/embedding -name "vllm-metrics.json" 2>/dev/null
 
 # If missing, metrics collection may have failed
 # Check logs:
-tail -f results/llm/*/metrics-collector.log results/embedding/*/logs/metrics-collector.log 2>/dev/null
+tail -f results/llm/*/metrics-collector.log \
+  results/embedding/*/logs/metrics-collector.log 2>/dev/null
 ```
 
 ### Grafana shows no data
@@ -539,7 +556,8 @@ ps aux | grep "ssh.*8000:localhost:8000"
 open http://localhost:9090/targets
 ```
 
-**Note:** Streamlit works independently of Grafana - if Grafana has issues, you can still analyze results in Streamlit!
+**Note:** Streamlit works independently of Grafana - if
+Grafana has issues, you can still analyze results in Streamlit!
 
 ## Tips
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -10,6 +10,7 @@ Comprehensive documentation for vLLM CPU performance evaluation.
 - **Understanding results**: See [Metrics Guide](methodology/metrics.md)
 - **Experiment tracking**: See [MLflow Integration](mlflow.md)
 - **Dashboards**: See [Dashboards Quick Start](dashboards-quickstart.md)
+- **Terminal viewer**: See [Terminal Results Viewer](terminal-results-viewer.md)
 - **Metrics collection**: See [Metrics Collection Guide](metrics-collection.md)
 
 ## Documentation Structure
@@ -18,6 +19,7 @@ Comprehensive documentation for vLLM CPU performance evaluation.
 docs/
 ├── getting-started.md        # Quick start guide
 ├── dashboards-quickstart.md  # Streamlit dashboard guide
+├── terminal-results-viewer.md # Terminal results viewer
 ├── metrics-collection.md     # vLLM metrics collection
 ├── mlflow.md                 # MLflow experiment tracking
 ├── environment-variables.md  # Environment variable reference
@@ -47,6 +49,8 @@ docs/
 1. [Getting Started](getting-started.md) - Setup and run your first test
 2. [Dashboards Quick Start](dashboards-quickstart.md) - View results in
    Streamlit
+3. [Terminal Results Viewer](terminal-results-viewer.md) - Quick
+   results in the terminal
 
 ### For Test Execution
 
@@ -74,7 +78,9 @@ docs/
 
 1. [MLflow Experiment Tracking](mlflow.md) - Track and compare experiments
 2. [Interactive Dashboards](dashboards-quickstart.md) - Visualize results
-3. [Metrics Collection Guide](metrics-collection.md) - Server-side metrics
+3. [Terminal Results Viewer](terminal-results-viewer.md) - Quick
+   terminal output
+4. [Metrics Collection Guide](metrics-collection.md) - Server-side metrics
 
 ## Contributing to Documentation
 
@@ -109,6 +115,7 @@ pre-commit run --all-files
 | ansible/model-predownload.md | ✅ Complete |
 | mlflow.md | ✅ Complete |
 | dashboards-quickstart.md | ✅ Complete |
+| terminal-results-viewer.md | ✅ Complete |
 | metrics-collection.md | ✅ Complete |
 
 <!-- markdownlint-enable MD013 -->

--- a/docs/terminal-results-viewer.md
+++ b/docs/terminal-results-viewer.md
@@ -1,0 +1,258 @@
+---
+layout: default
+title: Terminal Results Viewer
+---
+
+View benchmark results directly in the terminal without launching a
+dashboard.
+
+## TL;DR
+
+```bash
+cd automation/test-execution/ansible
+
+# View LLM (GuideLLM) results
+ansible-playbook view-results.yml \
+  -e "results_path=results/llm/TinyLlama__TinyLlama-1.1B-Chat-v1.0/chat-20260428-124238/32cores-numa3-tp1/"
+
+# View embedding (vllm bench serve) results
+ansible-playbook view-results.yml \
+  -e "results_path=results/embedding/BAAI__bge-small-en-v1.5/20260710-143022/"
+
+# Auto-display after benchmark runs
+ansible-playbook -i inventory/hosts.yml llm-benchmark.yml \
+  -e "show_results=true" ...
+```
+
+## Overview
+
+The terminal results viewer (`view_results.py`) prints a compact summary
+table of benchmark results to stdout. It auto-detects whether the results
+are from an LLM (GuideLLM) or embedding (vllm bench serve) run and
+formats the output accordingly.
+
+**Purpose:** Quick post-run review without switching windows
+
+**Requirements:**
+- Python 3.6+ (stdlib only, no pip install needed)
+- Works offline, no network access
+
+**When to use:**
+- Quick glance at results in the same terminal where you ran the test
+- CI/CD pipelines where a browser is not available
+- Comparing a single run before diving into the Streamlit dashboard
+
+For full interactive analysis with charts, filtering, and multi-run
+comparisons, use the
+[Streamlit dashboard](dashboards-quickstart.md) instead.
+
+## Usage
+
+### View Existing Results
+
+Use the `view-results.yml` playbook to display results from any
+previous benchmark run:
+
+```bash
+cd automation/test-execution/ansible
+
+# LLM results (relative path from project root)
+ansible-playbook view-results.yml \
+  -e "results_path=results/llm/TinyLlama__TinyLlama-1.1B-Chat-v1.0/chat-20260428-124238/32cores-numa3-tp1/"
+
+# Embedding results
+ansible-playbook view-results.yml \
+  -e "results_path=results/embedding/BAAI__bge-small-en-v1.5/20260710-143022/"
+
+# Absolute paths also work
+ansible-playbook view-results.yml \
+  -e "results_path=/home/user/benchmark-results/..."
+
+# Suppress metadata header
+ansible-playbook view-results.yml \
+  -e "results_path=..." -e "no_header=true"
+```
+
+The playbook auto-detects the result format:
+
+| Directory contents | Detected as |
+|--------------------|-------------|
+| Contains `benchmarks.json` | LLM |
+| Contains `baseline/` or `latency/` subdirs | Embedding |
+| Contains `sweep-*.json` or `concurrent-*.json` | Embedding |
+
+### Auto-Display After Benchmark Runs
+
+All three benchmark playbooks support automatic result display via the
+`show_results` variable:
+
+```bash
+# LLM single-config test
+ansible-playbook -i inventory/hosts.yml llm-benchmark.yml \
+  -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \
+  -e "workload_type=chat" \
+  -e "core_config_name=32cores-numa3-tp1" \
+  -e "show_results=true"
+
+# LLM auto (multi-config sweep)
+ansible-playbook -i inventory/hosts.yml llm-benchmark-auto.yml \
+  -e "test_model=meta-llama/Llama-3.2-1B-Instruct" \
+  -e "show_results=true"
+
+# Embedding test
+ansible-playbook -i inventory/hosts.yml embedding-benchmark.yml \
+  -e "test_model=BAAI/bge-small-en-v1.5" \
+  -e "scenario=all" \
+  -e "show_results=true"
+```
+
+The summary is displayed after results are fetched to the local machine
+but before log collection. It runs with `failed_when: false` so it
+never blocks the pipeline.
+
+## Output Format
+
+### LLM Results
+
+<!-- markdownlint-disable MD013 -->
+
+```text
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ vLLM CPU Benchmark Results — LLM
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Model:    TinyLlama/TinyLlama-1.1B-Chat-v1.0
+ Workload: chat | Cores: 32 | Platform: Intel Xeon 6975P
+ vLLM: 0.18.0 | Caching: baseline | Date: 2026-04-28
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  Conc │    Tok/s │     TTFT (ms)        │     ITL (ms)         │   E2E Latency (ms)         │  Reqs │ Err
+       │   (mean) │   med    p95     p99  │   med    p95    p99  │     med      p95      p99  │       │
+  ─────┼──────────┼──────────────────────-┼──────────────────────┼───────────────────────────--┼───────┼────
+     1 │    125.3 │    85     92      98  │   8.1    9.2     11  │    4120     4350     4580  │    15 │   0
+     8 │    986.2 │   292    950    1200  │   8.3    9.8     12  │    7247     8120     8950  │    56 │   0
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+<!-- markdownlint-enable MD013 -->
+
+**Columns:**
+
+<!-- markdownlint-disable MD013 -->
+
+| Column | Source | Unit |
+|--------|--------|------|
+| Conc | `config.strategy.streams` or `max_concurrency` | count |
+| Tok/s | `metrics.tokens_per_second.successful.mean` | tokens/sec |
+| TTFT | `metrics.time_to_first_token_ms.successful` | ms |
+| ITL | `metrics.inter_token_latency_ms.successful` | ms |
+| E2E Latency | `metrics.request_latency.successful` | ms (from s) |
+| Reqs | `scheduler_metrics.requests_made.successful` | count |
+| Err | `scheduler_metrics.requests_made.errored` | count |
+
+<!-- markdownlint-enable MD013 -->
+
+Rows are sorted by concurrency level ascending.
+
+### Embedding Results
+
+<!-- markdownlint-disable MD013 -->
+
+```text
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ vLLM CPU Benchmark Results — Embedding
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Model:    BAAI/bge-small-en-v1.5
+ Scenario: all | Cores: N/A | Platform: Intel Xeon 6975P
+ vLLM: 0.8.5.post1 | Prompts: 250 | Input len: 512 | Date: 2026-07-10
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+       Type │    Label │        RPS │        Tok/s │        E2E Latency (ms)                          │   Reqs │  Dur(s)
+            │          │            │              │       mean        med        std        p99       │        │
+  ──────────┼──────────┼────────────┼──────────────┼──────────────────────────────────────────────────-┼────────┼────────
+   baseline │      inf │      52.10 │      26675.2 │       19.1       18.5        3.2       32.4      │    250 │    4.8
+   baseline │    25pct │      13.03 │       6671.0 │       19.2       18.6        3.1       31.9      │    250 │   19.2
+ concurrent │        2 │      51.90 │      26576.0 │       38.2       37.5        5.8       58.1      │    250 │    4.8
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+<!-- markdownlint-enable MD013 -->
+
+**Columns:**
+
+<!-- markdownlint-disable MD013 -->
+
+| Column | Source | Unit |
+|--------|--------|------|
+| Type | `baseline` (sweep) or `concurrent` | - |
+| Label | `inf`, `25pct`, `2`, etc. | - |
+| RPS | `request_throughput` | req/sec |
+| Tok/s | `total_token_throughput` | tokens/sec |
+| E2E Latency | `mean_e2el_ms`, `median_e2el_ms`, etc. | ms |
+| Reqs | `completed` | count |
+| Dur(s) | `duration` | seconds |
+
+<!-- markdownlint-enable MD013 -->
+
+Rows are sorted: baseline first (inf, then by percentage), then
+concurrent by concurrency count.
+
+## Metadata Header
+
+When `test-metadata.json` exists alongside the results, the viewer
+displays a header block with:
+
+- **Model name** and workload type (LLM) or scenario (embedding)
+- **Platform** (CPU model, cleaned up for readability)
+- **Core count**, **vLLM version**, and **test date**
+
+Use `--no-header` to suppress this block.
+
+## When to Use What
+
+| Scenario | Terminal Viewer | Streamlit |
+|----------|-----------------|-----------|
+| Quick post-run check | Best | Overkill |
+| CI/CD pipeline | Only option | N/A |
+| Compare multiple runs | N/A | Best |
+| Interactive exploration | N/A | Best |
+| Share results in a ticket | Copy-paste table | Screenshot |
+| Deep metric analysis | N/A | Best |
+
+## Troubleshooting
+
+### "Could not detect result format"
+
+The script could not find `benchmarks.json` (LLM) or `baseline/` /
+`latency/` subdirs (embedding) at the given path. Verify you are
+pointing at the correct results directory:
+
+```bash
+# LLM: should contain benchmarks.json
+ls <path>/benchmarks.json
+
+# Embedding: should contain baseline/ or latency/ subdirs
+ls <path>/baseline/ <path>/latency/
+```
+
+### Missing columns show "-"
+
+A dash (`-`) indicates the metric was not present in the result file.
+This can happen with older result formats or partial runs.
+
+### Ansible does not show results
+
+Ensure `show_results=true` is passed as an extra variable:
+
+```bash
+ansible-playbook ... -e "show_results=true"
+```
+
+The display tasks are gated by this variable and default to `false`.
+
+## Related Documentation
+
+- [Dashboards Quick Start](dashboards-quickstart.md) - Interactive
+  Streamlit dashboard for full analysis
+- [Scripts Reference](scripts-reference.md) - All available scripts
+- [Test Execution with Ansible](ansible/test-execution.md) - Running
+  benchmarks

--- a/docs/terminal-results-viewer.md
+++ b/docs/terminal-results-viewer.md
@@ -222,16 +222,19 @@ Use `--no-header` to suppress this block.
 
 ### "Could not detect result format"
 
-The script could not find `benchmarks.json` (LLM) or `baseline/` /
-`latency/` subdirs (embedding) at the given path. Verify you are
-pointing at the correct results directory:
+The script could not find `benchmarks.json` (LLM) or embedding
+result files at the given path. Verify you are pointing at the
+correct results directory:
 
 ```bash
 # LLM: should contain benchmarks.json
 ls <path>/benchmarks.json
 
-# Embedding: should contain baseline/ or latency/ subdirs
+# Embedding: subdirectory layout
 ls <path>/baseline/ <path>/latency/
+
+# Embedding: top-level file layout
+ls <path>/sweep-*.json <path>/concurrent-*.json
 ```
 
 ### Missing columns show "-"


### PR DESCRIPTION
Add view_results.py for displaying benchmark results directly in the terminal without launching a dashboard. Supports both LLM (GuideLLM) and embedding (vllm bench serve) formats with auto-detection.

Add view-results.yml playbook for Ansible-driven results viewing of existing benchmark runs. Add show_results variable to all three benchmark playbooks for auto-display after runs. Include GitHub Pages documentation and cross-references from existing docs.