### PR TITLE
Feat CVE bench

### DIFF
--- a/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
+++ b/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
@@ -769,7 +769,7 @@
           - "Mean File F1:   {{ vloc_mean_file_f1 }}  (Phase A — matches VLoc leaderboard)"
           - "Abstain Rate:   {{ vloc_abstain_rate }}"
           - "TNR:            {{ vloc_tnr }}  (Phase B)"
-          - "FPR:            {{ vloc_fpr }}  (Phase B)"
+          - "False Pos Rate: {{ vloc_fpr }}  (Phase B)"
           - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           - "Wall time:  {{ vloc_wall_time }}s"
           - "Tasks/hr:   {{ vloc_tasks_per_hour }}"

--- a/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
+++ b/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
@@ -89,7 +89,7 @@
         max_model_len: >-
           {%- if max_model_len is defined -%}{{ max_model_len }}
           {%- elif vloc_runner == 'vllm_qwen_3_5' -%}2048
-          {%- elif vloc_runner == 'vllm_antares' -%}8192
+          {%- elif vloc_runner == 'vllm_antares' -%}16384
           {%- else -%}32768{%- endif -%}
         vllm_extra_serve_args: >-
           {%- if vloc_runner == 'vllm_antares' -%}--trust-remote-code
@@ -99,7 +99,7 @@
         vllm_kv_cache_gb: >-
           {%- if vllm_kv_cache_gb is defined -%}{{ vllm_kv_cache_gb }}
           {%- elif vloc_runner == 'vllm_qwen_3_5' -%}10
-          {%- elif vloc_runner == 'vllm_antares' -%}8
+          {%- elif vloc_runner == 'vllm_antares' -%}12
           {%- else -%}16{%- endif -%}
         vloc_model_name: >-
           {%- if vloc_runner == 'vllm_antares' -%}{{ test_model }}

--- a/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
+++ b/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
@@ -89,7 +89,7 @@
         max_model_len: >-
           {%- if max_model_len is defined -%}{{ max_model_len }}
           {%- elif vloc_runner == 'vllm_qwen_3_5' -%}2048
-          {%- elif vloc_runner == 'vllm_antares' -%}16384
+          {%- elif vloc_runner == 'vllm_antares' -%}32768
           {%- else -%}32768{%- endif -%}
         vllm_extra_serve_args: >-
           {%- if vloc_runner == 'vllm_antares' -%}--trust-remote-code
@@ -99,7 +99,7 @@
         vllm_kv_cache_gb: >-
           {%- if vllm_kv_cache_gb is defined -%}{{ vllm_kv_cache_gb }}
           {%- elif vloc_runner == 'vllm_qwen_3_5' -%}10
-          {%- elif vloc_runner == 'vllm_antares' -%}12
+          {%- elif vloc_runner == 'vllm_antares' -%}16
           {%- else -%}16{%- endif -%}
         vloc_model_name: >-
           {%- if vloc_runner == 'vllm_antares' -%}{{ test_model }}

--- a/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
+++ b/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
@@ -36,7 +36,8 @@
 #   -e "vloc_harness_cpuset_mems=1"        # VLoc harness NUMA memory nodes
 #
 # Runner → vLLM argument mapping:
-#   vllm           → (no extra args)              — Granite, generic chat
+#   vllm           → --enable-auto-tool-choice    — Granite, generic chat (tool calling)
+#                    --tool-call-parser granite4
 #   vllm_antares   → --trust-remote-code          — Antares /v1/completions
 #   vllm_qwen_3_5  → --enable-auto-tool-choice    — Qwen3.5 tool calling
 #                    --tool-call-parser qwen3_coder
@@ -786,8 +787,8 @@
           - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           - "Mean File F1:   {{ vloc_mean_file_f1 }}  (Phase A — matches VLoc leaderboard)"
           - "Abstain Rate:   {{ vloc_abstain_rate }}"
-          - "TNR:            {{ vloc_tnr }}  (Phase B)"
-          - "False Pos Rate: {{ vloc_fpr }}  (Phase B)"
+          - "TNR:            {{ vloc_tnr if (vloc_phase_b_n | int) > 0 else 'N/A (Phase B not run)' }}"
+          - "False Pos Rate: {{ vloc_fpr if (vloc_phase_b_n | int) > 0 else 'N/A (Phase B not run)' }}"
           - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           - "Wall time:  {{ vloc_wall_time }}s"
           - "Tasks/hr:   {{ vloc_tasks_per_hour }}"

--- a/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
+++ b/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
@@ -201,7 +201,11 @@
     # Uses shared patch script for single-source, idempotent patching.
     - name: Check if Granite hybrid patch is needed
       ansible.builtin.set_fact:
-        needs_granite_patch: "{{ 'granite-4.0' in hostvars['localhost']['test_model'] }}"
+        needs_granite_patch: >-
+          {{
+            'granite-4.0' in hostvars['localhost']['test_model'] or
+            'antares' in hostvars['localhost']['test_model']
+          }}
 
     - name: Apply Granite hybrid patch via shared script
       ansible.builtin.script:

--- a/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
+++ b/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
@@ -1,0 +1,730 @@
+---
+# ==============================================================================
+# CVE Vulnerability Localization Benchmark (VLoc Bench)
+# ==============================================================================
+# Runs the Cisco VLoc Bench agent harness against a vLLM-served model.
+# Measures File F1 (Phase A) and True Negative Rate (Phase B).
+#
+# Usage:
+#   ansible-playbook -i inventory/hosts.yml llm-benchmark-cve-vloc.yml \
+#     -e "test_model=ibm-granite/granite-4.0-1b" \
+#     -e "vloc_runner=vllm" \
+#     -e "requested_cores=16"
+#
+# Required parameters:
+#   -e "test_model=<HF model ID>"
+#   -e "vloc_runner=<vllm|vllm_antares|vllm_qwen_3_5|vllm_gemma_4>"
+#
+# Optional parameters:
+#   -e "requested_cores=16"           # CPU cores (default: 16)
+#   -e "vloc_phases=a"                # a, b, or ab (default: a)
+#   -e "vloc_workers=1"               # Parallel VLoc workers (default: 1)
+#   -e "vloc_n_limit=5"               # Max tasks, 0=all (default: 5)
+#   -e "vloc_dir=/tmp/vloc-bench"     # DUT-side cache for data/results
+#   -e "vloc_config=configs/default.yaml"  # VLoc config file
+#   -e "max_model_len=4096"           # vLLM max context (default: per-runner)
+#   -e "vllm_dtype=auto"              # Model dtype (default: per-runner)
+#   -e "vllm_port=8200"               # vLLM serve port (default: 8200)
+#   -e "cleanup_after_test=false"     # Keep container running (default: true)
+#
+# Runner → vLLM argument mapping:
+#   vllm           → (no extra args)              — Granite, generic chat
+#   vllm_antares   → --trust-remote-code          — Antares /v1/completions
+#   vllm_qwen_3_5  → --enable-auto-tool-choice    — Qwen3.5 tool calling
+#                    --tool-call-parser qwen3_coder
+#   vllm_gemma_4   → --enable-auto-tool-choice    — Gemma-4 tool calling
+#                    --tool-call-parser gemma4
+# ==============================================================================
+
+# ==============================================================================
+# PHASE 1: Setup and Validation
+# ==============================================================================
+
+- name: "CVE VLoc Bench - Setup"
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Validate required variables
+      ansible.builtin.assert:
+        that:
+          - test_model is defined
+          - test_model | length > 0
+          - vloc_runner is defined
+          - vloc_runner in ['vllm', 'vllm_antares', 'vllm_qwen_3_5', 'vllm_gemma_4']
+        fail_msg: |
+          Missing or invalid required variables. Please provide:
+          -e "test_model=<HF model ID>"
+          -e "vloc_runner=<vllm|vllm_antares|vllm_qwen_3_5|vllm_gemma_4>"
+
+    - name: Initialize test configuration
+      ansible.builtin.set_fact:
+        test_run_id: "{{ lookup('pipe', 'date +%Y%m%d-%H%M%S') }}"
+        vloc_phases: "{{ vloc_phases | default('a') }}"
+        vloc_workers: "{{ vloc_workers | default(1) | int }}"
+        vloc_n_limit: "{{ vloc_n_limit | default(5) | int }}"
+        vloc_dir: "{{ vloc_dir | default('/tmp/vloc-bench') }}"
+        vloc_config: "{{ vloc_config | default('configs/default.yaml') }}"
+        vloc_harness_image: "{{ vloc_harness_image | default('vloc-bench-harness:latest') }}"
+        vloc_sandbox_image: "{{ vloc_sandbox_image | default('vulnerability-localization-benchmark-sandbox:latest') }}"
+        requested_cores: "{{ requested_cores | default(16) | int }}"
+        vllm_port: "{{ vllm_port | default(8200) | int }}"
+        local_results_base: "{{ playbook_dir }}/../../../results/llm"
+
+    - name: Set per-runner defaults
+      ansible.builtin.set_fact:
+        vllm_dtype: >-
+          {%- if vllm_dtype is defined -%}{{ vllm_dtype }}
+          {%- elif vloc_runner == 'vllm_antares' -%}bfloat16
+          {%- else -%}auto{%- endif -%}
+        max_model_len: >-
+          {%- if max_model_len is defined -%}{{ max_model_len }}
+          {%- elif vloc_runner == 'vllm_qwen_3_5' -%}2048
+          {%- elif vloc_runner == 'vllm_antares' -%}8192
+          {%- else -%}4096{%- endif -%}
+        vllm_extra_serve_args: >-
+          {%- if vloc_runner == 'vllm_antares' -%}--trust-remote-code
+          {%- elif vloc_runner == 'vllm_qwen_3_5' -%}--enable-auto-tool-choice --tool-call-parser qwen3_coder
+          {%- elif vloc_runner == 'vllm_gemma_4' -%}--enable-auto-tool-choice --tool-call-parser gemma4
+          {%- else -%}{%- endif -%}
+        vloc_model_name: >-
+          {%- if vloc_runner == 'vllm_antares' -%}{{ test_model }}
+          {%- else -%}{{ test_model }}{%- endif -%}
+
+    - name: Sanitize model name for filesystem
+      ansible.builtin.set_fact:
+        model_safe: "{{ test_model | replace('/', '__') }}"
+        config_id: "{{ requested_cores }}cores-{{ vloc_phases }}-{{ vloc_n_limit }}tasks-{{ vloc_workers }}w"
+
+    - name: Set DUT-side paths
+      ansible.builtin.set_fact:
+        vloc_data_dir: "{{ vloc_dir }}/data"
+        vloc_results_dir: "{{ vloc_dir }}/results/{{ test_run_id }}"
+
+    - name: Create results directory
+      ansible.builtin.file:
+        path: "{{ local_results_base }}/{{ model_safe }}/cve-vloc-{{ test_run_id }}/{{ config_id }}"
+        state: directory
+        mode: "0755"
+
+    - name: Display test configuration
+      ansible.builtin.debug:
+        msg:
+          - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          - "CVE Vulnerability Localization Benchmark"
+          - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          - "Test Run ID: {{ test_run_id }}"
+          - "Model: {{ test_model }}"
+          - "VLoc Runner: {{ vloc_runner }}"
+          - "Phases: {{ vloc_phases }}"
+          - "Workers: {{ vloc_workers }}"
+          - "Task Limit: {{ vloc_n_limit }} (0=all)"
+          - "Cores: {{ requested_cores }}"
+          - "Max Model Len: {{ max_model_len }}"
+          - "Dtype: {{ vllm_dtype }}"
+          - "Port: {{ vllm_port }}"
+          - "VLoc Harness Image: {{ vloc_harness_image }}"
+          - "DUT Data Cache: {{ vloc_data_dir }}"
+          - "Extra vLLM Args: {{ vllm_extra_serve_args | default('(none)') }}"
+          - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# ==============================================================================
+# PHASE 2: Start vLLM Server on DUT
+# ==============================================================================
+
+- name: "Phase 2 - Start vLLM Server on DUT"
+  hosts: dut
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Setup HuggingFace token
+      ansible.builtin.include_role:
+        name: hf_token
+        tasks_from: setup-optional
+
+    - name: Stop any existing vLLM container
+      containers.podman.podman_container:
+        name: "vllm-cve-vloc"
+        state: absent
+      failed_when: false
+
+    - name: Get DUT user home directory
+      ansible.builtin.shell: "echo $HOME"
+      register: dut_home
+      changed_when: false
+
+    # Granite hybrid patch (TODO: remove when vLLM > v0.25.1)
+    # vLLM v0.25.1 missing full_attention layer type — fixed by PR #47867.
+    # Uses shared patch script for single-source, idempotent patching.
+    - name: Check if Granite hybrid patch is needed
+      ansible.builtin.set_fact:
+        needs_granite_patch: "{{ 'granite-4.0' in hostvars['localhost']['test_model'] }}"
+
+    - name: Apply Granite hybrid patch via shared script
+      ansible.builtin.script:
+        cmd: >-
+          {{ playbook_dir }}/../scripts/bash/patch-vllm-granite-hybrid.sh
+          --container-image {{ container_runtime.image }}
+          --output-dir /tmp/vllm-patch
+      when: needs_granite_patch | bool
+      changed_when: true
+      register: granite_patch_result
+
+    - name: Verify Granite patch was applied
+      ansible.builtin.stat:
+        path: /tmp/vllm-patch/granitemoehybrid.py
+      register: granite_patch_file
+      when: needs_granite_patch | bool
+
+    - name: Fail if Granite patch is missing
+      ansible.builtin.assert:
+        that: granite_patch_file.stat.exists
+        fail_msg: >-
+          Granite hybrid patch failed — /tmp/vllm-patch/granitemoehybrid.py not found.
+          Check patch script output: {{ granite_patch_result.stdout | default('') }}
+      when: needs_granite_patch | bool
+
+    # Container entrypoint is "vllm serve", so pass model + args only
+    - name: Build vLLM serve command
+      ansible.builtin.set_fact:
+        vllm_serve_cmd: >-
+          {{ hostvars['localhost']['test_model'] }}
+          --dtype {{ hostvars['localhost']['vllm_dtype'] }}
+          --max-model-len {{ hostvars['localhost']['max_model_len'] }}
+          --host 0.0.0.0
+          --port {{ hostvars['localhost']['vllm_port'] }}
+          {{ hostvars['localhost']['vllm_extra_serve_args'] }}
+
+    - name: Display vLLM command
+      ansible.builtin.debug:
+        msg: "vLLM command: {{ vllm_serve_cmd }}"
+
+    - name: Build volume list
+      ansible.builtin.set_fact:
+        vllm_volumes: >-
+          {{
+            ["{{ dut_home.stdout }}/.cache/huggingface:/root/.cache/huggingface:z"]
+            + (needs_granite_patch | bool) | ternary(
+              ["/tmp/vllm-patch/granitemoehybrid.py:/opt/venv/lib/python3.12/site-packages/vllm/model_executor/models/granitemoehybrid.py:z"],
+              []
+            )
+          }}
+
+    - name: Start vLLM container
+      containers.podman.podman_container:
+        name: "vllm-cve-vloc"
+        image: "{{ container_runtime.image }}"
+        state: started
+        command: "{{ vllm_serve_cmd }}"
+        network_mode: host
+        security_opt: "{{ container_runtime.security_opts }}"
+        cap_add: "{{ container_runtime.capabilities }}"
+        shm_size: "{{ container_runtime.shm_size }}"
+        # Pins cores 0..N-1; on NUMA systems, prefer inventory-driven pinning
+        cpuset_cpus: "0-{{ (hostvars['localhost']['requested_cores'] | int) - 1 }}"
+        env:
+          HF_TOKEN: "{{ hf_token | default('') }}"
+          OMP_NUM_THREADS: "{{ hostvars['localhost']['requested_cores'] }}"
+        volume: "{{ vllm_volumes }}"
+      no_log: true
+
+# ==============================================================================
+# PHASE 3: Health Check
+# ==============================================================================
+
+- name: "Phase 3 - Wait for vLLM Server to be Ready"
+  hosts: dut
+  gather_facts: false
+
+  tasks:
+    - name: Wait for vLLM health endpoint
+      ansible.builtin.uri:
+        url: "http://localhost:{{ hostvars['localhost']['vllm_port'] }}/health"
+        method: GET
+        status_code: 200
+      register: health_check_result
+      retries: "{{ health_check.timeout | int // health_check.interval | int }}"
+      delay: "{{ health_check.interval }}"
+      until: health_check_result.status == 200
+
+    - name: Verify model is loaded
+      ansible.builtin.uri:
+        url: "http://localhost:{{ hostvars['localhost']['vllm_port'] }}/v1/models"
+        method: GET
+        status_code: 200
+      register: models_check
+
+    - name: Display available models
+      ansible.builtin.debug:
+        msg: "Available models: {{ models_check.json.data | map(attribute='id') | list }}"
+
+    - name: Get vLLM version
+      ansible.builtin.uri:
+        url: "http://localhost:{{ hostvars['localhost']['vllm_port'] }}/version"
+        method: GET
+        status_code: 200
+      register: vllm_version_response
+      failed_when: false
+
+    - name: Save vLLM version
+      ansible.builtin.set_fact:
+        detected_vllm_version: "{{ vllm_version_response.json.version | default('unknown') }}"
+      delegate_to: localhost
+      delegate_facts: true
+
+# ==============================================================================
+# PHASE 4: Setup and Run VLoc Bench (containerized)
+# ==============================================================================
+# VLoc Bench runs in a container — nothing is installed natively on the DUT.
+# The harness container spawns sandbox containers on the host via Docker
+# socket passthrough (sibling containers, not Docker-in-Docker).
+
+- name: "Phase 4 - Setup and Run VLoc Bench"
+  hosts: dut
+  become: false
+  gather_facts: false
+
+  vars:
+    vloc_harness_image: "{{ hostvars['localhost']['vloc_harness_image'] }}"
+    vloc_sandbox_image: "{{ hostvars['localhost']['vloc_sandbox_image'] }}"
+    vloc_config: "{{ hostvars['localhost']['vloc_config'] }}"
+    vloc_runner: "{{ hostvars['localhost']['vloc_runner'] }}"
+    vloc_phases: "{{ hostvars['localhost']['vloc_phases'] }}"
+    vloc_workers: "{{ hostvars['localhost']['vloc_workers'] }}"
+    vloc_n_limit: "{{ hostvars['localhost']['vloc_n_limit'] }}"
+    vloc_model_name: "{{ hostvars['localhost']['vloc_model_name'] }}"
+    vllm_port: "{{ hostvars['localhost']['vllm_port'] }}"
+    test_run_id: "{{ hostvars['localhost']['test_run_id'] }}"
+    config_id: "{{ hostvars['localhost']['config_id'] }}"
+    model_safe: "{{ hostvars['localhost']['model_safe'] }}"
+    vloc_data_dir: "{{ hostvars['localhost']['vloc_data_dir'] }}"
+    vloc_results_dir: "{{ hostvars['localhost']['vloc_results_dir'] }}"
+
+  tasks:
+    # ------------------------------------------------------------------
+    # 4.1 Detect Podman socket for Docker socket passthrough
+    # ------------------------------------------------------------------
+    - name: Get user ID
+      ansible.builtin.command: id -u
+      register: dut_uid
+      changed_when: false
+
+    - name: Set Podman socket path
+      ansible.builtin.set_fact:
+        podman_socket: "/run/user/{{ dut_uid.stdout }}/podman/podman.sock"
+
+    - name: Ensure Podman socket is active
+      ansible.builtin.systemd:
+        name: podman.socket
+        scope: user
+        state: started
+        enabled: true
+
+    - name: Verify Podman socket exists
+      ansible.builtin.stat:
+        path: "{{ podman_socket }}"
+      register: socket_check
+
+    - name: Fail if Podman socket not available
+      ansible.builtin.assert:
+        that: socket_check.stat.exists
+        fail_msg: >-
+          Podman socket not found at {{ podman_socket }}.
+          Run: systemctl --user enable --now podman.socket
+
+    # ------------------------------------------------------------------
+    # 4.2 Build VLoc harness container image
+    # ------------------------------------------------------------------
+    - name: Check if VLoc harness image exists
+      ansible.builtin.command:
+        cmd: podman image exists {{ vloc_harness_image }}
+      register: harness_image_check
+      failed_when: false
+      changed_when: false
+
+    - name: Create harness image build directory
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: vloc-build-
+      register: build_dir
+      when: harness_image_check.rc != 0
+
+    - name: Copy VLoc harness Dockerfile to DUT
+      ansible.builtin.copy:
+        src: "{{ playbook_dir }}/../containers/vloc-bench/Dockerfile"
+        dest: "{{ build_dir.path }}/Dockerfile"
+        mode: "0644"
+      when: harness_image_check.rc != 0
+
+    - name: Build VLoc harness image
+      ansible.builtin.command:
+        cmd: podman build -t {{ vloc_harness_image }} {{ build_dir.path }}/
+      when: harness_image_check.rc != 0
+      changed_when: true
+      timeout: 600
+
+    - name: Clean up build directory
+      ansible.builtin.file:
+        path: "{{ build_dir.path }}"
+        state: absent
+      when: build_dir.path is defined
+
+    # ------------------------------------------------------------------
+    # 4.3 Build VLoc sandbox image on host
+    # ------------------------------------------------------------------
+    - name: Check if sandbox image exists
+      ansible.builtin.command:
+        cmd: podman image exists {{ vloc_sandbox_image }}
+      register: sandbox_image_check
+      failed_when: false
+      changed_when: false
+
+    - name: Extract sandbox Dockerfile from harness image
+      ansible.builtin.shell: >-
+        podman run --rm {{ vloc_harness_image }}
+        cat /opt/vloc-bench/Dockerfile
+        > /tmp/vloc-sandbox-Dockerfile
+      when: sandbox_image_check.rc != 0
+      changed_when: true
+
+    - name: Build sandbox image
+      ansible.builtin.command:
+        cmd: podman build -t {{ vloc_sandbox_image }} -f /tmp/vloc-sandbox-Dockerfile /tmp
+      when: sandbox_image_check.rc != 0
+      changed_when: true
+      timeout: 300
+
+    # ------------------------------------------------------------------
+    # 4.4 Download VLoc dataset (cached between runs)
+    # ------------------------------------------------------------------
+    - name: Create data directory
+      ansible.builtin.file:
+        path: "{{ vloc_data_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Check if dataset is downloaded
+      ansible.builtin.find:
+        paths: "{{ vloc_data_dir }}"
+        patterns: "*.zip"
+      register: dataset_check
+
+    - name: Download VLoc dataset via harness container
+      ansible.builtin.command:
+        cmd: >-
+          podman run --rm
+          -v {{ vloc_data_dir }}:/opt/vloc-bench/data/ghsa-vulns:z
+          --entrypoint python3
+          {{ vloc_harness_image }}
+          data/downloader_and_verifier.py --source-dir data/
+      when: dataset_check.matched == 0
+      changed_when: true
+      timeout: 3600
+
+    # ------------------------------------------------------------------
+    # 4.5 Run VLoc Bench CLI
+    # ------------------------------------------------------------------
+    - name: Create results directory on DUT
+      ansible.builtin.file:
+        path: "{{ vloc_results_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Remove stale VLoc run container
+      containers.podman.podman_container:
+        name: "vloc-bench-run"
+        state: absent
+      failed_when: false
+
+    - name: Display VLoc Bench command
+      ansible.builtin.debug:
+        msg: >-
+          podman run --network host
+          -v {{ podman_socket }}:/var/run/docker.sock:z
+          -v {{ vloc_data_dir }}:/opt/vloc-bench/data/ghsa-vulns:z
+          -v {{ vloc_results_dir }}:/results:z
+          {{ vloc_harness_image }}
+          python3 -m vulnerability_localization_benchmark.cli
+          --config {{ vloc_config }}
+          --api-base http://localhost:{{ vllm_port }}/v1
+          --model-name {{ vloc_model_name }}
+          --runner {{ vloc_runner }}
+          --phases {{ vloc_phases }}
+          --workers {{ vloc_workers }}
+          --n-limit {{ vloc_n_limit }}
+          --output-dir /results
+          --permissive
+
+    - name: Record start time
+      ansible.builtin.set_fact:
+        vloc_start_time: "{{ lookup('pipe', 'date +%s') }}"
+
+    - name: Start VLoc Bench container
+      containers.podman.podman_container:
+        name: "vloc-bench-run"
+        image: "{{ vloc_harness_image }}"
+        state: started
+        command: >-
+          python3 -m vulnerability_localization_benchmark.cli
+          --config {{ vloc_config }}
+          --api-base http://localhost:{{ vllm_port }}/v1
+          --model-name {{ vloc_model_name }}
+          --runner {{ vloc_runner }}
+          --phases {{ vloc_phases }}
+          --workers {{ vloc_workers }}
+          --n-limit {{ vloc_n_limit }}
+          --output-dir /results
+          --permissive
+        network_mode: host
+        env:
+          PYTHONPATH: "/opt/vloc-bench/src"
+        volume:
+          - "{{ podman_socket }}:/var/run/docker.sock:z"
+          - "{{ vloc_data_dir }}:/opt/vloc-bench/data/ghsa-vulns:z"
+          - "{{ vloc_results_dir }}:/results:z"
+        detach: true
+        rm: false
+
+    - name: Wait for VLoc Bench to complete
+      ansible.builtin.command:
+        cmd: podman wait vloc-bench-run
+      register: vloc_wait_result
+      changed_when: false
+      timeout: 14400
+
+    - name: Get VLoc exit code
+      ansible.builtin.command:
+        cmd: podman inspect vloc-bench-run --format '{% raw %}{{.State.ExitCode}}{% endraw %}'
+      register: vloc_exit_code
+      changed_when: false
+
+    - name: Capture VLoc Bench logs
+      ansible.builtin.command:
+        cmd: podman logs vloc-bench-run
+      register: vloc_logs
+      changed_when: false
+
+    - name: Record end time and wall time
+      ansible.builtin.set_fact:
+        vloc_end_time: "{{ lookup('pipe', 'date +%s') }}"
+        vloc_wall_time: "{{ (lookup('pipe', 'date +%s') | int) - (vloc_start_time | int) }}"
+
+    - name: Display VLoc Bench output
+      ansible.builtin.debug:
+        msg: "{{ vloc_logs.stdout_lines | default([]) }}"
+
+    - name: Display wall time
+      ansible.builtin.debug:
+        msg: "VLoc Bench completed in {{ vloc_wall_time }}s (exit code: {{ vloc_exit_code.stdout }})"
+
+    - name: Remove VLoc run container
+      containers.podman.podman_container:
+        name: "vloc-bench-run"
+        state: absent
+
+# ==============================================================================
+# PHASE 5: Parse and Collect Results
+# ==============================================================================
+
+- name: "Phase 5 - Parse and Collect Results"
+  hosts: dut
+  become: false
+  gather_facts: false
+
+  vars:
+    vloc_harness_image: "{{ hostvars['localhost']['vloc_harness_image'] }}"
+    vloc_results_dir: "{{ hostvars['localhost']['vloc_results_dir'] }}"
+    test_run_id: "{{ hostvars['localhost']['test_run_id'] }}"
+    config_id: "{{ hostvars['localhost']['config_id'] }}"
+    model_safe: "{{ hostvars['localhost']['model_safe'] }}"
+    local_results_base: "{{ hostvars['localhost']['local_results_base'] }}"
+    results_dest: "{{ local_results_base }}/{{ model_safe }}/cve-vloc-{{ test_run_id }}/{{ config_id }}"
+
+  tasks:
+    - name: Check for aggregate results
+      ansible.builtin.stat:
+        path: "{{ vloc_results_dir }}/aggregate.json"
+      register: aggregate_check
+
+    - name: Read aggregate results
+      ansible.builtin.slurp:
+        src: "{{ vloc_results_dir }}/aggregate.json"
+      register: aggregate_raw
+      when: aggregate_check.stat.exists
+
+    - name: Parse aggregate results
+      ansible.builtin.set_fact:
+        aggregate_data: "{{ aggregate_raw.content | b64decode | from_json }}"
+      when: aggregate_check.stat.exists
+
+    # Upstream aggregate.json schema (vulnerability_localization_benchmark/scoring.py):
+    #   { "phase_a": { "mean_file_f1": float, "abstain_rate": float, "n_entries": int },
+    #     "phase_b": { "true_negative_rate": float, "false_positive_rate": float, "n_entries": int } }
+    - name: Extract Phase A metrics
+      ansible.builtin.set_fact:
+        vloc_mean_file_f1: "{{ aggregate_data.phase_a.mean_file_f1 | default(0.0) }}"
+        vloc_abstain_rate: "{{ aggregate_data.phase_a.abstain_rate | default(0.0) }}"
+        vloc_phase_a_n: "{{ aggregate_data.phase_a.n_entries | default(0) }}"
+      when: aggregate_check.stat.exists and aggregate_data.phase_a is defined
+
+    - name: Extract Phase B metrics
+      ansible.builtin.set_fact:
+        vloc_tnr: "{{ aggregate_data.phase_b.true_negative_rate | default(0.0) }}"
+        vloc_fpr: "{{ aggregate_data.phase_b.false_positive_rate | default(0.0) }}"
+        vloc_phase_b_n: "{{ aggregate_data.phase_b.n_entries | default(0) }}"
+      when: aggregate_check.stat.exists and aggregate_data.phase_b is defined
+
+    - name: Set defaults for missing phases
+      ansible.builtin.set_fact:
+        vloc_mean_file_f1: "{{ vloc_mean_file_f1 | default(0.0) }}"
+        vloc_abstain_rate: "{{ vloc_abstain_rate | default(0.0) }}"
+        vloc_phase_a_n: "{{ vloc_phase_a_n | default(0) }}"
+        vloc_tnr: "{{ vloc_tnr | default('null') }}"
+        vloc_fpr: "{{ vloc_fpr | default('null') }}"
+        vloc_phase_b_n: "{{ vloc_phase_b_n | default(0) }}"
+      when: aggregate_check.stat.exists
+
+    - name: Compute total tasks completed
+      ansible.builtin.set_fact:
+        vloc_tasks_completed: "{{ (vloc_phase_a_n | int) + (vloc_phase_b_n | int) }}"
+      when: aggregate_check.stat.exists
+
+    - name: Set default metrics if no aggregate
+      ansible.builtin.set_fact:
+        vloc_mean_file_f1: 0.0
+        vloc_abstain_rate: 0.0
+        vloc_phase_a_n: 0
+        vloc_tnr: "null"
+        vloc_fpr: "null"
+        vloc_phase_b_n: 0
+        vloc_tasks_completed: 0
+      when: not aggregate_check.stat.exists
+
+    - name: Warn if aggregate.json missing but CLI succeeded
+      ansible.builtin.debug:
+        msg: "WARNING: aggregate.json not found — results will be zeros. Check VLoc output dir."
+      when: not aggregate_check.stat.exists
+
+    - name: Compute tasks per hour
+      ansible.builtin.set_fact:
+        vloc_wall_time: "{{ hostvars['localhost']['vloc_wall_time'] | default(0) }}"
+        vloc_tasks_per_hour: >-
+          {{ ((vloc_tasks_completed | float) / ((hostvars['localhost']['vloc_wall_time'] | float) / 3600.0)) | round(2)
+             if (hostvars['localhost']['vloc_wall_time'] | float) > 0 else 0.0 }}
+
+    - name: Get VLoc Bench commit from harness image
+      ansible.builtin.command:
+        cmd: podman run --rm {{ vloc_harness_image }} git rev-parse --short HEAD
+      register: vloc_commit
+      changed_when: false
+      failed_when: false
+
+    - name: Write test metadata
+      ansible.builtin.copy:
+        content: |
+          {
+            "test_run_id": "{{ test_run_id }}",
+            "timestamp": "{{ lookup('pipe', 'date -Iseconds') }}",
+            "test_type": "cve-vloc",
+            "use_case": "cve_localization",
+            "model": "{{ hostvars['localhost']['test_model'] }}",
+            "model_source": "huggingface",
+            "vloc_runner": "{{ hostvars['localhost']['vloc_runner'] }}",
+            "vloc_phases": "{{ hostvars['localhost']['vloc_phases'] }}",
+            "configuration": {
+              "cores": {{ hostvars['localhost']['requested_cores'] }},
+              "workers": {{ hostvars['localhost']['vloc_workers'] }},
+              "n_limit": {{ hostvars['localhost']['vloc_n_limit'] }},
+              "max_model_len": {{ hostvars['localhost']['max_model_len'] }},
+              "vllm_dtype": "{{ hostvars['localhost']['vllm_dtype'] }}",
+              "vllm_extra_serve_args": "{{ hostvars['localhost']['vllm_extra_serve_args'] | default('') }}"
+            },
+            "environment": {
+              "container_image": "{{ container_runtime.image }}",
+              "vllm_version": "{{ hostvars['localhost']['detected_vllm_version'] | default('unknown') }}",
+              "vloc_bench_commit": "{{ vloc_commit.stdout | default('unknown') }}"
+            }
+          }
+        dest: "{{ results_dest }}/test-metadata.json"
+        mode: "0644"
+      delegate_to: localhost
+
+    - name: Write results
+      ansible.builtin.copy:
+        content: |
+          {
+            "test_run_id": "{{ test_run_id }}",
+            "timestamp": "{{ lookup('pipe', 'date -Iseconds') }}",
+            "test_type": "cve-vloc",
+            "use_case": "cve_localization",
+            "model": "{{ hostvars['localhost']['test_model'] }}",
+            "vloc_runner": "{{ hostvars['localhost']['vloc_runner'] }}",
+            "vloc_phases": "{{ hostvars['localhost']['vloc_phases'] }}",
+            "metrics": {
+              "mean_file_f1": {{ vloc_mean_file_f1 }},
+              "abstain_rate": {{ vloc_abstain_rate }},
+              "true_negative_rate": {{ vloc_tnr }},
+              "false_positive_rate": {{ vloc_fpr }},
+              "phase_a_tasks": {{ vloc_phase_a_n }},
+              "phase_b_tasks": {{ vloc_phase_b_n }},
+              "tasks_completed": {{ vloc_tasks_completed }},
+              "wall_time_seconds": {{ vloc_wall_time }},
+              "tasks_per_hour": {{ vloc_tasks_per_hour }}
+            }
+          }
+        dest: "{{ results_dest }}/results.json"
+        mode: "0644"
+      delegate_to: localhost
+
+    - name: Copy VLoc Bench raw output
+      ansible.posix.synchronize:
+        src: "{{ vloc_results_dir }}/"
+        dest: "{{ results_dest }}/vloc-output/"
+        mode: pull
+        recursive: true
+      failed_when: false
+
+    - name: Display results summary
+      ansible.builtin.debug:
+        msg:
+          - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          - "CVE VLoc Bench Results"
+          - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          - "Model: {{ hostvars['localhost']['test_model'] }}"
+          - "Runner: {{ hostvars['localhost']['vloc_runner'] }}"
+          - "Phases: {{ hostvars['localhost']['vloc_phases'] }}"
+          - "Tasks completed: {{ vloc_tasks_completed }} (A={{ vloc_phase_a_n }}, B={{ vloc_phase_b_n }})"
+          - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          - "Mean File F1:   {{ vloc_mean_file_f1 }}  (Phase A — matches VLoc leaderboard)"
+          - "Abstain Rate:   {{ vloc_abstain_rate }}"
+          - "TNR:            {{ vloc_tnr }}  (Phase B)"
+          - "FPR:            {{ vloc_fpr }}  (Phase B)"
+          - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          - "Wall time:  {{ vloc_wall_time }}s"
+          - "Tasks/hr:   {{ vloc_tasks_per_hour }}"
+          - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          - "Results:    {{ results_dest }}"
+          - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# ==============================================================================
+# PHASE 6: Cleanup
+# ==============================================================================
+
+- name: "Phase 6 - Cleanup (if requested)"
+  hosts: dut
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Stop vLLM container
+      containers.podman.podman_container:
+        name: "vllm-cve-vloc"
+        state: absent
+      when: cleanup_after_test | default(true) | bool
+
+    - name: Display cleanup status
+      ansible.builtin.debug:
+        msg: >-
+          vLLM server {{ 'stopped and removed' if (cleanup_after_test | default(true) | bool)
+          else 'still running — use -e cleanup_after_test=true to stop' }}

--- a/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
+++ b/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
@@ -89,7 +89,7 @@
           {%- if max_model_len is defined -%}{{ max_model_len }}
           {%- elif vloc_runner == 'vllm_qwen_3_5' -%}2048
           {%- elif vloc_runner == 'vllm_antares' -%}8192
-          {%- else -%}4096{%- endif -%}
+          {%- else -%}32768{%- endif -%}
         vllm_extra_serve_args: >-
           {%- if vloc_runner == 'vllm_antares' -%}--trust-remote-code
           {%- elif vloc_runner == 'vllm_qwen_3_5' -%}--enable-auto-tool-choice --tool-call-parser qwen3_coder
@@ -99,7 +99,7 @@
           {%- if vllm_kv_cache_gb is defined -%}{{ vllm_kv_cache_gb }}
           {%- elif vloc_runner == 'vllm_qwen_3_5' -%}10
           {%- elif vloc_runner == 'vllm_antares' -%}8
-          {%- else -%}4{%- endif -%}
+          {%- else -%}16{%- endif -%}
         vloc_model_name: >-
           {%- if vloc_runner == 'vllm_antares' -%}{{ test_model }}
           {%- else -%}{{ test_model }}{%- endif -%}

--- a/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
+++ b/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
@@ -150,7 +150,7 @@
       failed_when: false
 
     - name: Get DUT user home directory
-      ansible.builtin.shell: "echo $HOME"
+      ansible.builtin.shell: "getent passwd {{ ansible_user }} | cut -d: -f6"
       register: dut_home
       changed_when: false
 
@@ -185,6 +185,14 @@
           Check patch script output: {{ granite_patch_result.stdout | default('') }}
       when: needs_granite_patch | bool
 
+    - name: Verify Granite patch contains full_attention fix
+      ansible.builtin.command:
+        cmd: grep -q 'full_attention' /tmp/vllm-patch/granitemoehybrid.py
+      register: granite_patch_content
+      changed_when: false
+      failed_when: granite_patch_content.rc != 0
+      when: needs_granite_patch | bool
+
     # Container entrypoint is "vllm serve", so pass model + args only
     - name: Build vLLM serve command
       ansible.builtin.set_fact:
@@ -204,7 +212,7 @@
       ansible.builtin.set_fact:
         vllm_volumes: >-
           {{
-            ["{{ dut_home.stdout }}/.cache/huggingface:/root/.cache/huggingface:z"]
+            [dut_home.stdout ~ "/.cache/huggingface:/root/.cache/huggingface:z"]
             + (needs_granite_patch | bool) | ternary(
               ["/tmp/vllm-patch/granitemoehybrid.py:/opt/venv/lib/python3.12/site-packages/vllm/model_executor/models/granitemoehybrid.py:z"],
               []
@@ -286,6 +294,7 @@
   gather_facts: false
 
   vars:
+    ansible_become: false
     vloc_harness_image: "{{ hostvars['localhost']['vloc_harness_image'] }}"
     vloc_sandbox_image: "{{ hostvars['localhost']['vloc_sandbox_image'] }}"
     vloc_config: "{{ hostvars['localhost']['vloc_config'] }}"
@@ -372,6 +381,9 @@
 
     # ------------------------------------------------------------------
     # 4.3 Build VLoc sandbox image on host
+    # Canonical name: vulnerability-localization-benchmark-sandbox:latest
+    # Must match sandbox.image in configs/default.yaml (upstream omits :latest
+    # but Podman/Docker resolve bare names to :latest).
     # ------------------------------------------------------------------
     - name: Check if sandbox image exists
       ansible.builtin.command:
@@ -417,7 +429,7 @@
           -v {{ vloc_data_dir }}:/opt/vloc-bench/data/ghsa-vulns:z
           --entrypoint python3
           {{ vloc_harness_image }}
-          data/downloader_and_verifier.py --source-dir data/
+          data/downloader_and_verifier.py --output-dir data/ghsa-vulns
       when: dataset_check.matched == 0
       changed_when: true
       timeout: 3600
@@ -518,6 +530,17 @@
       ansible.builtin.debug:
         msg: "VLoc Bench completed in {{ vloc_wall_time }}s (exit code: {{ vloc_exit_code.stdout }})"
 
+    - name: Fail on non-zero VLoc exit code
+      ansible.builtin.fail:
+        msg: >-
+          VLoc Bench exited with code {{ vloc_exit_code.stdout }}.
+          Override with -e vloc_allow_failure=true to continue anyway.
+          Last 20 log lines:
+          {{ (vloc_logs.stdout_lines | default([]))[-20:] | join('\n') }}
+      when:
+        - vloc_exit_code.stdout | int != 0
+        - not (vloc_allow_failure | default(false) | bool)
+
     - name: Remove VLoc run container
       containers.podman.podman_container:
         name: "vloc-bench-run"
@@ -533,6 +556,7 @@
   gather_facts: false
 
   vars:
+    ansible_become: false
     vloc_harness_image: "{{ hostvars['localhost']['vloc_harness_image'] }}"
     vloc_results_dir: "{{ hostvars['localhost']['vloc_results_dir'] }}"
     test_run_id: "{{ hostvars['localhost']['test_run_id'] }}"
@@ -606,12 +630,12 @@
         msg: "WARNING: aggregate.json not found — results will be zeros. Check VLoc output dir."
       when: not aggregate_check.stat.exists
 
+    # vloc_wall_time lives on the dut host (set in Phase 4) — do NOT read from localhost
     - name: Compute tasks per hour
       ansible.builtin.set_fact:
-        vloc_wall_time: "{{ hostvars['localhost']['vloc_wall_time'] | default(0) }}"
         vloc_tasks_per_hour: >-
-          {{ ((vloc_tasks_completed | float) / ((hostvars['localhost']['vloc_wall_time'] | float) / 3600.0)) | round(2)
-             if (hostvars['localhost']['vloc_wall_time'] | float) > 0 else 0.0 }}
+          {{ ((vloc_tasks_completed | float) / ((vloc_wall_time | float) / 3600.0)) | round(2)
+             if (vloc_wall_time | default(0) | float) > 0 else 0.0 }}
 
     - name: Get VLoc Bench commit from harness image
       ansible.builtin.command:

--- a/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
+++ b/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
@@ -28,6 +28,13 @@
 #   -e "vllm_port=8200"               # vLLM serve port (default: 8200)
 #   -e "cleanup_after_test=false"     # Keep container running (default: true)
 #
+# NUMA / CPU pinning (optional — default is no NUMA binding):
+#   -e "vloc_vllm_cpuset_cpus=0-23"       # vLLM CPU cores (default: 0-{N-1})
+#   -e "vloc_vllm_cpuset_mems=0"           # vLLM NUMA memory nodes
+#   -e "vloc_vllm_omp_bind=0-23"           # vLLM OMP thread binding
+#   -e "vloc_harness_cpuset_cpus=24-47"    # VLoc harness CPU cores
+#   -e "vloc_harness_cpuset_mems=1"        # VLoc harness NUMA memory nodes
+#
 # Runner → vLLM argument mapping:
 #   vllm           → (no extra args)              — Granite, generic chat
 #   vllm_antares   → --trust-remote-code          — Antares /v1/completions
@@ -97,6 +104,19 @@
           {%- if vloc_runner == 'vllm_antares' -%}{{ test_model }}
           {%- else -%}{{ test_model }}{%- endif -%}
 
+    - name: Set NUMA / CPU pinning configuration
+      ansible.builtin.set_fact:
+        vloc_vllm_cpuset_cpus: >-
+          {{ vloc_vllm_cpuset_cpus | default('0-' ~ ((requested_cores | int) - 1)) }}
+        vloc_vllm_cpuset_mems: >-
+          {{ vloc_vllm_cpuset_mems | default('') }}
+        vloc_vllm_omp_bind: >-
+          {{ vloc_vllm_omp_bind | default('') }}
+        vloc_harness_cpuset_cpus: >-
+          {{ vloc_harness_cpuset_cpus | default('') }}
+        vloc_harness_cpuset_mems: >-
+          {{ vloc_harness_cpuset_mems | default('') }}
+
     - name: Sanitize model name for filesystem
       ansible.builtin.set_fact:
         model_safe: "{{ test_model | replace('/', '__') }}"
@@ -132,6 +152,11 @@
           - "VLoc Harness Image: {{ vloc_harness_image }}"
           - "DUT Data Cache: {{ vloc_data_dir }}"
           - "KV Cache: {{ vllm_kv_cache_gb }} GB (VLLM_CPU_KVCACHE_SPACE)"
+          - "vLLM CPUs: {{ vloc_vllm_cpuset_cpus }}"
+          - "vLLM NUMA Mems: {{ vloc_vllm_cpuset_mems | default('(auto)', true) }}"
+          - "vLLM OMP Bind: {{ vloc_vllm_omp_bind | default('(none)', true) }}"
+          - "Harness CPUs: {{ vloc_harness_cpuset_cpus | default('(unpinned)', true) }}"
+          - "Harness NUMA Mems: {{ vloc_harness_cpuset_mems | default('(auto)', true) }}"
           - "Extra vLLM Args: {{ vllm_extra_serve_args | default('(none)') }}"
           - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
@@ -236,12 +261,13 @@
         security_opt: "{{ container_runtime.security_opts }}"
         cap_add: "{{ container_runtime.capabilities }}"
         shm_size: "{{ container_runtime.shm_size }}"
-        # Pins cores 0..N-1; on NUMA systems, prefer inventory-driven pinning
-        cpuset_cpus: "0-{{ (hostvars['localhost']['requested_cores'] | int) - 1 }}"
+        cpuset_cpus: "{{ hostvars['localhost']['vloc_vllm_cpuset_cpus'] }}"
+        cpuset_mems: "{{ hostvars['localhost']['vloc_vllm_cpuset_mems'] | default(omit, true) }}"
         env:
           HF_TOKEN: "{{ hf_token | default('') }}"
           OMP_NUM_THREADS: "{{ hostvars['localhost']['requested_cores'] }}"
           VLLM_CPU_KVCACHE_SPACE: "{{ hostvars['localhost']['vllm_kv_cache_gb'] }}"
+          VLLM_CPU_OMP_THREADS_BIND: "{{ hostvars['localhost']['vloc_vllm_omp_bind'] | default(omit, true) }}"
         volume: "{{ vllm_volumes }}"
       no_log: true
 
@@ -428,6 +454,7 @@
       ansible.builtin.find:
         paths: "{{ vloc_data_dir }}"
         patterns: "*.zip"
+        recurse: true
       register: dataset_check
 
     - name: Download VLoc dataset via harness container
@@ -497,10 +524,14 @@
           --output-dir /results
           --permissive
         network_mode: host
+        security_opt:
+          - "label=disable"
+        cpuset_cpus: "{{ hostvars['localhost']['vloc_harness_cpuset_cpus'] | default(omit, true) }}"
+        cpuset_mems: "{{ hostvars['localhost']['vloc_harness_cpuset_mems'] | default(omit, true) }}"
         env:
           PYTHONPATH: "/opt/vloc-bench/src"
         volume:
-          - "{{ podman_socket }}:/var/run/docker.sock:z"
+          - "{{ podman_socket }}:/var/run/docker.sock"
           - "{{ vloc_data_dir }}:/opt/vloc-bench/data/ghsa-vulns:z"
           - "{{ vloc_results_dir }}:/results:z"
         detach: true
@@ -670,7 +701,14 @@
               "n_limit": {{ hostvars['localhost']['vloc_n_limit'] }},
               "max_model_len": {{ hostvars['localhost']['max_model_len'] }},
               "vllm_dtype": "{{ hostvars['localhost']['vllm_dtype'] }}",
-              "vllm_extra_serve_args": "{{ hostvars['localhost']['vllm_extra_serve_args'] | default('') }}"
+              "vllm_extra_serve_args": "{{ hostvars['localhost']['vllm_extra_serve_args'] | default('') }}",
+              "numa": {
+                "vllm_cpuset_cpus": "{{ hostvars['localhost']['vloc_vllm_cpuset_cpus'] }}",
+                "vllm_cpuset_mems": "{{ hostvars['localhost']['vloc_vllm_cpuset_mems'] | default('', true) }}",
+                "vllm_omp_bind": "{{ hostvars['localhost']['vloc_vllm_omp_bind'] | default('', true) }}",
+                "harness_cpuset_cpus": "{{ hostvars['localhost']['vloc_harness_cpuset_cpus'] | default('', true) }}",
+                "harness_cpuset_mems": "{{ hostvars['localhost']['vloc_harness_cpuset_mems'] | default('', true) }}"
+              }
             },
             "environment": {
               "container_image": "{{ container_runtime.image }}",

--- a/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
+++ b/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
@@ -71,7 +71,7 @@
         vloc_phases: "{{ vloc_phases | default('a') }}"
         vloc_workers: "{{ vloc_workers | default(1) | int }}"
         vloc_n_limit: "{{ vloc_n_limit | default(5) | int }}"
-        vloc_dir: "{{ vloc_dir | default('/tmp/vloc-bench') }}"
+        vloc_dir: "{{ vloc_dir | default('') }}"
         vloc_config: "{{ vloc_config | default('configs/default.yaml') }}"
         vloc_harness_image: "{{ vloc_harness_image | default('vloc-bench-harness:latest') }}"
         vloc_sandbox_image: "{{ vloc_sandbox_image | default('vulnerability-localization-benchmark-sandbox:latest') }}"
@@ -94,7 +94,7 @@
           {%- if vloc_runner == 'vllm_antares' -%}--trust-remote-code
           {%- elif vloc_runner == 'vllm_qwen_3_5' -%}--enable-auto-tool-choice --tool-call-parser qwen3_coder
           {%- elif vloc_runner == 'vllm_gemma_4' -%}--enable-auto-tool-choice --tool-call-parser gemma4
-          {%- else -%}{%- endif -%}
+          {%- else -%}--enable-auto-tool-choice --tool-call-parser granite4{%- endif -%}
         vllm_kv_cache_gb: >-
           {%- if vllm_kv_cache_gb is defined -%}{{ vllm_kv_cache_gb }}
           {%- elif vloc_runner == 'vllm_qwen_3_5' -%}10
@@ -122,10 +122,10 @@
         model_safe: "{{ test_model | replace('/', '__') }}"
         config_id: "{{ requested_cores }}cores-{{ vloc_phases }}-{{ vloc_n_limit }}tasks-{{ vloc_workers }}w"
 
-    - name: Set DUT-side paths
+    - name: Set DUT-side paths (placeholder; resolved from DUT home in Phase 2 if vloc_dir unset)
       ansible.builtin.set_fact:
-        vloc_data_dir: "{{ vloc_dir }}/data"
-        vloc_results_dir: "{{ vloc_dir }}/results/{{ test_run_id }}"
+        vloc_data_dir: "{{ (vloc_dir ~ '/data') if vloc_dir else '' }}"
+        vloc_results_dir: "{{ (vloc_dir ~ '/results/' ~ test_run_id) if vloc_dir else '' }}"
 
     - name: Create results directory
       ansible.builtin.file:
@@ -150,7 +150,7 @@
           - "Dtype: {{ vllm_dtype }}"
           - "Port: {{ vllm_port }}"
           - "VLoc Harness Image: {{ vloc_harness_image }}"
-          - "DUT Data Cache: {{ vloc_data_dir }}"
+          - "DUT Data Cache: {{ vloc_data_dir if vloc_data_dir else '(auto: ~/vloc-bench/data on DUT)' }}"
           - "KV Cache: {{ vllm_kv_cache_gb }} GB (VLLM_CPU_KVCACHE_SPACE)"
           - "vLLM CPUs: {{ vloc_vllm_cpuset_cpus }}"
           - "vLLM NUMA Mems: {{ vloc_vllm_cpuset_mems | default('(auto)', true) }}"
@@ -185,6 +185,15 @@
       ansible.builtin.shell: "getent passwd {{ ansible_user }} | cut -d: -f6"
       register: dut_home
       changed_when: false
+
+    - name: Resolve vloc working directory from DUT home (when not explicitly set)
+      ansible.builtin.set_fact:
+        vloc_dir: "{{ dut_home.stdout }}/vloc-bench"
+        vloc_data_dir: "{{ dut_home.stdout }}/vloc-bench/data"
+        vloc_results_dir: "{{ dut_home.stdout }}/vloc-bench/results/{{ hostvars['localhost']['test_run_id'] }}"
+      delegate_to: localhost
+      delegate_facts: true
+      when: not hostvars['localhost']['vloc_dir']
 
     # Granite hybrid patch (TODO: remove when vLLM > v0.25.1)
     # vLLM v0.25.1 missing full_attention layer type — fixed by PR #47867.
@@ -250,6 +259,14 @@
               []
             )
           }}
+
+    - name: Ensure HuggingFace cache directory exists
+      ansible.builtin.file:
+        path: "{{ dut_home.stdout }}/.cache/huggingface"
+        state: directory
+        mode: "0755"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
 
     - name: Start vLLM container
       containers.podman.podman_container:
@@ -467,6 +484,7 @@
           data/downloader_and_verifier.py --output-dir data/ghsa-vulns
       when: dataset_check.matched == 0
       changed_when: true
+      failed_when: false
       timeout: 3600
 
     # ------------------------------------------------------------------

--- a/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
+++ b/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
@@ -26,6 +26,9 @@
 #   -e "vllm_dtype=auto"              # Model dtype (default: per-runner)
 #   -e "vllm_kv_cache_gb=4"            # CPU KV cache GB (default: per-runner)
 #   -e "vllm_port=8200"               # vLLM serve port (default: 8200)
+#   -e "vllm_container_image=..."     # Override vLLM image (default: container_runtime.image)
+#   -e "vloc_permissive=true"         # Skip sandbox command allowlist (default: false)
+#   -e "vloc_allow_empty=true"        # Allow 0 completed tasks (default: false)
 #   -e "cleanup_after_test=false"     # Keep container running (default: true)
 #
 # NUMA / CPU pinning (optional — default is no NUMA binding):
@@ -78,6 +81,9 @@
         vloc_sandbox_image: "{{ vloc_sandbox_image | default('vulnerability-localization-benchmark-sandbox:latest') }}"
         requested_cores: "{{ requested_cores | default(16) | int }}"
         vllm_port: "{{ vllm_port | default(8200) | int }}"
+        vllm_container_image: "{{ vllm_container_image | default(container_runtime.image) }}"
+        vloc_permissive: "{{ vloc_permissive | default(false) | bool }}"
+        granite_patch_overlay: false
         local_results_base: "{{ playbook_dir }}/../../../results/llm"
 
     - name: Set per-runner defaults
@@ -88,7 +94,7 @@
           {%- else -%}auto{%- endif -%}
         max_model_len: >-
           {%- if max_model_len is defined -%}{{ max_model_len }}
-          {%- elif vloc_runner == 'vllm_qwen_3_5' -%}2048
+          {%- elif vloc_runner == 'vllm_qwen_3_5' -%}4096
           {%- elif vloc_runner == 'vllm_antares' -%}32768
           {%- else -%}32768{%- endif -%}
         vllm_extra_serve_args: >-
@@ -101,9 +107,7 @@
           {%- elif vloc_runner == 'vllm_qwen_3_5' -%}10
           {%- elif vloc_runner == 'vllm_antares' -%}16
           {%- else -%}16{%- endif -%}
-        vloc_model_name: >-
-          {%- if vloc_runner == 'vllm_antares' -%}{{ test_model }}
-          {%- else -%}{{ test_model }}{%- endif -%}
+        vloc_model_name: "{{ test_model }}"
 
     - name: Set NUMA / CPU pinning configuration
       ansible.builtin.set_fact:
@@ -150,7 +154,9 @@
           - "Max Model Len: {{ max_model_len }}"
           - "Dtype: {{ vllm_dtype }}"
           - "Port: {{ vllm_port }}"
+          - "vLLM Image: {{ vllm_container_image }}"
           - "VLoc Harness Image: {{ vloc_harness_image }}"
+          - "Permissive sandbox: {{ vloc_permissive }}"
           - "DUT Data Cache: {{ vloc_data_dir if vloc_data_dir else '(auto: ~/vloc-bench/data on DUT)' }}"
           - "KV Cache: {{ vllm_kv_cache_gb }} GB (VLLM_CPU_KVCACHE_SPACE)"
           - "vLLM CPUs: {{ vloc_vllm_cpuset_cpus }}"
@@ -211,33 +217,55 @@
       ansible.builtin.script:
         cmd: >-
           {{ playbook_dir }}/../scripts/bash/patch-vllm-granite-hybrid.sh
-          --container-image {{ container_runtime.image }}
+          --container-image {{ hostvars['localhost']['vllm_container_image'] }}
           --output-dir /tmp/vllm-patch
       when: needs_granite_patch | bool
       changed_when: true
       register: granite_patch_result
 
-    - name: Verify Granite patch was applied
+    - name: Check whether a patched overlay file was written
       ansible.builtin.stat:
         path: /tmp/vllm-patch/granitemoehybrid.py
       register: granite_patch_file
       when: needs_granite_patch | bool
 
-    - name: Fail if Granite patch is missing
-      ansible.builtin.assert:
-        that: granite_patch_file.stat.exists
-        fail_msg: >-
-          Granite hybrid patch failed — /tmp/vllm-patch/granitemoehybrid.py not found.
-          Check patch script output: {{ granite_patch_result.stdout | default('') }}
+    - name: Record whether to mount the Granite overlay
+      ansible.builtin.set_fact:
+        granite_patch_overlay: "{{ granite_patch_file.stat.exists | default(false) }}"
       when: needs_granite_patch | bool
 
-    - name: Verify Granite patch contains full_attention fix
+    - name: Verify overlay contains full_attention fix
       ansible.builtin.command:
         cmd: grep -q 'full_attention' /tmp/vllm-patch/granitemoehybrid.py
       register: granite_patch_content
       changed_when: false
       failed_when: granite_patch_content.rc != 0
-      when: needs_granite_patch | bool
+      when:
+        - needs_granite_patch | bool
+        - granite_patch_overlay | bool
+
+    - name: Confirm image already has full_attention when no overlay was written
+      ansible.builtin.command:
+        cmd: >-
+          podman run --rm --entrypoint cat
+          {{ hostvars['localhost']['vllm_container_image'] }}
+          /opt/venv/lib/python3.12/site-packages/vllm/model_executor/models/granitemoehybrid.py
+      register: granite_image_src
+      changed_when: false
+      when:
+        - needs_granite_patch | bool
+        - not (granite_patch_overlay | bool)
+
+    - name: Fail if image is missing full_attention and no overlay was produced
+      ansible.builtin.assert:
+        that: "'full_attention' in (granite_image_src.stdout | default(''))"
+        fail_msg: >-
+          Granite hybrid patch was skipped but the container image does not
+          contain full_attention. Patch script output:
+          {{ granite_patch_result.stdout | default('') }}
+      when:
+        - needs_granite_patch | bool
+        - not (granite_patch_overlay | bool)
 
     # Container entrypoint is "vllm serve", so pass model + args only
     - name: Build vLLM serve command
@@ -259,7 +287,7 @@
         vllm_volumes: >-
           {{
             [dut_home.stdout ~ "/.cache/huggingface:/root/.cache/huggingface:z"]
-            + (needs_granite_patch | bool) | ternary(
+            + (granite_patch_overlay | default(false) | bool) | ternary(
               ["/tmp/vllm-patch/granitemoehybrid.py:/opt/venv/lib/python3.12/site-packages/vllm/model_executor/models/granitemoehybrid.py:z"],
               []
             )
@@ -274,24 +302,41 @@
         group: "{{ ansible_user }}"
 
     - name: Start vLLM container
-      containers.podman.podman_container:
-        name: "vllm-cve-vloc"
-        image: "{{ container_runtime.image }}"
-        state: started
-        command: "{{ vllm_serve_cmd }}"
-        network_mode: host
-        security_opt: "{{ container_runtime.security_opts }}"
-        cap_add: "{{ container_runtime.capabilities }}"
-        shm_size: "{{ container_runtime.shm_size }}"
-        cpuset_cpus: "{{ hostvars['localhost']['vloc_vllm_cpuset_cpus'] }}"
-        cpuset_mems: "{{ hostvars['localhost']['vloc_vllm_cpuset_mems'] | default(omit, true) }}"
-        env:
-          HF_TOKEN: "{{ hf_token | default('') }}"
-          OMP_NUM_THREADS: "{{ hostvars['localhost']['requested_cores'] }}"
-          VLLM_CPU_KVCACHE_SPACE: "{{ hostvars['localhost']['vllm_kv_cache_gb'] }}"
-          VLLM_CPU_OMP_THREADS_BIND: "{{ hostvars['localhost']['vloc_vllm_omp_bind'] | default(omit, true) }}"
-        volume: "{{ vllm_volumes }}"
-      no_log: true
+      block:
+        - name: Launch vLLM container (HF_TOKEN redacted)
+          containers.podman.podman_container:
+            name: "vllm-cve-vloc"
+            image: "{{ hostvars['localhost']['vllm_container_image'] }}"
+            state: started
+            command: "{{ vllm_serve_cmd }}"
+            network_mode: host
+            security_opt: "{{ container_runtime.security_opts }}"
+            cap_add: "{{ container_runtime.capabilities }}"
+            shm_size: "{{ container_runtime.shm_size }}"
+            cpuset_cpus: "{{ hostvars['localhost']['vloc_vllm_cpuset_cpus'] }}"
+            cpuset_mems: "{{ hostvars['localhost']['vloc_vllm_cpuset_mems'] | default(omit, true) }}"
+            env:
+              HF_TOKEN: "{{ hf_token | default('') }}"
+              OMP_NUM_THREADS: "{{ hostvars['localhost']['requested_cores'] }}"
+              VLLM_CPU_KVCACHE_SPACE: "{{ hostvars['localhost']['vllm_kv_cache_gb'] }}"
+              VLLM_CPU_OMP_THREADS_BIND: "{{ hostvars['localhost']['vloc_vllm_omp_bind'] | default(omit, true) }}"
+            volume: "{{ vllm_volumes }}"
+          no_log: true
+      rescue:
+        - name: Capture vLLM container logs after start failure
+          ansible.builtin.command:
+            cmd: podman logs vllm-cve-vloc
+          register: vllm_start_logs
+          changed_when: false
+          failed_when: false
+
+        - name: Fail with vLLM start logs (token omitted)
+          ansible.builtin.fail:
+            msg: >-
+              vLLM container failed to start. Common causes: bad image,
+              Granite patch overlay, port already in use, or OOM.
+              Last log lines:
+              {{ (vllm_start_logs.stdout_lines | default([]))[-40:] | join('\n') }}
 
 # ==============================================================================
 # PHASE 3: Health Check
@@ -359,6 +404,7 @@
     vloc_workers: "{{ hostvars['localhost']['vloc_workers'] }}"
     vloc_n_limit: "{{ hostvars['localhost']['vloc_n_limit'] }}"
     vloc_model_name: "{{ hostvars['localhost']['vloc_model_name'] }}"
+    vloc_permissive: "{{ hostvars['localhost']['vloc_permissive'] }}"
     vllm_port: "{{ hostvars['localhost']['vllm_port'] }}"
     test_run_id: "{{ hostvars['localhost']['test_run_id'] }}"
     config_id: "{{ hostvars['localhost']['config_id'] }}"
@@ -489,8 +535,25 @@
           data/downloader_and_verifier.py --output-dir data/ghsa-vulns
       when: dataset_check.matched == 0
       changed_when: true
-      failed_when: false
+      register: dataset_download
       timeout: 3600
+
+    - name: Re-check dataset after download
+      ansible.builtin.find:
+        paths: "{{ vloc_data_dir }}"
+        patterns: "*.zip"
+        recurse: true
+      register: dataset_after
+      when: dataset_check.matched == 0
+
+    - name: Fail if VLoc dataset is missing
+      ansible.builtin.assert:
+        that: >-
+          (dataset_check.matched | int) > 0
+          or (dataset_after.matched | default(0) | int) > 0
+        fail_msg: >-
+          VLoc dataset download produced no zip files in {{ vloc_data_dir }}.
+          {{ dataset_download.stderr | default(dataset_download.stdout | default('')) }}
 
     # ------------------------------------------------------------------
     # 4.5 Run VLoc Bench CLI
@@ -507,14 +570,9 @@
         state: absent
       failed_when: false
 
-    - name: Display VLoc Bench command
-      ansible.builtin.debug:
-        msg: >-
-          podman run --network host
-          -v {{ podman_socket }}:/var/run/docker.sock:z
-          -v {{ vloc_data_dir }}:/opt/vloc-bench/data/ghsa-vulns:z
-          -v {{ vloc_results_dir }}:/results:z
-          {{ vloc_harness_image }}
+    - name: Build VLoc CLI command
+      ansible.builtin.set_fact:
+        vloc_cli_command: >-
           python3 -m vulnerability_localization_benchmark.cli
           --config {{ vloc_config }}
           --api-base http://localhost:{{ vllm_port }}/v1
@@ -524,7 +582,17 @@
           --workers {{ vloc_workers }}
           --n-limit {{ vloc_n_limit }}
           --output-dir /results
-          --permissive
+          {{ '--permissive' if (vloc_permissive | default(false) | bool) else '' }}
+
+    - name: Display VLoc Bench command
+      ansible.builtin.debug:
+        msg: >-
+          podman run --network host
+          -v {{ podman_socket }}:/var/run/docker.sock:z
+          -v {{ vloc_data_dir }}:/opt/vloc-bench/data/ghsa-vulns:z
+          -v {{ vloc_results_dir }}:/results:z
+          {{ vloc_harness_image }}
+          {{ vloc_cli_command }}
 
     - name: Record start time
       ansible.builtin.set_fact:
@@ -535,17 +603,7 @@
         name: "vloc-bench-run"
         image: "{{ vloc_harness_image }}"
         state: started
-        command: >-
-          python3 -m vulnerability_localization_benchmark.cli
-          --config {{ vloc_config }}
-          --api-base http://localhost:{{ vllm_port }}/v1
-          --model-name {{ vloc_model_name }}
-          --runner {{ vloc_runner }}
-          --phases {{ vloc_phases }}
-          --workers {{ vloc_workers }}
-          --n-limit {{ vloc_n_limit }}
-          --output-dir /results
-          --permissive
+        command: "{{ vloc_cli_command }}"
         network_mode: host
         security_opt:
           - "label=disable"
@@ -554,7 +612,7 @@
         env:
           PYTHONPATH: "/opt/vloc-bench/src"
         volume:
-          - "{{ podman_socket }}:/var/run/docker.sock"
+          - "{{ podman_socket }}:/var/run/docker.sock:z"
           - "{{ vloc_data_dir }}:/opt/vloc-bench/data/ghsa-vulns:z"
           - "{{ vloc_results_dir }}:/results:z"
         detach: true
@@ -725,6 +783,7 @@
               "max_model_len": {{ hostvars['localhost']['max_model_len'] }},
               "vllm_dtype": "{{ hostvars['localhost']['vllm_dtype'] }}",
               "vllm_extra_serve_args": "{{ hostvars['localhost']['vllm_extra_serve_args'] | default('') }}",
+              "vloc_permissive": {{ hostvars['localhost']['vloc_permissive'] | default(false) | bool | lower }},
               "numa": {
                 "vllm_cpuset_cpus": "{{ hostvars['localhost']['vloc_vllm_cpuset_cpus'] }}",
                 "vllm_cpuset_mems": "{{ hostvars['localhost']['vloc_vllm_cpuset_mems'] | default('', true) }}",
@@ -734,7 +793,7 @@
               }
             },
             "environment": {
-              "container_image": "{{ container_runtime.image }}",
+              "container_image": "{{ hostvars['localhost']['vllm_container_image'] }}",
               "vllm_version": "{{ hostvars['localhost']['detected_vllm_version'] | default('unknown') }}",
               "vloc_bench_commit": "{{ vloc_commit.stdout | default('unknown') }}"
             }
@@ -799,6 +858,17 @@
           - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           - "Results:    {{ results_dest }}"
           - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    - name: Fail if no tasks completed
+      ansible.builtin.fail:
+        msg: >-
+          VLoc Bench completed 0 tasks
+          (aggregate.json {{ 'missing' if not aggregate_check.stat.exists else 'present but empty' }}).
+          Results were still written to {{ results_dest }} for debugging.
+          Override with -e vloc_allow_empty=true to treat this as success.
+      when:
+        - (vloc_tasks_completed | default(0) | int) == 0
+        - not (vloc_allow_empty | default(false) | bool)
 
 # ==============================================================================
 # PHASE 6: Cleanup

--- a/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
+++ b/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
@@ -24,6 +24,7 @@
 #   -e "vloc_config=configs/default.yaml"  # VLoc config file
 #   -e "max_model_len=4096"           # vLLM max context (default: per-runner)
 #   -e "vllm_dtype=auto"              # Model dtype (default: per-runner)
+#   -e "vllm_kv_cache_gb=4"            # CPU KV cache GB (default: per-runner)
 #   -e "vllm_port=8200"               # vLLM serve port (default: 8200)
 #   -e "cleanup_after_test=false"     # Keep container running (default: true)
 #
@@ -87,6 +88,11 @@
           {%- elif vloc_runner == 'vllm_qwen_3_5' -%}--enable-auto-tool-choice --tool-call-parser qwen3_coder
           {%- elif vloc_runner == 'vllm_gemma_4' -%}--enable-auto-tool-choice --tool-call-parser gemma4
           {%- else -%}{%- endif -%}
+        vllm_kv_cache_gb: >-
+          {%- if vllm_kv_cache_gb is defined -%}{{ vllm_kv_cache_gb }}
+          {%- elif vloc_runner == 'vllm_qwen_3_5' -%}10
+          {%- elif vloc_runner == 'vllm_antares' -%}8
+          {%- else -%}4{%- endif -%}
         vloc_model_name: >-
           {%- if vloc_runner == 'vllm_antares' -%}{{ test_model }}
           {%- else -%}{{ test_model }}{%- endif -%}
@@ -125,6 +131,7 @@
           - "Port: {{ vllm_port }}"
           - "VLoc Harness Image: {{ vloc_harness_image }}"
           - "DUT Data Cache: {{ vloc_data_dir }}"
+          - "KV Cache: {{ vllm_kv_cache_gb }} GB (VLLM_CPU_KVCACHE_SPACE)"
           - "Extra vLLM Args: {{ vllm_extra_serve_args | default('(none)') }}"
           - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
@@ -234,6 +241,7 @@
         env:
           HF_TOKEN: "{{ hf_token | default('') }}"
           OMP_NUM_THREADS: "{{ hostvars['localhost']['requested_cores'] }}"
+          VLLM_CPU_KVCACHE_SPACE: "{{ hostvars['localhost']['vllm_kv_cache_gb'] }}"
         volume: "{{ vllm_volumes }}"
       no_log: true
 

--- a/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
+++ b/automation/test-execution/ansible/llm-benchmark-cve-vloc.yml
@@ -29,6 +29,7 @@
 #   -e "vllm_container_image=..."     # Override vLLM image (default: container_runtime.image)
 #   -e "vloc_permissive=true"         # Skip sandbox command allowlist (default: false)
 #   -e "vloc_allow_empty=true"        # Allow 0 completed tasks (default: false)
+#   -e "vloc_allow_failure=true"      # Continue after a non-zero VLoc exit (default: false)
 #   -e "cleanup_after_test=false"     # Keep container running (default: true)
 #
 # NUMA / CPU pinning (optional — default is no NUMA binding):
@@ -494,20 +495,33 @@
       failed_when: false
       changed_when: false
 
+    - name: Create sandbox image build directory
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: vloc-sandbox-
+      register: sandbox_build_dir
+      when: sandbox_image_check.rc != 0
+
     - name: Extract sandbox Dockerfile from harness image
       ansible.builtin.shell: >-
         podman run --rm {{ vloc_harness_image }}
         cat /opt/vloc-bench/Dockerfile
-        > /tmp/vloc-sandbox-Dockerfile
+        > {{ sandbox_build_dir.path }}/Dockerfile
       when: sandbox_image_check.rc != 0
       changed_when: true
 
     - name: Build sandbox image
       ansible.builtin.command:
-        cmd: podman build -t {{ vloc_sandbox_image }} -f /tmp/vloc-sandbox-Dockerfile /tmp
+        cmd: podman build -t {{ vloc_sandbox_image }} {{ sandbox_build_dir.path }}/
       when: sandbox_image_check.rc != 0
       changed_when: true
       timeout: 300
+
+    - name: Clean up sandbox build directory
+      ansible.builtin.file:
+        path: "{{ sandbox_build_dir.path }}"
+        state: absent
+      when: sandbox_build_dir.path is defined
 
     # ------------------------------------------------------------------
     # 4.4 Download VLoc dataset (cached between runs)
@@ -650,21 +664,23 @@
       ansible.builtin.debug:
         msg: "VLoc Bench completed in {{ vloc_wall_time }}s (exit code: {{ vloc_exit_code.stdout }})"
 
-    - name: Fail on non-zero VLoc exit code
-      ansible.builtin.fail:
-        msg: >-
-          VLoc Bench exited with code {{ vloc_exit_code.stdout }}.
-          Override with -e vloc_allow_failure=true to continue anyway.
-          Last 20 log lines:
-          {{ (vloc_logs.stdout_lines | default([]))[-20:] | join('\n') }}
-      when:
-        - vloc_exit_code.stdout | int != 0
-        - not (vloc_allow_failure | default(false) | bool)
-
-    - name: Remove VLoc run container
-      containers.podman.podman_container:
-        name: "vloc-bench-run"
-        state: absent
+    - name: Handle VLoc run completion
+      block:
+        - name: Fail on non-zero VLoc exit code
+          ansible.builtin.fail:
+            msg: >-
+              VLoc Bench exited with code {{ vloc_exit_code.stdout }}.
+              Override with -e vloc_allow_failure=true to continue anyway.
+              Last 20 log lines:
+              {{ (vloc_logs.stdout_lines | default([]))[-20:] | join('\n') }}
+          when:
+            - vloc_exit_code.stdout | int != 0
+            - not (vloc_allow_failure | default(false) | bool)
+      always:
+        - name: Remove VLoc run container
+          containers.podman.podman_container:
+            name: "vloc-bench-run"
+            state: absent
 
 # ==============================================================================
 # PHASE 5: Parse and Collect Results
@@ -814,15 +830,15 @@
             "vloc_runner": "{{ hostvars['localhost']['vloc_runner'] }}",
             "vloc_phases": "{{ hostvars['localhost']['vloc_phases'] }}",
             "metrics": {
-              "mean_file_f1": {{ vloc_mean_file_f1 }},
-              "abstain_rate": {{ vloc_abstain_rate }},
-              "true_negative_rate": {{ vloc_tnr }},
-              "false_positive_rate": {{ vloc_fpr }},
-              "phase_a_tasks": {{ vloc_phase_a_n }},
-              "phase_b_tasks": {{ vloc_phase_b_n }},
-              "tasks_completed": {{ vloc_tasks_completed }},
-              "wall_time_seconds": {{ vloc_wall_time }},
-              "tasks_per_hour": {{ vloc_tasks_per_hour }}
+              "mean_file_f1": {{ vloc_mean_file_f1 | default(0.0) | float | to_json }},
+              "abstain_rate": {{ vloc_abstain_rate | default(0.0) | float | to_json }},
+              "true_negative_rate": {{ (none if (vloc_tnr | default('null') | string) in ['null', 'None'] else (vloc_tnr | float)) | to_json }},
+              "false_positive_rate": {{ (none if (vloc_fpr | default('null') | string) in ['null', 'None'] else (vloc_fpr | float)) | to_json }},
+              "phase_a_tasks": {{ vloc_phase_a_n | default(0) | int | to_json }},
+              "phase_b_tasks": {{ vloc_phase_b_n | default(0) | int | to_json }},
+              "tasks_completed": {{ vloc_tasks_completed | default(0) | int | to_json }},
+              "wall_time_seconds": {{ vloc_wall_time | default(0) | int | to_json }},
+              "tasks_per_hour": {{ vloc_tasks_per_hour | default(0.0) | float | to_json }}
             }
           }
         dest: "{{ results_dest }}/results.json"

--- a/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
+++ b/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
@@ -12,7 +12,7 @@
 # Optional parameters:
 #   -e "dataset_path=/path/to/dataset.txt"  # Custom dataset file
 #   -e "input_len=512"                       # For random dataset
-#   -e "output_len=256"                      # For random/sharegpt/cnn_dailymail datasets
+#   -e "output_len=256"                      # For random/sharegpt datasets
 #   -e "vllm_container_image=vllm/vllm-openai:latest"  # Default (upstream vLLM)
 #   -e "vllm_container_image=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0"  # RHAIIS optimized
 #   -e "vllm_extra_args=--enforce-eager"                 # Extra args passed to vllm bench
@@ -26,7 +26,10 @@
 #
 # Dataset types: sonnet, random, sharegpt
 #   - sonnet: Classic sonnet text (needs dataset_path)
-#   - random: Synthetic random tokens (needs input_len, output_len)
+#   - random: Synthetic random tokens (needs input_len/output_len via
+#     --random-input-len/--random-output-len). Use for long-doc shapes
+#     (e.g. 4096→256); HF datasets like cnn_dailymail are not supported
+#     by vllm bench throughput in this path.
 #   - sharegpt: ShareGPT conversations (built-in dataset)
 
 - name: "Offline Batch Benchmark - Setup"
@@ -194,9 +197,9 @@
         dataset_file: "{{ dataset_path }}"
       when: dataset_path is defined
 
-    - name: Note for HuggingFace datasets
+    - name: Note for sharegpt dataset
       ansible.builtin.debug:
-        msg: "Using HuggingFace dataset: {{ dataset_name }} (built-in)"
+        msg: "Using ShareGPT built-in dataset (vllm bench throughput)"
       when: dataset_name == 'sharegpt'
 
 - name: "Offline Batch Benchmark - Run Benchmark"

--- a/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
+++ b/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
@@ -26,10 +26,11 @@
 #
 # Dataset types: sonnet, random, sharegpt
 #   - sonnet: Classic sonnet text (needs dataset_path)
-#   - random: Synthetic random tokens (needs input_len/output_len via
-#     --random-input-len/--random-output-len). Use for long-doc shapes
-#     (e.g. 4096→256); HF datasets like cnn_dailymail are not supported
-#     by vllm bench throughput in this path.
+#   - random: Synthetic random tokens (defaults: 512 input tokens, 256
+#     output tokens). --random-input-len / --random-output-len override
+#     those defaults. Use for long-doc shapes (e.g. 4096→256); HF
+#     datasets like cnn_dailymail are not supported by vllm bench
+#     throughput in this path.
 #   - sharegpt: ShareGPT conversations (built-in dataset)
 
 - name: "Offline Batch Benchmark - Setup"

--- a/automation/test-execution/containers/vloc-bench/Dockerfile
+++ b/automation/test-execution/containers/vloc-bench/Dockerfile
@@ -47,9 +47,9 @@ WORKDIR /opt/vloc-bench
 # Install --no-deps to skip the heavy ML packages listed in pyproject.toml.
 RUN pip install --no-cache-dir --no-deps -e . && \
     pip install --no-cache-dir \
-        'requests>=2.31' \
-        'pyyaml>=6.0' \
-        'tqdm>=4.66' \
-        'openai>=2.0'
+        'requests==2.32.3' \
+        'pyyaml==6.0.2' \
+        'tqdm==4.67.1' \
+        'openai==2.2.0'
 
 ENV PYTHONPATH=/opt/vloc-bench/src

--- a/automation/test-execution/containers/vloc-bench/Dockerfile
+++ b/automation/test-execution/containers/vloc-bench/Dockerfile
@@ -16,7 +16,7 @@
 #       --api-base http://localhost:8200/v1 \
 #       --model-name <model> --runner <runner> \
 #       --phases a --workers 1 --n-limit 5 \
-#       --output-dir /results --permissive
+#       --output-dir /results
 
 FROM python:3.12-slim
 
@@ -32,10 +32,13 @@ RUN ARCH="$(uname -m)" && \
     | tar xz -C /usr/local/bin --strip-components=1 docker/docker && \
     chmod +x /usr/local/bin/docker
 
-ARG VLOC_REF=main
-RUN git clone --depth 1 -b "${VLOC_REF}" \
-        https://github.com/cisco-foundation-ai/vulnerability-localization-benchmark.git \
-        /opt/vloc-bench
+# Pin to a VLoc Bench commit (not floating main) so rebuilds are reproducible.
+# Bump this SHA deliberately after reviewing upstream changes.
+ARG VLOC_REF=000c19cda9ba027e1d241216768b2b6358685000
+RUN git clone https://github.com/cisco-foundation-ai/vulnerability-localization-benchmark.git \
+        /opt/vloc-bench \
+    && git -C /opt/vloc-bench checkout --detach "${VLOC_REF}" \
+    && test "$(git -C /opt/vloc-bench rev-parse HEAD)" = "${VLOC_REF}"
 
 WORKDIR /opt/vloc-bench
 

--- a/automation/test-execution/containers/vloc-bench/Dockerfile
+++ b/automation/test-execution/containers/vloc-bench/Dockerfile
@@ -1,0 +1,52 @@
+# VLoc Bench CLI Harness
+# Runs the Cisco VLoc Bench evaluation CLI in a container.
+# Sandbox containers are spawned on the host via Docker socket passthrough.
+#
+# Build:
+#   podman build -t vloc-bench-harness .
+#
+# Run (after sandbox image + dataset are ready):
+#   podman run --rm --network host \
+#     -v /run/user/$(id -u)/podman/podman.sock:/var/run/docker.sock:z \
+#     -v /tmp/vloc-data:/opt/vloc-bench/data/ghsa-vulns:z \
+#     -v /tmp/vloc-results:/results:z \
+#     vloc-bench-harness \
+#     python3 -m vulnerability_localization_benchmark.cli \
+#       --config configs/default.yaml \
+#       --api-base http://localhost:8200/v1 \
+#       --model-name <model> --runner <runner> \
+#       --phases a --workers 1 --n-limit 5 \
+#       --output-dir /results --permissive
+
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Docker CLI only — for spawning sandbox containers via host socket
+ARG DOCKER_VERSION=27.5.1
+RUN ARCH="$(uname -m)" && \
+    curl -fsSL \
+      "https://download.docker.com/linux/static/stable/${ARCH}/docker-${DOCKER_VERSION}.tgz" \
+    | tar xz -C /usr/local/bin --strip-components=1 docker/docker && \
+    chmod +x /usr/local/bin/docker
+
+ARG VLOC_REF=main
+RUN git clone --depth 1 -b "${VLOC_REF}" \
+        https://github.com/cisco-foundation-ai/vulnerability-localization-benchmark.git \
+        /opt/vloc-bench
+
+WORKDIR /opt/vloc-bench
+
+# The CLI, agent, model runners, and scoring modules only import
+# requests/yaml/tqdm — they talk to vLLM over HTTP, not via torch/vllm.
+# Install --no-deps to skip the heavy ML packages listed in pyproject.toml.
+RUN pip install --no-cache-dir --no-deps -e . && \
+    pip install --no-cache-dir \
+        'requests>=2.31' \
+        'pyyaml>=6.0' \
+        'tqdm>=4.66' \
+        'openai>=2.0'
+
+ENV PYTHONPATH=/opt/vloc-bench/src

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/Home.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/Home.py
@@ -53,6 +53,7 @@ vLLM CPU benchmark results:
 📊 **Embedding Metrics** - Embedding model performance (vLLM bench serve)
 📦 **Offline Batch** - Batch processing performance (vLLM bench throughput)
 🎧 **Audio Metrics** - Audio-specific performance for ASR models
+🔍 **CVE VLoc** - Vulnerability localization quality (VLoc Bench agent loop)
 
 **👈 Use the sidebar to navigate between dashboards**
 """)
@@ -245,10 +246,12 @@ with tab1:
 
     **Offline batch results are saved to:** `results/llm/`
 
-    Each dashboard loads from its respective directory - just run a test and refresh!
+    Each dashboard loads from its respective directory —
+    just run a test and refresh!
 
-    **Note**: External endpoint runs always show client metrics. Server-side metrics are
-    available when the external endpoint exposes `/metrics`.
+    **Note**: External endpoint runs always show client metrics.
+    Server-side metrics are available when the external endpoint
+    exposes `/metrics`.
     """)
 
 with tab2:

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/Home.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/Home.py
@@ -155,6 +155,23 @@ with col4:
     - Environment tracking
     """)
 
+with col6:
+    st.markdown("### 🔍 CVE VLoc")
+    st.info("""
+    **What**: VLoc Bench agent-loop quality (CVE localization)
+
+    **Metrics**:
+    - File F1 (Phase A)
+    - True Negative Rate (Phase B)
+    - Abstain rate
+    - Tasks per hour
+
+    **Features**:
+    - Upstream leaderboard comparison
+    - File F1 score bands
+    - CPU vs GPU delta
+    """)
+
 st.markdown("---")
 
 # Quick start
@@ -246,6 +263,18 @@ with tab1:
 
     **Offline batch results are saved to:** `results/llm/`
 
+    **CVE VLoc Tests:**
+    ```bash
+    # Quick smoke (5 tasks, Granite-4.0-350M, Phase A)
+    ./automation/test-execution/scripts/bash/run-cve-vloc-suite.sh smoke
+
+    # Phase A, Granite family, 25 tasks
+    ./automation/test-execution/scripts/bash/run-cve-vloc-suite.sh phase-a \\
+      --models granite --n-limit 25 --cores 16
+    ```
+
+    **CVE VLoc results are saved to:** `results/llm/*/cve-vloc-*/`
+
     Each dashboard loads from its respective directory —
     just run a test and refresh!
 
@@ -309,9 +338,16 @@ with tab3:
     - 📈 Batch size scaling curves
     - 🐳 Container/version tracking
 
+    **CVE VLoc Dashboard adds:**
+    - 🎯 Phase A File F1 vs abstain rate
+    - 🛡️ Phase B true-negative / false-positive rates
+    - 📊 Upstream GPU leaderboard comparison
+    - ⚡ Tasks/hour throughput
+
     **Analysis Workflow:**
     - LLM (Online): Start with Client Metrics, then Server Metrics
     - LLM (Offline Batch): Use Offline Batch for throughput workloads
+    - CVE localization: Use CVE VLoc for File F1 / TNR (not offline capacity)
     - Embedding: Use saturation curves to find optimal load
     - Compare metrics between models for performance analysis
     """)

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/5_🔍_CVE_VLoc.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/5_🔍_CVE_VLoc.py
@@ -288,6 +288,9 @@ def _parse_leaderboard_entries(entries: list) -> pd.DataFrame:
     return pd.DataFrame(rows) if rows else pd.DataFrame()
 
 
+_MAX_LEADERBOARD_BYTES = 1_000_000
+
+
 @st.cache_data(ttl=3600)
 def load_leaderboard() -> tuple:
     """Fetch the upstream VLoc leaderboard JSON.
@@ -301,7 +304,10 @@ def load_leaderboard() -> tuple:
         with urllib.request.urlopen(
             LEADERBOARD_JSON_URL, timeout=8
         ) as resp:
-            raw = json.loads(resp.read())
+            raw_bytes = resp.read(_MAX_LEADERBOARD_BYTES + 1)
+        if len(raw_bytes) > _MAX_LEADERBOARD_BYTES:
+            raise ValueError("leaderboard response exceeded size cap")
+        raw = json.loads(raw_bytes)
         # Unwrap envelope: top-level may be a dict with a "models" key
         if isinstance(raw, dict):
             entries = raw.get("models", [])
@@ -320,34 +326,6 @@ def load_leaderboard() -> tuple:
 # ---------------------------------------------------------------------------
 # Chart helpers
 # ---------------------------------------------------------------------------
-
-def _bar_chart(
-    labels: list,
-    values: list,
-    title: str,
-    yaxis_title: str,
-    color: str,
-    hover_fmt: str = "%{y:.3f}",
-    height: int = 400,
-) -> go.Figure:
-    fig = go.Figure(go.Bar(
-        x=labels,
-        y=values,
-        text=[f"{v:.3f}" if v is not None else "—" for v in values],
-        textposition="auto",
-        marker_color=color,
-        hovertemplate=f"<b>%{{x}}</b><br>{yaxis_title}: {hover_fmt}<extra></extra>",
-    ))
-    fig.update_layout(
-        title=title,
-        xaxis_title="Model",
-        yaxis_title=yaxis_title,
-        yaxis=dict(range=[0, 1]),
-        height=height,
-        showlegend=False,
-    )
-    return fig
-
 
 # File F1 bands for the leaderboard. Each chart gets its own y-axis so a
 # 0.002 Granite score is not flattened against a 0.22 GPT-class score.
@@ -634,8 +612,8 @@ def main():
     best_per_model = (
         dff.sort_values("mean_file_f1", ascending=False)
         .groupby("model_short", sort=False)
-        .first()
-        .reset_index()
+        .head(1)
+        .reset_index(drop=True)
     )
 
     # ==================================================================
@@ -733,8 +711,8 @@ def main():
     phase_b_data = (
         phase_b_runs.sort_values("true_negative_rate", ascending=False)
         .groupby("model_short", sort=False)
-        .first()
-        .reset_index()
+        .head(1)
+        .reset_index(drop=True)
         if not phase_b_runs.empty
         else phase_b_runs
     )
@@ -815,7 +793,7 @@ def main():
             for _, row in best_per_model.iterrows():
                 lb_name = row["leaderboard_name"]
                 f1 = row["mean_file_f1"]
-                if lb_name and f1 is not None:
+                if lb_name and pd.notna(f1):
                     # Keep the best local score if model appears multiple times
                     if lb_name not in local_scores or f1 > local_scores[lb_name]:
                         local_scores[lb_name] = f1
@@ -941,7 +919,7 @@ def main():
         .reset_index()
     )
     tput_data["label"] = (
-        tput_data["model_short"] + "\n" + tput_data["cores"].astype(str) + " cores"
+        tput_data["model_short"] + "<br>" + tput_data["cores"].astype(str) + " cores"
     )
     tput_data = tput_data.sort_values("tasks_per_hour", ascending=False)
 

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/5_🔍_CVE_VLoc.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/5_🔍_CVE_VLoc.py
@@ -538,12 +538,14 @@ def main():
         st.warning("No CVE-VLoc results found.")
         st.code(
             "# Run a CVE-VLoc benchmark (from repository root):\n"
-            "./cpueval --suite cve-vloc --model ibm-granite/granite-4.0-350m\n"
+            "./automation/test-execution/scripts/bash/run-cve-vloc-suite.sh "
+            "smoke\n"
             "\n"
             "# Or via Ansible:\n"
             "ansible-playbook automation/test-execution/ansible/"
             "llm-benchmark-cve-vloc.yml \\\n"
-            '  -e "test_model=ibm-granite/granite-4.0-350m"\n'
+            '  -e "test_model=ibm-granite/granite-4.0-350m" \\\n'
+            '  -e "vloc_runner=vllm" \\\n'
             '  -e "requested_cores=16"'
         )
         return
@@ -644,12 +646,17 @@ def main():
     n_models = dff["model_short"].nunique()
     n_runs = len(dff)
     best_f1 = dff["mean_file_f1"].max()
-    best_model = dff.loc[dff["mean_file_f1"].idxmax(), "model_short"] if best_f1 is not None else "—"
+    if pd.isna(best_f1):
+        best_f1_label = "—"
+        best_model = "—"
+    else:
+        best_f1_label = f"{best_f1:.3f}"
+        best_model = dff.loc[dff["mean_file_f1"].idxmax(), "model_short"]
 
     kpi1, kpi2, kpi3, kpi4 = st.columns(4)
     kpi1.metric("Models Tested", n_models)
     kpi2.metric("Total Runs", n_runs)
-    kpi3.metric("Best File F1", f"{best_f1:.3f}" if best_f1 is not None else "—")
+    kpi3.metric("Best File F1", best_f1_label)
     kpi4.metric("Best Model", best_model)
     st.caption(
         "Best File F1 and Best Model are **Phase A** scores (did the model "
@@ -717,10 +724,20 @@ def main():
     # ==================================================================
     # SECTION 2: Phase B — True Negative Rate
     # ==================================================================
-    phase_b_data = best_per_model[
-        best_per_model["true_negative_rate"].notna()
-        & (best_per_model["phase_b_tasks"] > 0)
+    # Phase B: pick the best TNR among runs that actually ran Phase B,
+    # not the File-F1-best run (which may be Phase A-only).
+    phase_b_runs = dff[
+        dff["true_negative_rate"].notna()
+        & (dff["phase_b_tasks"] > 0)
     ]
+    phase_b_data = (
+        phase_b_runs.sort_values("true_negative_rate", ascending=False)
+        .groupby("model_short", sort=False)
+        .first()
+        .reset_index()
+        if not phase_b_runs.empty
+        else phase_b_runs
+    )
 
     if not phase_b_data.empty:
         st.divider()
@@ -892,7 +909,7 @@ def main():
                         "LB File F1 (GPU)": "{:.3f}",
                         "Our File F1 (CPU)": "{:.3f}",
                         "Delta": "{:+.3f}",
-                    }).applymap(
+                    }).map(
                         lambda v: "color: green" if isinstance(v, float) and v >= 0
                         else ("color: red" if isinstance(v, float) and v < 0 else ""),
                         subset=["Delta"],

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/5_🔍_CVE_VLoc.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/5_🔍_CVE_VLoc.py
@@ -1,0 +1,998 @@
+#!/usr/bin/env python3
+"""CVE Vulnerability Localization Dashboard.
+
+Displays results from the VLoc Bench agent-loop evaluation and
+optionally compares them against the upstream leaderboard.
+"""
+
+import json
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import pandas as pd
+import plotly.graph_objects as go
+import streamlit as st
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from config_manager import DashboardConfig, normalize_vllm_version  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+LEADERBOARD_JSON_URL = (
+    "https://raw.githubusercontent.com/cisco-foundation-ai/"
+    "vulnerability-localization-benchmark/main/docs/model-performance.json"
+)
+
+# Map local model short-names (after the '/') to leaderboard model labels.
+# Keys are lowercased for case-insensitive matching.
+_LOCAL_TO_LEADERBOARD: Dict[str, str] = {
+    "granite-4.0-350m": "Granite-4.0-350M",
+    "granite-4.0-1b": "Granite-4.0-1B",
+    "granite-4.0-micro": "Granite-4.0-Micro",
+    "antares-350m": "Antares-350M-GRPO",
+    "antares-1b": "Antares-1B-GRPO",
+    "antares-3b": "Antares-3B-GRPO",
+    "qwen3.5-9b": "Qwen3.5-9B",
+    "qwen3.5-27b": "Qwen3.5-27B",
+    "qwen3.5-35b-a3b": "Qwen3.5-35B-A3B",
+    "qwen3.5-72b": "Qwen3.5-72B",
+    "qwen3.5-122b": "Qwen3.5-122B",
+}
+
+# Colors shared across charts
+_COLORS = {
+    "file_f1": "#1f77b4",
+    "abstain": "#d62728",
+    "tnr": "#2ca02c",
+    "throughput": "#ff7f0e",
+    "leaderboard": "#9467bd",
+    "local": "#1f77b4",
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _model_short(model: str) -> str:
+    return model.split("/")[-1]
+
+
+def _leaderboard_name(model: str) -> Optional[str]:
+    key = _model_short(model).lower()
+    return _LOCAL_TO_LEADERBOARD.get(key)
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+@st.cache_data
+def load_cve_results(results_base_dir: str) -> pd.DataFrame:
+    """Scan results/llm/ for cve-vloc-* directories and load all runs."""
+    rows: List[dict] = []
+    base = Path(results_base_dir)
+
+    if not base.exists():
+        return pd.DataFrame()
+
+    for model_dir in base.iterdir():
+        if not model_dir.is_dir() or model_dir.name.startswith("."):
+            continue
+
+        for ts_dir in model_dir.iterdir():
+            if not ts_dir.is_dir() or not ts_dir.name.startswith("cve-vloc-"):
+                continue
+
+            for config_dir in ts_dir.iterdir():
+                if not config_dir.is_dir():
+                    continue
+
+                results_file = config_dir / "results.json"
+                meta_file = config_dir / "test-metadata.json"
+
+                if not (results_file.exists() and meta_file.exists()):
+                    continue
+
+                try:
+                    with open(results_file) as f:
+                        res = json.load(f)
+                    with open(meta_file) as f:
+                        meta = json.load(f)
+                except Exception as exc:
+                    st.warning(f"Could not load {config_dir}: {exc}")
+                    continue
+
+                cfg = meta.get("configuration", {})
+                env = meta.get("environment", {})
+                metrics = res.get("metrics", {})
+
+                row = {
+                    "model": meta.get("model", "unknown"),
+                    "model_short": _model_short(meta.get("model", "unknown")),
+                    "vloc_runner": meta.get("vloc_runner", "vllm"),
+                    "vloc_phases": meta.get("vloc_phases", "a"),
+                    "test_run_id": meta.get("test_run_id", ""),
+                    "timestamp": meta.get("timestamp", ""),
+                    "cores": cfg.get("cores", 0),
+                    "workers": cfg.get("workers", 1),
+                    "n_limit": cfg.get("n_limit", 0),
+                    "max_model_len": cfg.get("max_model_len", 0),
+                    "vllm_version": normalize_vllm_version(
+                        env.get("vllm_version", "unknown")
+                    ),
+                    "container_image": env.get("container_image", "unknown"),
+                    "vloc_bench_commit": env.get("vloc_bench_commit", ""),
+                    # Quality metrics
+                    "mean_file_f1": metrics.get("mean_file_f1"),
+                    "abstain_rate": metrics.get("abstain_rate"),
+                    "true_negative_rate": metrics.get("true_negative_rate"),
+                    "false_positive_rate": metrics.get("false_positive_rate"),
+                    # Throughput
+                    "tasks_per_hour": metrics.get("tasks_per_hour"),
+                    "wall_time_seconds": metrics.get("wall_time_seconds"),
+                    "tasks_completed": metrics.get("tasks_completed", 0),
+                    "phase_a_tasks": metrics.get("phase_a_tasks", 0),
+                    "phase_b_tasks": metrics.get("phase_b_tasks", 0),
+                    # Derived
+                    "leaderboard_name": _leaderboard_name(
+                        meta.get("model", "")
+                    ),
+                    "config_label": config_dir.name,
+                }
+                rows.append(row)
+
+    if not rows:
+        return pd.DataFrame()
+
+    df = pd.DataFrame(rows)
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
+    return df
+
+
+# Embedded snapshot of the upstream leaderboard (fetched 2026-08-11).
+# Used as a fallback when the network is unavailable.
+_FALLBACK_LEADERBOARD = [
+    {"model": "GPT-5.5 (xhigh)", "size": "—", "type": "frontier",
+     "file_f1": 0.229, "precision": 0.310, "recall": 0.221,
+     "true_negative_rate": 0.279, "false_positive_rate": 0.721,
+     "submitted_nothing_rate": 0.158},
+    {"model": "GPT-5.5", "size": "—", "type": "frontier",
+     "file_f1": 0.221, "precision": 0.305, "recall": 0.211,
+     "true_negative_rate": 0.192, "false_positive_rate": 0.808,
+     "submitted_nothing_rate": 0.158},
+    {"model": "Antares-3B-GRPO", "size": "3B", "type": "open-weights",
+     "file_f1": 0.223, "precision": 0.298, "recall": 0.219,
+     "true_negative_rate": None, "false_positive_rate": None,
+     "submitted_nothing_rate": None},
+    {"model": "Antares-1B-GRPO", "size": "1B", "type": "open-weights",
+     "file_f1": 0.209, "precision": 0.268, "recall": 0.221,
+     "true_negative_rate": None, "false_positive_rate": None,
+     "submitted_nothing_rate": None},
+    {"model": "GLM-5.2", "size": "753B", "type": "open-weights",
+     "file_f1": 0.186, "precision": 0.226, "recall": 0.186,
+     "true_negative_rate": None, "false_positive_rate": None,
+     "submitted_nothing_rate": None},
+    {"model": "Gemini-3-Pro", "size": "—", "type": "frontier",
+     "file_f1": 0.152, "precision": 0.190, "recall": 0.153,
+     "true_negative_rate": 0.329, "false_positive_rate": 0.671,
+     "submitted_nothing_rate": 27.1},
+    {"model": "Antares-350M-GRPO", "size": "350M", "type": "open-weights",
+     "file_f1": 0.135, "precision": 0.144, "recall": 0.176,
+     "true_negative_rate": None, "false_positive_rate": None,
+     "submitted_nothing_rate": None},
+    {"model": "Gemma-4-31B", "size": "31B", "type": "open-weights",
+     "file_f1": 0.101, "precision": 0.131, "recall": 0.097,
+     "true_negative_rate": 0.682, "false_positive_rate": 0.318,
+     "submitted_nothing_rate": None},
+    {"model": "Gemini-2.5-Flash", "size": "—", "type": "frontier",
+     "file_f1": 0.102, "precision": 0.132, "recall": 0.098,
+     "true_negative_rate": 0.392, "false_positive_rate": 0.608,
+     "submitted_nothing_rate": 37.8},
+    {"model": "GPT-5-Mini", "size": "—", "type": "frontier",
+     "file_f1": 0.098, "precision": 0.115, "recall": 0.096,
+     "true_negative_rate": 0.702, "false_positive_rate": 0.298,
+     "submitted_nothing_rate": 67.7},
+    {"model": "Gemini-3.1-Flash-Lite", "size": "—", "type": "frontier",
+     "file_f1": 0.095, "precision": 0.131, "recall": 0.090,
+     "true_negative_rate": 0.632, "false_positive_rate": 0.368,
+     "submitted_nothing_rate": 62.3},
+    {"model": "Qwen3.5-27B", "size": "27B", "type": "open-weights",
+     "file_f1": 0.091, "precision": 0.116, "recall": 0.088,
+     "true_negative_rate": 0.748, "false_positive_rate": 0.252,
+     "submitted_nothing_rate": None},
+    {"model": "Qwen3.5-122B", "size": "122B", "type": "open-weights",
+     "file_f1": 0.091, "precision": 0.124, "recall": 0.083,
+     "true_negative_rate": 0.750, "false_positive_rate": 0.250,
+     "submitted_nothing_rate": None},
+    {"model": "Qwen3.5-35B-A3B", "size": "35B", "type": "open-weights",
+     "file_f1": 0.085, "precision": 0.115, "recall": 0.081,
+     "true_negative_rate": 0.740, "false_positive_rate": 0.260,
+     "submitted_nothing_rate": None},
+    {"model": "GPT-OSS-20B", "size": "20B", "type": "open-weights",
+     "file_f1": 0.070, "precision": 0.095, "recall": 0.065,
+     "true_negative_rate": 0.719, "false_positive_rate": 0.281,
+     "submitted_nothing_rate": None},
+    {"model": "GPT-OSS-120B", "size": "120B", "type": "open-weights",
+     "file_f1": 0.069, "precision": 0.095, "recall": 0.062,
+     "true_negative_rate": 0.720, "false_positive_rate": 0.280,
+     "submitted_nothing_rate": None},
+    {"model": "MiniMax-M2.7", "size": "229B", "type": "open-weights",
+     "file_f1": 0.054, "precision": 0.078, "recall": 0.050,
+     "true_negative_rate": 0.321, "false_positive_rate": 0.679,
+     "submitted_nothing_rate": 28.4},
+    {"model": "GPT-5", "size": "—", "type": "frontier",
+     "file_f1": 0.048, "precision": 0.062, "recall": 0.048,
+     "true_negative_rate": 0.743, "false_positive_rate": 0.257,
+     "submitted_nothing_rate": 69.9},
+    {"model": "CodeScout-14B", "size": "14B", "type": "open-weights",
+     "file_f1": 0.044, "precision": 0.065, "recall": 0.039,
+     "true_negative_rate": 0.563, "false_positive_rate": 0.437,
+     "submitted_nothing_rate": None},
+    {"model": "Qwen3.5-9B", "size": "9B", "type": "open-weights",
+     "file_f1": 0.043, "precision": 0.058, "recall": 0.039,
+     "true_negative_rate": 0.814, "false_positive_rate": 0.186,
+     "submitted_nothing_rate": None},
+    {"model": "Gemma-4-E2B", "size": "2B", "type": "open-weights",
+     "file_f1": 0.039, "precision": 0.045, "recall": 0.042,
+     "true_negative_rate": 0.755, "false_positive_rate": 0.245,
+     "submitted_nothing_rate": None},
+    {"model": "Gemma-4-E4B", "size": "4B", "type": "open-weights",
+     "file_f1": 0.034, "precision": 0.039, "recall": 0.034,
+     "true_negative_rate": 0.845, "false_positive_rate": 0.155,
+     "submitted_nothing_rate": None},
+    {"model": "Llama-3.3-70B", "size": "70B", "type": "open-weights",
+     "file_f1": 0.012, "precision": 0.016, "recall": 0.014,
+     "true_negative_rate": 0.745, "false_positive_rate": 0.255,
+     "submitted_nothing_rate": None},
+    {"model": "GPT-5-Nano", "size": "—", "type": "frontier",
+     "file_f1": 0.024, "precision": 0.038, "recall": 0.021,
+     "true_negative_rate": 0.868, "false_positive_rate": 0.132,
+     "submitted_nothing_rate": 86.0},
+    {"model": "Granite-4.0-350M", "size": "350M", "type": "open-weights",
+     "file_f1": 0.001, "precision": 0.001, "recall": 0.001,
+     "true_negative_rate": None, "false_positive_rate": None,
+     "submitted_nothing_rate": None},
+    {"model": "Granite-4.0-Micro", "size": "3B", "type": "open-weights",
+     "file_f1": 0.000, "precision": 0.000, "recall": 0.000,
+     "true_negative_rate": None, "false_positive_rate": None,
+     "submitted_nothing_rate": None},
+    {"model": "Granite-4.0-1B", "size": "1B", "type": "open-weights",
+     "file_f1": 0.000, "precision": 0.000, "recall": 0.000,
+     "true_negative_rate": None, "false_positive_rate": None,
+     "submitted_nothing_rate": None},
+]
+
+
+def _parse_leaderboard_entries(entries: list) -> pd.DataFrame:
+    rows = []
+    for entry in entries:
+        rows.append({
+            "lb_model": entry.get("model", ""),
+            "lb_size": entry.get("size", ""),
+            "lb_type": entry.get("type", ""),
+            "lb_file_f1": entry.get("file_f1"),
+            "lb_precision": entry.get("precision"),
+            "lb_recall": entry.get("recall"),
+            "lb_true_negative_rate": entry.get("true_negative_rate"),
+            "lb_false_positive_rate": entry.get("false_positive_rate"),
+            "lb_submitted_nothing_rate": entry.get(
+                "submitted_nothing_rate"
+            ),
+        })
+    return pd.DataFrame(rows) if rows else pd.DataFrame()
+
+
+@st.cache_data(ttl=3600)
+def load_leaderboard() -> tuple:
+    """Fetch the upstream VLoc leaderboard JSON.
+
+    Returns (DataFrame, source_label) where source_label is either
+    "live" or "cached" so the caller can inform the user.
+    The JSON envelope is {"note": "...", "models": [...]}.
+    Falls back to an embedded snapshot when the network is unavailable.
+    """
+    try:
+        with urllib.request.urlopen(
+            LEADERBOARD_JSON_URL, timeout=8
+        ) as resp:
+            raw = json.loads(resp.read())
+        # Unwrap envelope: top-level may be a dict with a "models" key
+        if isinstance(raw, dict):
+            entries = raw.get("models", [])
+        elif isinstance(raw, list):
+            entries = raw
+        else:
+            entries = []
+        if entries:
+            return _parse_leaderboard_entries(entries), "live"
+    except Exception:
+        pass
+
+    return _parse_leaderboard_entries(_FALLBACK_LEADERBOARD), "cached"
+
+
+# ---------------------------------------------------------------------------
+# Chart helpers
+# ---------------------------------------------------------------------------
+
+def _bar_chart(
+    labels: list,
+    values: list,
+    title: str,
+    yaxis_title: str,
+    color: str,
+    hover_fmt: str = "%{y:.3f}",
+    height: int = 400,
+) -> go.Figure:
+    fig = go.Figure(go.Bar(
+        x=labels,
+        y=values,
+        text=[f"{v:.3f}" if v is not None else "—" for v in values],
+        textposition="auto",
+        marker_color=color,
+        hovertemplate=f"<b>%{{x}}</b><br>{yaxis_title}: {hover_fmt}<extra></extra>",
+    ))
+    fig.update_layout(
+        title=title,
+        xaxis_title="Model",
+        yaxis_title=yaxis_title,
+        yaxis=dict(range=[0, 1]),
+        height=height,
+        showlegend=False,
+    )
+    return fig
+
+
+# File F1 bands for the leaderboard. Each chart gets its own y-axis so a
+# 0.002 Granite score is not flattened against a 0.22 GPT-class score.
+_F1_BANDS = [
+    {
+        "title": "High File F1 (≥ 0.15) — models that actually find the files",
+        "lo": 0.15,
+        "hi": None,
+        "y_floor": 0.30,
+    },
+    {
+        "title": "Mid File F1 (0.05–0.15) — partial localization",
+        "lo": 0.05,
+        "hi": 0.15,
+        "y_floor": 0.16,
+    },
+    {
+        "title": "Low File F1 (< 0.05) — near-zero / untrained baseline",
+        "lo": None,
+        "hi": 0.05,
+        "y_floor": 0.06,
+    },
+]
+
+
+def _in_f1_band(score, lo, hi) -> bool:
+    if score is None or pd.isna(score):
+        return False
+    if lo is not None and score < lo:
+        return False
+    if hi is not None and score >= hi:
+        return False
+    return True
+
+
+def _leaderboard_band_figure(
+    band_df: pd.DataFrame,
+    title: str,
+    y_floor: float,
+) -> go.Figure:
+    """Grouped GPU-vs-CPU File F1 bars for one score band."""
+    plot_df = band_df.sort_values("lb_file_f1", ascending=False).copy()
+    plot_df["xlabel"] = plot_df.apply(
+        lambda r: f"★ {r['lb_model']}" if r["has_local"] else r["lb_model"],
+        axis=1,
+    )
+
+    fig = go.Figure()
+    fig.add_trace(go.Bar(
+        name="Leaderboard (GPU)",
+        x=plot_df["xlabel"],
+        y=plot_df["lb_file_f1"].fillna(0),
+        marker_color=_COLORS["leaderboard"],
+        opacity=0.75,
+        hovertemplate="<b>%{x}</b><br>GPU File F1: %{y:.3f}<extra></extra>",
+    ))
+
+    local = plot_df[plot_df["has_local"]]
+    if not local.empty:
+        fig.add_trace(go.Bar(
+            name="Our results (CPU)",
+            x=local["xlabel"],
+            y=local["local_file_f1"],
+            text=[f"{v:.3f}" for v in local["local_file_f1"]],
+            textposition="auto",
+            marker_color=_COLORS["local"],
+            marker_line=dict(width=1.5, color="#08306b"),
+            hovertemplate="<b>%{x}</b><br>CPU File F1: %{y:.3f}<extra></extra>",
+        ))
+
+    y_vals = plot_df["lb_file_f1"].dropna().tolist()
+    if not local.empty:
+        y_vals.extend(local["local_file_f1"].dropna().tolist())
+    y_max = max(max(y_vals) * 1.2, y_floor) if y_vals else y_floor
+
+    fig.update_layout(
+        barmode="group",
+        title=title,
+        xaxis_title="Model  (★ = we tested this model on CPU)",
+        yaxis_title="File F1",
+        yaxis=dict(range=[0, y_max]),
+        height=400,
+        legend=dict(orientation="h", yanchor="bottom", y=1.02),
+        xaxis_tickangle=-30,
+    )
+    return fig
+
+
+def _render_phase_explainer() -> None:
+    """Plain-language Phase A vs Phase B primer for a non-specialist reader."""
+    with st.expander("How Phase A and Phase B work", expanded=True):
+        st.markdown(
+            "We ask the model to act like a security reviewer with a terminal. "
+            "Each CVE is tested **twice**, with the same bug description, on two "
+            "versions of the same project:"
+        )
+        col_a, col_b = st.columns(2)
+        with col_a:
+            st.markdown(
+                """
+**Phase A — Find the bug**
+
+We hand the model a project that **still contains** a known security hole
+and ask: *which files is it in?*
+
+- **Right answer:** name the vulnerable files.
+- **Wrong answers:** stay silent, or point at the wrong files.
+- **Score:** File F1 (1.0 = found every vulnerable file and named no extras).
+"""
+            )
+        with col_b:
+            st.markdown(
+                """
+**Phase B — Don't cry wolf**
+
+We hand the model the **same project after the hole has been patched**
+and ask: *is anything still wrong?*
+
+- **Right answer:** say *no vulnerability found*.
+- **Wrong answer:** still flag the patched files (a false alarm).
+- **Score:** True Negative Rate (1.0 = correctly cleared every patched repo).
+"""
+            )
+        st.markdown(
+            """
+**A useful model needs both skills.** Finding real bugs (Phase A) and staying
+quiet once they are fixed (Phase B) are different tests. A high score on only
+one phase is not a passing grade.
+
+**Why a quiet model can look great on Phase B:** if a model almost never
+reports a vulnerability, Phase A collapses (it never finds the bug) but
+Phase B looks strong (saying "nothing found" is the correct answer on
+patched code). That pattern is expected for untrained baselines such as
+Granite-4.0. The opposite pattern — hunting aggressively — raises Phase A
+and then over-flags patched code on Phase B.
+"""
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    st.set_page_config(
+        page_title="CVE Vulnerability Localization",
+        page_icon="🔍",
+        layout="wide",
+    )
+
+    st.title("🔍 CVE Vulnerability Localization (VLoc Bench)")
+    st.markdown(
+        "Quality and throughput results from the Cisco VLoc Bench "
+        "agent-loop evaluation. Each CVE is scored twice: **Phase A** (find "
+        "the still-vulnerable files) and **Phase B** (recognize that the "
+        "patch already fixed it). Higher File F1 and True Negative Rate "
+        "are better — but they measure different skills, so they are not "
+        "interchangeable."
+    )
+    _render_phase_explainer()
+
+    # ------------------------------------------------------------------
+    # Sidebar — configuration
+    # ------------------------------------------------------------------
+    with st.sidebar:
+        st.header("Configuration")
+
+        config = DashboardConfig()
+        default_results_dir = str(Path(config.get_results_directory()))
+
+        results_dir_input = st.text_input(
+            "Results Directory",
+            value=default_results_dir,
+            help="Path to the results/llm directory",
+            key="results_dir_cve",
+        )
+
+        if st.button("🔄 Reload Data"):
+            st.cache_data.clear()
+            st.rerun()
+
+    # ------------------------------------------------------------------
+    # Load data
+    # ------------------------------------------------------------------
+    df = load_cve_results(results_dir_input)
+
+    if df.empty:
+        st.warning("No CVE-VLoc results found.")
+        st.code(
+            "# Run a CVE-VLoc benchmark (from repository root):\n"
+            "./cpueval --suite cve-vloc --model ibm-granite/granite-4.0-350m\n"
+            "\n"
+            "# Or via Ansible:\n"
+            "ansible-playbook automation/test-execution/ansible/"
+            "llm-benchmark-cve-vloc.yml \\\n"
+            '  -e "test_model=ibm-granite/granite-4.0-350m"\n'
+            '  -e "requested_cores=16"'
+        )
+        return
+
+    st.success(f"Loaded {len(df)} CVE-VLoc test run(s)")
+
+    # ------------------------------------------------------------------
+    # Sidebar — filters (after data loaded)
+    # ------------------------------------------------------------------
+    with st.sidebar:
+        st.markdown("---")
+        st.header("Filters")
+
+        all_models = sorted(df["model_short"].unique().tolist())
+        sel_models = st.multiselect(
+            "Model", options=all_models, default=all_models, key="cve_models"
+        )
+        if not sel_models:
+            sel_models = all_models
+
+        all_phases = sorted(df["vloc_phases"].unique().tolist())
+        sel_phases = st.multiselect(
+            "Phases run", options=all_phases, default=all_phases, key="cve_phases"
+        )
+        if not sel_phases:
+            sel_phases = all_phases
+
+        all_cores = sorted(df["cores"].unique().tolist())
+        sel_cores = st.multiselect(
+            "Cores", options=all_cores, default=all_cores, key="cve_cores"
+        )
+        if not sel_cores:
+            sel_cores = all_cores
+
+        if df["vllm_version"].nunique() > 1:
+            all_versions = sorted(df["vllm_version"].unique().tolist())
+            sel_versions = st.multiselect(
+                "vLLM Version",
+                options=all_versions,
+                default=all_versions,
+                key="cve_versions",
+            )
+            if not sel_versions:
+                sel_versions = all_versions
+        else:
+            sel_versions = df["vllm_version"].unique().tolist()
+
+        st.markdown("---")
+        show_leaderboard = st.checkbox(
+            "Compare to upstream leaderboard",
+            value=True,
+            help="Fetch reference scores from the VLoc Bench leaderboard",
+        )
+
+    # Apply filters
+    dff = df[
+        df["model_short"].isin(sel_models)
+        & df["vloc_phases"].isin(sel_phases)
+        & df["cores"].isin(sel_cores)
+        & df["vllm_version"].isin(sel_versions)
+    ].copy()
+
+    if dff.empty:
+        st.warning("No results match the current filters.")
+        return
+
+    # Environment banner
+    unique_versions = dff["vllm_version"].unique()
+    unique_containers = dff["container_image"].unique()
+    if len(unique_versions) > 1 or len(unique_containers) > 1:
+        st.warning(
+            f"**Mixed environments** — {len(unique_containers)} container "
+            f"image(s), {len(unique_versions)} vLLM version(s). "
+            "Compare with care."
+        )
+    else:
+        container_short = (
+            unique_containers[0].split("/")[-1]
+            if len(unique_containers) > 0
+            else "unknown"
+        )
+        ver = unique_versions[0] if len(unique_versions) > 0 else "unknown"
+        st.info(f"🐳 **Environment**: {container_short} (vLLM {ver})")
+
+    # Best run per model (highest mean_file_f1 among all runs for that model)
+    best_per_model = (
+        dff.sort_values("mean_file_f1", ascending=False)
+        .groupby("model_short", sort=False)
+        .first()
+        .reset_index()
+    )
+
+    # ==================================================================
+    # KPI SUMMARY
+    # ==================================================================
+    st.header("📊 Summary")
+
+    n_models = dff["model_short"].nunique()
+    n_runs = len(dff)
+    best_f1 = dff["mean_file_f1"].max()
+    best_model = dff.loc[dff["mean_file_f1"].idxmax(), "model_short"] if best_f1 is not None else "—"
+
+    kpi1, kpi2, kpi3, kpi4 = st.columns(4)
+    kpi1.metric("Models Tested", n_models)
+    kpi2.metric("Total Runs", n_runs)
+    kpi3.metric("Best File F1", f"{best_f1:.3f}" if best_f1 is not None else "—")
+    kpi4.metric("Best Model", best_model)
+    st.caption(
+        "Best File F1 and Best Model are **Phase A** scores (did the model "
+        "find the vulnerable files?). They do not include Phase B "
+        "(did it stay quiet on already-patched code?)."
+    )
+
+    # ==================================================================
+    # SECTION 1: Quality — File F1
+    # ==================================================================
+    st.divider()
+    st.subheader("1️⃣ Localization Quality — File F1 (Phase A)")
+    st.markdown(
+        "Phase A is the **find-the-bug** test: the vulnerability is still "
+        "in the code, and the model must name the right files. "
+        "File F1 is the harmonic mean of precision (were the files it named "
+        "actually vulnerable?) and recall (did it find all of them?). "
+        "A score of 1.0 means it identified every vulnerable file and "
+        "submitted no extras. Silence counts as a miss (File F1 = 0)."
+    )
+
+    # Latest run per model (use best F1 for comparison)
+    f1_data = (
+        best_per_model[["model_short", "mean_file_f1", "abstain_rate"]]
+        .sort_values("mean_file_f1", ascending=False)
+    )
+
+    fig_f1 = go.Figure()
+    fig_f1.add_trace(go.Bar(
+        name="File F1",
+        x=f1_data["model_short"],
+        y=f1_data["mean_file_f1"].fillna(0),
+        text=[f"{v:.3f}" for v in f1_data["mean_file_f1"].fillna(0)],
+        textposition="auto",
+        marker_color=_COLORS["file_f1"],
+        hovertemplate="<b>%{x}</b><br>File F1: %{y:.3f}<extra></extra>",
+    ))
+    fig_f1.add_trace(go.Bar(
+        name="Abstain Rate",
+        x=f1_data["model_short"],
+        y=f1_data["abstain_rate"].fillna(0),
+        text=[f"{v:.2%}" for v in f1_data["abstain_rate"].fillna(0)],
+        textposition="auto",
+        marker_color=_COLORS["abstain"],
+        opacity=0.6,
+        hovertemplate="<b>%{x}</b><br>Abstain Rate: %{y:.2%}<extra></extra>",
+    ))
+    fig_f1.update_layout(
+        barmode="group",
+        xaxis_title="Model",
+        yaxis_title="Score (0–1)",
+        yaxis=dict(range=[0, 1]),
+        height=420,
+        legend=dict(orientation="h", yanchor="bottom", y=1.02),
+    )
+    st.plotly_chart(fig_f1, use_container_width=True)
+    st.caption(
+        "**Abstain Rate** (red) = fraction of tasks where the model submitted "
+        "nothing. File F1 is 0 on those tasks. A high abstain rate usually "
+        "means the model has not been trained to use the terminal tools this "
+        "benchmark requires — it never starts the search, so it cannot find "
+        "the bug."
+    )
+
+    # ==================================================================
+    # SECTION 2: Phase B — True Negative Rate
+    # ==================================================================
+    phase_b_data = best_per_model[
+        best_per_model["true_negative_rate"].notna()
+        & (best_per_model["phase_b_tasks"] > 0)
+    ]
+
+    if not phase_b_data.empty:
+        st.divider()
+        st.subheader("2️⃣ False Positive Resistance — True Negative Rate (Phase B)")
+        st.markdown(
+            "Phase B is the **don't-cry-wolf** test: the same project, after "
+            "the bug has already been patched. A True Negative means the "
+            "model correctly declared *no vulnerability found*. "
+            "A False Positive means it still flagged the fixed code as "
+            "vulnerable. High TNR is good — but only if Phase A is also good. "
+            "A model that never reports a bug will ace Phase B and fail Phase A."
+        )
+
+        tnr_data = phase_b_data.sort_values("true_negative_rate", ascending=False)
+
+        fig_tnr = go.Figure()
+        fig_tnr.add_trace(go.Bar(
+            name="True Negative Rate",
+            x=tnr_data["model_short"],
+            y=tnr_data["true_negative_rate"].fillna(0),
+            text=[f"{v:.3f}" for v in tnr_data["true_negative_rate"].fillna(0)],
+            textposition="auto",
+            marker_color=_COLORS["tnr"],
+            hovertemplate="<b>%{x}</b><br>TNR: %{y:.3f}<extra></extra>",
+        ))
+        if "false_positive_rate" in tnr_data.columns:
+            fig_tnr.add_trace(go.Bar(
+                name="False Positive Rate",
+                x=tnr_data["model_short"],
+                y=tnr_data["false_positive_rate"].fillna(0),
+                text=[f"{v:.3f}" for v in tnr_data["false_positive_rate"].fillna(0)],
+                textposition="auto",
+                marker_color=_COLORS["abstain"],
+                opacity=0.6,
+                hovertemplate=(
+                    "<b>%{x}</b><br>"
+                    "False Positive Rate: %{y:.3f}<extra></extra>"
+                ),
+            ))
+        fig_tnr.update_layout(
+            barmode="group",
+            xaxis_title="Model",
+            yaxis_title="Rate (0–1)",
+            yaxis=dict(range=[0, 1]),
+            height=380,
+            legend=dict(orientation="h", yanchor="bottom", y=1.02),
+        )
+        st.plotly_chart(fig_tnr, use_container_width=True)
+
+    # ==================================================================
+    # SECTION 3: Leaderboard Comparison
+    # ==================================================================
+    if show_leaderboard:
+        st.divider()
+        st.subheader("3️⃣ Upstream Leaderboard Context")
+        st.caption(
+            "This section is Phase A File F1 only — the same skill as chart 1, "
+            "compared with the published GPU leaderboard. It is not a Phase B "
+            "ranking."
+        )
+
+        lb_df, lb_source = load_leaderboard()
+
+        if lb_source == "cached":
+            st.info(
+                "ℹ️ Network unavailable — using embedded leaderboard "
+                "snapshot (fetched 2026-08-11). "
+                "Restart the dashboard with network access to refresh."
+            )
+
+        if not lb_df.empty:
+            # Build a combined view: all leaderboard models + our local results
+            # annotated with whether we ran them
+            local_scores: Dict[str, float] = {}
+            for _, row in best_per_model.iterrows():
+                lb_name = row["leaderboard_name"]
+                f1 = row["mean_file_f1"]
+                if lb_name and f1 is not None:
+                    # Keep the best local score if model appears multiple times
+                    if lb_name not in local_scores or f1 > local_scores[lb_name]:
+                        local_scores[lb_name] = f1
+
+            # Merge leaderboard with local scores
+            lb_df["local_file_f1"] = lb_df["lb_model"].map(local_scores)
+            lb_df["has_local"] = lb_df["local_file_f1"].notna()
+
+            st.markdown(
+                "The published leaderboard is a **Phase A File F1** ranking "
+                "(GPU). One chart cannot show both a 0.22 GPT-class score and "
+                "a 0.002 Granite score without flattening the models we "
+                "actually ran. The three charts below group models by score "
+                "band; each band has its own vertical scale. ★ marks models "
+                "we tested on CPU. Placement follows File F1, not Phase B "
+                "TNR — Granite belongs in the low band here even when its "
+                "Phase B score is high."
+            )
+
+            tested = lb_df[lb_df["has_local"]].copy()
+            if not tested.empty:
+                def _band_label(score) -> str:
+                    if _in_f1_band(score, 0.15, None):
+                        return "High (≥ 0.15)"
+                    if _in_f1_band(score, 0.05, 0.15):
+                        return "Mid (0.05–0.15)"
+                    return "Low (< 0.05)"
+
+                tested["band"] = tested["lb_file_f1"].apply(_band_label)
+                locations = ", ".join(
+                    f"**{row['lb_model']}** → {row['band']}"
+                    for _, row in tested.sort_values(
+                        "lb_file_f1", ascending=False
+                    ).iterrows()
+                )
+                st.markdown(f"Where our tested models sit: {locations}.")
+
+            for band in _F1_BANDS:
+                band_df = lb_df[
+                    lb_df["lb_file_f1"].apply(
+                        lambda s, lo=band["lo"], hi=band["hi"]: _in_f1_band(
+                            s, lo, hi
+                        )
+                    )
+                ]
+                if band_df.empty:
+                    continue
+                fig_lb = _leaderboard_band_figure(
+                    band_df, band["title"], band["y_floor"]
+                )
+                st.plotly_chart(fig_lb, use_container_width=True)
+
+            st.caption(
+                "Purple bars = leaderboard reference scores (GPU). "
+                "Blue bars = our CPU results on the same model (★). "
+                "CPU scores may differ from GPU reference due to "
+                "different n_limit, temperature sensitivity, and inference speed. "
+                "These charts are Phase A File F1 only — they do not rank "
+                "Phase B (don't-cry-wolf) performance."
+            )
+
+            # Leaderboard table with local score column
+            with st.expander("📋 Full leaderboard table", expanded=False):
+                display_lb = lb_df[
+                    ["lb_model", "lb_size", "lb_type", "lb_file_f1",
+                     "lb_true_negative_rate", "lb_submitted_nothing_rate",
+                     "local_file_f1"]
+                ].copy()
+                display_lb.columns = [
+                    "Model", "Size", "Type", "File F1 (LB)",
+                    "TNR (LB)", "Abstain Rate (LB)", "File F1 (Our CPU)"
+                ]
+                display_lb = display_lb.sort_values("File F1 (LB)", ascending=False)
+                for col in ["File F1 (LB)", "TNR (LB)", "Abstain Rate (LB)", "File F1 (Our CPU)"]:
+                    display_lb[col] = display_lb[col].apply(
+                        lambda v: f"{v:.3f}" if pd.notna(v) else "—"
+                    )
+                st.dataframe(display_lb, hide_index=True, use_container_width=True)
+
+            # Delta table — only models we tested
+            matched = lb_df[lb_df["has_local"]].copy()
+            if not matched.empty:
+                st.markdown("**Score delta for tested models:**")
+                matched["delta"] = matched["local_file_f1"] - matched["lb_file_f1"]
+                delta_cols = ["lb_model", "lb_file_f1", "local_file_f1", "delta"]
+                delta_df = matched[delta_cols].copy()
+                delta_df.columns = ["Model", "LB File F1 (GPU)", "Our File F1 (CPU)", "Delta"]
+                delta_df = delta_df.sort_values("Our File F1 (CPU)", ascending=False)
+                st.dataframe(
+                    delta_df.style.format({
+                        "LB File F1 (GPU)": "{:.3f}",
+                        "Our File F1 (CPU)": "{:.3f}",
+                        "Delta": "{:+.3f}",
+                    }).applymap(
+                        lambda v: "color: green" if isinstance(v, float) and v >= 0
+                        else ("color: red" if isinstance(v, float) and v < 0 else ""),
+                        subset=["Delta"],
+                    ),
+                    hide_index=True,
+                    use_container_width=True,
+                )
+                st.caption(
+                    "Positive delta = our CPU result exceeds the GPU "
+                    "leaderboard for that model. "
+                    "Negative delta is expected for n_limit smoke tests "
+                    "(fewer tasks = noisier score)."
+                )
+
+    # ==================================================================
+    # SECTION 4: Throughput
+    # ==================================================================
+    st.divider()
+    st.subheader("4️⃣ Throughput — Tasks per Hour")
+    st.markdown(
+        "Higher tasks/hr means the model completes the agent loop faster "
+        "per CVE task (driven by inference speed on CPU)."
+    )
+
+    tput_data = (
+        dff[dff["tasks_per_hour"].notna()]
+        .groupby(["model_short", "cores"])["tasks_per_hour"]
+        .mean()
+        .reset_index()
+    )
+    tput_data["label"] = (
+        tput_data["model_short"] + "\n" + tput_data["cores"].astype(str) + " cores"
+    )
+    tput_data = tput_data.sort_values("tasks_per_hour", ascending=False)
+
+    if not tput_data.empty:
+        fig_tput = go.Figure(go.Bar(
+            x=tput_data["label"],
+            y=tput_data["tasks_per_hour"],
+            text=tput_data["tasks_per_hour"].round(1),
+            textposition="auto",
+            marker_color=_COLORS["throughput"],
+            hovertemplate="<b>%{x}</b><br>Tasks/hr: %{y:.1f}<extra></extra>",
+        ))
+        fig_tput.update_layout(
+            xaxis_title="Configuration",
+            yaxis_title="Tasks per Hour",
+            height=380,
+            showlegend=False,
+        )
+        st.plotly_chart(fig_tput, use_container_width=True)
+        st.caption(
+            "Smaller models complete tasks faster but may trade quality for speed. "
+            "Tasks/hr is a function of model size, CPU cores, and n_limit."
+        )
+    else:
+        st.info("No throughput data available in current results.")
+
+    # ==================================================================
+    # SECTION 5: All Runs Table
+    # ==================================================================
+    st.divider()
+    with st.expander("📋 All Runs — Raw Results", expanded=False):
+        display_cols = {
+            "model_short": "Model",
+            "vloc_phases": "Phases",
+            "cores": "Cores",
+            "workers": "Workers",
+            "n_limit": "N Limit",
+            "mean_file_f1": "File F1",
+            "abstain_rate": "Abstain Rate",
+            "true_negative_rate": "TNR",
+            "false_positive_rate": "FP Rate",
+            "tasks_completed": "Tasks Done",
+            "phase_a_tasks": "Phase A",
+            "phase_b_tasks": "Phase B",
+            "tasks_per_hour": "Tasks/hr",
+            "vllm_version": "vLLM Ver.",
+            "test_run_id": "Run ID",
+        }
+        avail = {k: v for k, v in display_cols.items() if k in dff.columns}
+        show_df = dff[list(avail.keys())].copy()
+        show_df.columns = list(avail.values())
+
+        for col in ["File F1", "Abstain Rate", "TNR", "FP Rate"]:
+            if col in show_df.columns:
+                show_df[col] = show_df[col].apply(
+                    lambda v: round(v, 4) if pd.notna(v) else None
+                )
+        if "Tasks/hr" in show_df.columns:
+            show_df["Tasks/hr"] = show_df["Tasks/hr"].apply(
+                lambda v: round(v, 1) if pd.notna(v) else None
+            )
+
+        st.dataframe(
+            show_df.sort_values(["Model", "Run ID"]),
+            hide_index=True,
+            use_container_width=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/automation/test-execution/scripts/bash/patch-vllm-granite-hybrid.sh
+++ b/automation/test-execution/scripts/bash/patch-vllm-granite-hybrid.sh
@@ -110,6 +110,10 @@ check_needed || rc=$?
 if [[ "${rc}" -eq 1 ]]; then
     echo "Patch not needed — container already has full_attention support"
     echo "Skipping patch (vLLM version likely > v0.25.1)"
+    if [[ -f "${OUTPUT_DIR}/granitemoehybrid.py" ]]; then
+        rm -f "${OUTPUT_DIR}/granitemoehybrid.py"
+        echo "Removed stale overlay: ${OUTPUT_DIR}/granitemoehybrid.py"
+    fi
     exit 0
 elif [[ "${rc}" -ne 0 ]]; then
     exit "${rc}"

--- a/automation/test-execution/scripts/bash/patch-vllm-granite-hybrid.sh
+++ b/automation/test-execution/scripts/bash/patch-vllm-granite-hybrid.sh
@@ -111,7 +111,7 @@ if [[ "${rc}" -eq 1 ]]; then
     echo "Patch not needed — container already has full_attention support"
     echo "Skipping patch (vLLM version likely > v0.25.1)"
     if [[ -f "${OUTPUT_DIR}/granitemoehybrid.py" ]]; then
-        rm -f "${OUTPUT_DIR}/granitemoehybrid.py"
+        rm -f "${OUTPUT_DIR}/granitemoehybrid.py" "${OUTPUT_DIR}/.image-id"
         echo "Removed stale overlay: ${OUTPUT_DIR}/granitemoehybrid.py"
     fi
     exit 0
@@ -121,9 +121,12 @@ fi
 
 assert_output_dir_safe "${OUTPUT_DIR}"
 
+STAMP_FILE="${OUTPUT_DIR}/.image-id"
 if [[ -f "${OUTPUT_DIR}/granitemoehybrid.py" ]] && \
-   grep -q '"full_attention"' "${OUTPUT_DIR}/granitemoehybrid.py" 2>/dev/null; then
-    echo "Patch already applied at ${OUTPUT_DIR}/granitemoehybrid.py"
+   grep -q '"full_attention"' "${OUTPUT_DIR}/granitemoehybrid.py" 2>/dev/null && \
+   [[ -f "${STAMP_FILE}" ]] && \
+   [[ "$(cat "${STAMP_FILE}")" == "${CONTAINER_IMAGE}" ]]; then
+    echo "Patch already applied at ${OUTPUT_DIR}/granitemoehybrid.py (image: ${CONTAINER_IMAGE})"
     exit 0
 fi
 
@@ -141,6 +144,7 @@ sed -i \
     "${OUTPUT_DIR}/granitemoehybrid.py"
 
 if grep -q '"full_attention"' "${OUTPUT_DIR}/granitemoehybrid.py"; then
+    echo "${CONTAINER_IMAGE}" > "${STAMP_FILE}"
     echo "Patch applied successfully: ${OUTPUT_DIR}/granitemoehybrid.py"
     echo ""
     echo "Mount into container with:"

--- a/automation/test-execution/scripts/bash/patch-vllm-granite-hybrid.sh
+++ b/automation/test-execution/scripts/bash/patch-vllm-granite-hybrid.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# ==============================================================================
+# Patch vLLM v0.25.1 for Granite-4.0 hybrid model support
+# ==============================================================================
+# vLLM v0.25.1 does not recognize the 'full_attention' and 'linear_attention'
+# layer types used by Granite-4.0 models with HuggingFace Transformers >= 5.13.0.
+# This was fixed upstream in vLLM PR #47867 but has not yet been released.
+#
+# This script extracts granitemoehybrid.py from the container image, applies
+# the fix, and writes it to a local path for volume-mounting into the container.
+#
+# TODO: Remove this patch once vLLM > v0.25.1 is released with PR #47867.
+#
+# Usage:
+#   ./patch-vllm-granite-hybrid.sh [options]
+#
+# Options:
+#   --output-dir DIR         Directory for patched file (default: /tmp/vllm-patch)
+#   --container-image IMAGE  vLLM container image (default: docker.io/vllm/vllm-openai-cpu:v0.25.1)
+#   --check                  Check if patch is needed (exit 0 if needed, 1 if not)
+#   -h, --help               Show this help
+#
+# The patched file should be mounted into the container:
+#   podman run ... \
+#     -v /tmp/vllm-patch/granitemoehybrid.py:/opt/venv/lib/python3.12/site-packages/vllm/model_executor/models/granitemoehybrid.py:z \
+#     ...
+# ==============================================================================
+
+set -euo pipefail
+
+OUTPUT_DIR="/tmp/vllm-patch"
+CONTAINER_IMAGE="${VLLM_CONTAINER_IMAGE:-docker.io/vllm/vllm-openai-cpu:v0.25.1}"
+CHECK_ONLY=false
+CONTAINER_PATH="/opt/venv/lib/python3.12/site-packages/vllm/model_executor/models/granitemoehybrid.py"
+
+usage() {
+    echo "Usage: $0 [--output-dir DIR] [--container-image IMAGE] [--check]"
+    echo ""
+    echo "Patches vLLM v0.25.1 to support Granite-4.0 hybrid models."
+    echo "TODO: Remove once vLLM > v0.25.1 ships with PR #47867."
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+        --container-image) CONTAINER_IMAGE="$2"; shift 2 ;;
+        --check) CHECK_ONLY=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: $1"; usage; exit 1 ;;
+    esac
+done
+
+ENGINE="${CONTAINER_ENGINE:-$(command -v podman 2>/dev/null || command -v docker 2>/dev/null)}"
+if [[ -z "${ENGINE}" ]]; then
+    echo "ERROR: No container engine (podman/docker) found" >&2
+    exit 1
+fi
+
+check_needed() {
+    local content
+    content=$("${ENGINE}" run --rm --entrypoint cat "${CONTAINER_IMAGE}" "${CONTAINER_PATH}" 2>/dev/null)
+    if echo "${content}" | grep -q '"full_attention"'; then
+        return 1
+    fi
+    return 0
+}
+
+if [[ "${CHECK_ONLY}" == "true" ]]; then
+    if check_needed; then
+        echo "Patch needed: ${CONTAINER_IMAGE} missing full_attention support"
+        exit 0
+    else
+        echo "Patch not needed: ${CONTAINER_IMAGE} already has full_attention support"
+        exit 1
+    fi
+fi
+
+if ! check_needed; then
+    echo "Patch not needed — container already has full_attention support"
+    echo "Skipping patch (vLLM version likely > v0.25.1)"
+    exit 0
+fi
+
+if [[ -f "${OUTPUT_DIR}/granitemoehybrid.py" ]] && \
+   grep -q '"full_attention"' "${OUTPUT_DIR}/granitemoehybrid.py" 2>/dev/null; then
+    echo "Patch already applied at ${OUTPUT_DIR}/granitemoehybrid.py"
+    exit 0
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+
+echo "Extracting granitemoehybrid.py from ${CONTAINER_IMAGE}..."
+"${ENGINE}" run --rm --entrypoint cat "${CONTAINER_IMAGE}" "${CONTAINER_PATH}" \
+    > "${OUTPUT_DIR}/granitemoehybrid.py"
+
+echo "Applying full_attention / linear_attention patch..."
+sed -i \
+    '/"mamba": GraniteMoeHybridMambaDecoderLayer,/a\    # Transformers >= 5.13.0 (vLLM PR #47867 backport — remove when vLLM > v0.25.1)\n    "full_attention": GraniteMoeHybridAttentionDecoderLayer,\n    "linear_attention": GraniteMoeHybridMambaDecoderLayer,' \
+    "${OUTPUT_DIR}/granitemoehybrid.py"
+
+if grep -q '"full_attention"' "${OUTPUT_DIR}/granitemoehybrid.py"; then
+    echo "Patch applied successfully: ${OUTPUT_DIR}/granitemoehybrid.py"
+    echo ""
+    echo "Mount into container with:"
+    echo "  -v ${OUTPUT_DIR}/granitemoehybrid.py:${CONTAINER_PATH}:z"
+else
+    echo "ERROR: Patch failed — full_attention not found in output" >&2
+    exit 1
+fi

--- a/automation/test-execution/scripts/bash/patch-vllm-granite-hybrid.sh
+++ b/automation/test-execution/scripts/bash/patch-vllm-granite-hybrid.sh
@@ -56,9 +56,31 @@ if [[ -z "${ENGINE}" ]]; then
     exit 1
 fi
 
+assert_output_dir_safe() {
+    local dir="$1"
+    if [[ ! -e "${dir}" ]]; then
+        return 0
+    fi
+    if [[ ! -d "${dir}" ]]; then
+        echo "ERROR: OUTPUT_DIR is not a directory: ${dir}" >&2
+        exit 1
+    fi
+    if [[ ! -O "${dir}" ]]; then
+        echo "ERROR: OUTPUT_DIR is not owned by the current user: ${dir}" >&2
+        exit 1
+    fi
+    if find "${dir}" -maxdepth 0 \( -perm -g=w -o -perm -o=w \) | grep -q .; then
+        echo "ERROR: OUTPUT_DIR is writable by group or others: ${dir}" >&2
+        exit 1
+    fi
+}
+
 check_needed() {
     local content
-    content=$("${ENGINE}" run --rm --entrypoint cat "${CONTAINER_IMAGE}" "${CONTAINER_PATH}" 2>/dev/null)
+    if ! content=$("${ENGINE}" run --rm --entrypoint cat "${CONTAINER_IMAGE}" "${CONTAINER_PATH}"); then
+        echo "ERROR: Failed to inspect ${CONTAINER_PATH} in ${CONTAINER_IMAGE}" >&2
+        return 2
+    fi
     if echo "${content}" | grep -q '"full_attention"'; then
         return 1
     fi
@@ -66,20 +88,34 @@ check_needed() {
 }
 
 if [[ "${CHECK_ONLY}" == "true" ]]; then
-    if check_needed; then
-        echo "Patch needed: ${CONTAINER_IMAGE} missing full_attention support"
-        exit 0
-    else
-        echo "Patch not needed: ${CONTAINER_IMAGE} already has full_attention support"
-        exit 1
-    fi
+    rc=0
+    check_needed || rc=$?
+    case "${rc}" in
+        0)
+            echo "Patch needed: ${CONTAINER_IMAGE} missing full_attention support"
+            exit 0
+            ;;
+        1)
+            echo "Patch not needed: ${CONTAINER_IMAGE} already has full_attention support"
+            exit 1
+            ;;
+        *)
+            exit "${rc}"
+            ;;
+    esac
 fi
 
-if ! check_needed; then
+rc=0
+check_needed || rc=$?
+if [[ "${rc}" -eq 1 ]]; then
     echo "Patch not needed — container already has full_attention support"
     echo "Skipping patch (vLLM version likely > v0.25.1)"
     exit 0
+elif [[ "${rc}" -ne 0 ]]; then
+    exit "${rc}"
 fi
+
+assert_output_dir_safe "${OUTPUT_DIR}"
 
 if [[ -f "${OUTPUT_DIR}/granitemoehybrid.py" ]] && \
    grep -q '"full_attention"' "${OUTPUT_DIR}/granitemoehybrid.py" 2>/dev/null; then
@@ -88,6 +124,8 @@ if [[ -f "${OUTPUT_DIR}/granitemoehybrid.py" ]] && \
 fi
 
 mkdir -p "${OUTPUT_DIR}"
+chmod 700 "${OUTPUT_DIR}"
+assert_output_dir_safe "${OUTPUT_DIR}"
 
 echo "Extracting granitemoehybrid.py from ${CONTAINER_IMAGE}..."
 "${ENGINE}" run --rm --entrypoint cat "${CONTAINER_IMAGE}" "${CONTAINER_PATH}" \

--- a/automation/test-execution/scripts/bash/run-cve-vloc-suite.sh
+++ b/automation/test-execution/scripts/bash/run-cve-vloc-suite.sh
@@ -23,7 +23,7 @@
 #   --workers NUM            Parallel VLoc workers (default: 1)
 #   --phases PHASES          a, b, or ab (default: a)
 #   --n-limit NUM            Max tasks per model (default: 5)
-#   --vloc-dir PATH          DUT-side cache dir for data/results (default: /tmp/vloc-bench)
+#   --vloc-dir PATH          DUT-side cache dir for data/results (default: ~/vloc-bench on DUT)
 #   --runner RUNNER          Override auto-detected VLoc runner
 #   --port PORT              vLLM port (default: 8200)
 #   --container-image IMAGE  Override vLLM container image
@@ -150,7 +150,7 @@ CORES_INPUT="16"
 WORKERS=1
 PHASES="a"
 N_LIMIT=5
-VLOC_DIR="${VLOC_DIR:-/tmp/vloc-bench}"
+VLOC_DIR="${VLOC_DIR:-}"
 RUNNER_OVERRIDE=""
 PORT=8200
 CONTAINER_IMAGE="${VLLM_CONTAINER_IMAGE:-}"
@@ -190,7 +190,7 @@ OPTIONS:
   --workers NUM            Parallel VLoc workers (default: 1)
   --phases PHASES          a, b, or ab (default: a)
   --n-limit NUM            Max tasks per model (default: 5)
-  --vloc-dir PATH          DUT-side cache dir for data/results (default: /tmp/vloc-bench)
+  --vloc-dir PATH          DUT-side cache dir for data/results (default: ~/vloc-bench on DUT)
   --runner RUNNER          Override auto-detected VLoc runner
   --port PORT              vLLM port (default: 8200)
   --container-image IMAGE  Override vLLM container image
@@ -336,7 +336,7 @@ echo "Cores:      ${CORE_COUNTS[*]}"
 echo "Workers:    ${WORKERS}"
 echo "Phases:     ${PHASES}"
 echo "N-limit:    ${N_LIMIT} (0=all 500)"
-echo "VLoc dir:   ${VLOC_DIR}"
+echo "VLoc dir:   ${VLOC_DIR:-(auto: ~/vloc-bench on DUT)}"
 echo "Port:       ${PORT}"
 if [[ -n "${CONTAINER_IMAGE}" ]]; then
     echo "Image:      ${CONTAINER_IMAGE}"
@@ -398,7 +398,7 @@ run_single() {
     cmd+=" -e vloc_phases=${PHASES}"
     cmd+=" -e vloc_workers=${WORKERS}"
     cmd+=" -e vloc_n_limit=${N_LIMIT}"
-    cmd+=" -e vloc_dir=${VLOC_DIR}"
+    [[ -n "${VLOC_DIR}" ]] && cmd+=" -e vloc_dir=${VLOC_DIR}"
     cmd+=" -e vllm_port=${PORT}"
     if [[ "${KEEP_SERVER:-false}" == "true" ]]; then
         cmd+=" -e cleanup_after_test=false"

--- a/automation/test-execution/scripts/bash/run-cve-vloc-suite.sh
+++ b/automation/test-execution/scripts/bash/run-cve-vloc-suite.sh
@@ -94,7 +94,7 @@ MODEL_GRANITE_MICRO="ibm-granite/granite-4.0-micro"
 # Required: Qwen (9B exception)
 MODEL_QWEN_9B="Qwen/Qwen3.5-9B"
 
-# Required: Antares (gated)
+# Required: Antares (gated — each model requires a separate access grant on HuggingFace)
 MODEL_ANTARES_1B="fdtn-ai/antares-1b"
 MODEL_ANTARES_350M="fdtn-ai/antares-350m"
 # Optional: Antares-3B (weights not public yet; skip if MODEL_ANTARES_3B unset)
@@ -360,7 +360,13 @@ done
 if [[ "${has_gated}" == "true" ]] && [[ -z "${HF_TOKEN:-}" ]]; then
     echo -e "${RED}ERROR: Model list includes gated models (Antares) but HF_TOKEN is not set.${NC}"
     echo "  export HF_TOKEN=hf_xxxxx"
-    echo "  Apply at: https://huggingface.co/fdtn-ai/antares-1b"
+    echo ""
+    echo "  Each Antares model requires a separate access grant — request access at:"
+    echo "    https://huggingface.co/fdtn-ai/antares-350m"
+    echo "    https://huggingface.co/fdtn-ai/antares-1b"
+    echo "    https://huggingface.co/fdtn-ai/antares-3b  (if running 3B)"
+    echo ""
+    echo "  A token valid for antares-1b does NOT automatically grant access to antares-350m."
     exit 1
 fi
 

--- a/automation/test-execution/scripts/bash/run-cve-vloc-suite.sh
+++ b/automation/test-execution/scripts/bash/run-cve-vloc-suite.sh
@@ -17,7 +17,7 @@
 #
 # Options:
 #   --models LIST            Comma-separated models or preset
-#                            Presets: granite, qwen, antares, public, all
+#                            Presets: granite, qwen, antares, gemma, public, all
 #                            Default: granite (smoke), all (model-sweep)
 #   --cores LIST             Comma-separated core counts (default: 16)
 #   --workers NUM            Parallel VLoc workers (default: 1)
@@ -188,7 +188,7 @@ MODES:
 
 OPTIONS:
   --models LIST            Comma-separated models or preset
-                           Presets: granite, qwen, antares, public, all
+                           Presets: granite, qwen, antares, gemma, public, all
   --cores LIST             Comma-separated core counts (default: 16)
   --workers NUM            Parallel VLoc workers (default: 1)
   --phases PHASES          a, b, or ab (default: a)
@@ -386,6 +386,7 @@ fi
 run_count=0
 pass_count=0
 fail_count=0
+dry_run_count=0
 failed_runs=()
 
 run_single() {
@@ -433,7 +434,7 @@ run_single() {
 
     if [[ "${DRY_RUN}" == "true" ]]; then
         echo -e "${YELLOW}[DRY RUN] ${cmd[*]}${NC}"
-        pass_count=$((pass_count + 1))
+        dry_run_count=$((dry_run_count + 1))
         return 0
     fi
 
@@ -475,7 +476,11 @@ echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━�
 echo -e "${BOLD}Suite Complete${NC}"
 echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo "Total runs: ${run_count}"
-echo -e "Passed:     ${GREEN}${pass_count}${NC}"
+if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "Dry-run:    ${dry_run_count} (not executed)"
+else
+    echo -e "Passed:     ${GREEN}${pass_count}${NC}"
+fi
 
 if [[ ${fail_count} -gt 0 ]]; then
     echo -e "Failed:     ${RED}${fail_count}${NC}"

--- a/automation/test-execution/scripts/bash/run-cve-vloc-suite.sh
+++ b/automation/test-execution/scripts/bash/run-cve-vloc-suite.sh
@@ -9,7 +9,7 @@
 #   ./run-cve-vloc-suite.sh <mode> [options]
 #
 # Modes:
-#   smoke                    - Quick gate: 5 tasks, Phase A, smallest Granite
+#   smoke                    - Quick gate: 5 tasks, Phase A, Granite-4.0-350M
 #   phase-a                  - Phase A (vulnerable code localization)
 #   phase-b                  - Phase B (patched code verification)
 #   full                     - Full 500-task run (WARN: hours on CPU)
@@ -28,6 +28,7 @@
 #   --port PORT              vLLM port (default: 8200)
 #   --container-image IMAGE  Override vLLM container image
 #   --keep-server            Don't stop vLLM container after the run
+#   --permissive             Skip VLoc sandbox command allowlist (NOT leaderboard-comparable)
 #   --dry-run                Show commands without executing
 #   --continue-on-error      Don't stop on first failure
 #   -h, --help               Show this help
@@ -156,6 +157,8 @@ PORT=8200
 CONTAINER_IMAGE="${VLLM_CONTAINER_IMAGE:-}"
 DRY_RUN=false
 CONTINUE_ON_ERROR=false
+KEEP_SERVER=false
+VLOC_PERMISSIVE=false
 
 # Colors
 GREEN='\033[0;32m'
@@ -177,7 +180,7 @@ USAGE:
   ./run-cve-vloc-suite.sh <mode> [options]
 
 MODES:
-  smoke           Quick gate: 5 tasks, Phase A, smallest Granite model
+  smoke           Quick gate: 5 tasks, Phase A, Granite-4.0-350M
   phase-a         Phase A (vulnerable code localization)
   phase-b         Phase B (patched code verification)
   full            Full 500-task run (WARNING: hours on CPU)
@@ -195,6 +198,8 @@ OPTIONS:
   --port PORT              vLLM port (default: 8200)
   --container-image IMAGE  Override vLLM container image
   --keep-server            Don't stop vLLM after the run
+  --permissive             Skip VLoc sandbox command allowlist
+                           (default: off — matches published leaderboard protocol)
   --dry-run                Show commands without executing
   --continue-on-error      Don't stop on first failure
   -h, --help               Show this help
@@ -244,6 +249,7 @@ while [[ $# -gt 0 ]]; do
         --dry-run)           DRY_RUN=true; shift ;;
         --continue-on-error) CONTINUE_ON_ERROR=true; shift ;;
         --keep-server)       KEEP_SERVER=true; shift ;;
+        --permissive)        VLOC_PERMISSIVE=true; shift ;;
         -h|--help)           usage ;;
         *)                   echo "Unknown option: $1"; usage ;;
     esac
@@ -255,7 +261,7 @@ done
 
 case "${MODE}" in
     smoke)
-        [[ -z "${MODELS_INPUT}" ]] && MODELS_INPUT="granite"
+        [[ -z "${MODELS_INPUT}" ]] && MODELS_INPUT="${MODEL_GRANITE_350M}"
         N_LIMIT="${VLOC_SMOKE_N:-5}"
         PHASES="a"
         ;;
@@ -341,6 +347,9 @@ echo "Port:       ${PORT}"
 if [[ -n "${CONTAINER_IMAGE}" ]]; then
     echo "Image:      ${CONTAINER_IMAGE}"
 fi
+if [[ "${VLOC_PERMISSIVE}" == "true" ]]; then
+    echo -e "Permissive: ${YELLOW}YES (sandbox allowlist disabled — not leaderboard-comparable)${NC}"
+fi
 if [[ "${DRY_RUN}" == "true" ]]; then
     echo -e "Dry run:    ${YELLOW}YES (no commands will be executed)${NC}"
 fi
@@ -396,36 +405,42 @@ run_single() {
     echo -e "${BLUE}│${NC} Cores: ${cores} | Workers: ${WORKERS} | Phases: ${PHASES} | N: ${N_LIMIT}"
     echo -e "${BLUE}└──────────────────────────────────────────────────────┘${NC}"
 
-    # Build ansible-playbook command
-    local cmd="ansible-playbook -i ${INVENTORY} ${PLAYBOOK}"
-    cmd+=" -e test_model=${model}"
-    cmd+=" -e vloc_runner=${runner}"
-    cmd+=" -e requested_cores=${cores}"
-    cmd+=" -e vloc_phases=${PHASES}"
-    cmd+=" -e vloc_workers=${WORKERS}"
-    cmd+=" -e vloc_n_limit=${N_LIMIT}"
-    [[ -n "${VLOC_DIR}" ]] && cmd+=" -e vloc_dir=${VLOC_DIR}"
-    cmd+=" -e vllm_port=${PORT}"
-    if [[ "${KEEP_SERVER:-false}" == "true" ]]; then
-        cmd+=" -e cleanup_after_test=false"
+    # Build ansible-playbook command as an argv array (no eval)
+    local cmd=(
+        ansible-playbook
+        -i "${INVENTORY}"
+        "${PLAYBOOK}"
+        -e "test_model=${model}"
+        -e "vloc_runner=${runner}"
+        -e "requested_cores=${cores}"
+        -e "vloc_phases=${PHASES}"
+        -e "vloc_workers=${WORKERS}"
+        -e "vloc_n_limit=${N_LIMIT}"
+        -e "vllm_port=${PORT}"
+    )
+    [[ -n "${VLOC_DIR}" ]] && cmd+=(-e "vloc_dir=${VLOC_DIR}")
+    if [[ "${KEEP_SERVER}" == "true" ]]; then
+        cmd+=(-e "cleanup_after_test=false")
     else
-        cmd+=" -e cleanup_after_test=true"
+        cmd+=(-e "cleanup_after_test=true")
     fi
-
     if [[ -n "${CONTAINER_IMAGE}" ]]; then
-        cmd+=" -e vllm_container_image=${CONTAINER_IMAGE}"
+        cmd+=(-e "vllm_container_image=${CONTAINER_IMAGE}")
+    fi
+    if [[ "${VLOC_PERMISSIVE}" == "true" ]]; then
+        cmd+=(-e "vloc_permissive=true")
     fi
 
     if [[ "${DRY_RUN}" == "true" ]]; then
-        echo -e "${YELLOW}[DRY RUN] ${cmd}${NC}"
+        echo -e "${YELLOW}[DRY RUN] ${cmd[*]}${NC}"
         pass_count=$((pass_count + 1))
         return 0
     fi
 
-    echo "Command: ${cmd}"
+    echo "Command: ${cmd[*]}"
     echo ""
 
-    if eval "${cmd}"; then
+    if "${cmd[@]}"; then
         echo -e "${GREEN}PASS${NC} — ${model} @ ${cores} cores"
         pass_count=$((pass_count + 1))
     else

--- a/automation/test-execution/scripts/bash/run-cve-vloc-suite.sh
+++ b/automation/test-execution/scripts/bash/run-cve-vloc-suite.sh
@@ -1,0 +1,471 @@
+#!/bin/bash
+# ==============================================================================
+# CVE Vulnerability Localization Benchmark Suite
+# ==============================================================================
+# Runs Cisco VLoc Bench against vLLM-served models on CPU.
+# Uses Ansible playbook: llm-benchmark-cve-vloc.yml
+#
+# Usage:
+#   ./run-cve-vloc-suite.sh <mode> [options]
+#
+# Modes:
+#   smoke                    - Quick gate: 5 tasks, Phase A, smallest Granite
+#   phase-a                  - Phase A (vulnerable code localization)
+#   phase-b                  - Phase B (patched code verification)
+#   full                     - Full 500-task run (WARN: hours on CPU)
+#   model-sweep              - All matrix models, fixed task count
+#
+# Options:
+#   --models LIST            Comma-separated models or preset
+#                            Presets: granite, qwen, antares, public, all
+#                            Default: granite (smoke), all (model-sweep)
+#   --cores LIST             Comma-separated core counts (default: 16)
+#   --workers NUM            Parallel VLoc workers (default: 1)
+#   --phases PHASES          a, b, or ab (default: a)
+#   --n-limit NUM            Max tasks per model (default: 5)
+#   --vloc-dir PATH          DUT-side cache dir for data/results (default: /tmp/vloc-bench)
+#   --runner RUNNER          Override auto-detected VLoc runner
+#   --port PORT              vLLM port (default: 8200)
+#   --container-image IMAGE  Override vLLM container image
+#   --keep-server            Don't stop vLLM container after the run
+#   --dry-run                Show commands without executing
+#   --continue-on-error      Don't stop on first failure
+#   -h, --help               Show this help
+#
+# Environment variables:
+#   HF_TOKEN                 HuggingFace token (for gated models)
+#   VLLM_CONTAINER_IMAGE     Override container image
+#   VLOC_DIR                 Override VLoc Bench directory
+#   VLOC_SMOKE_N             Override smoke task count (default: 5)
+#
+# Examples:
+#   # Quick smoke test
+#   ./run-cve-vloc-suite.sh smoke
+#
+#   # Phase A with Granite baselines, 25 tasks
+#   ./run-cve-vloc-suite.sh phase-a --models granite --n-limit 25 --cores 16
+#
+#   # Antares evaluation (requires HF_TOKEN)
+#   export HF_TOKEN=hf_xxxxx
+#   ./run-cve-vloc-suite.sh phase-a --models antares --n-limit 25
+#
+#   # All models, core sweep
+#   ./run-cve-vloc-suite.sh model-sweep --n-limit 10 --cores 8,16,32
+#
+#   # Dry run to see commands
+#   ./run-cve-vloc-suite.sh model-sweep --dry-run
+# ==============================================================================
+
+set -euo pipefail
+
+trap 'echo -e "\n\nInterrupted by user. Exiting..."; exit 130' SIGINT SIGTERM
+
+# Script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}"
+while [[ ! -d "${REPO_ROOT}/.git" ]] && [[ "${REPO_ROOT}" != "/" ]]; do
+    REPO_ROOT="$(dirname "${REPO_ROOT}")"
+done
+
+if [[ ! -d "${REPO_ROOT}/.git" ]]; then
+    echo "ERROR: Could not find repository root"
+    exit 1
+fi
+
+cd "${REPO_ROOT}"
+
+PLAYBOOK="automation/test-execution/ansible/llm-benchmark-cve-vloc.yml"
+INVENTORY="automation/test-execution/ansible/inventory/hosts.yml"
+
+if [[ ! -f "${PLAYBOOK}" ]]; then
+    echo "ERROR: Playbook not found: ${PLAYBOOK}"
+    exit 1
+fi
+
+# ============================================================================
+# Model matrix
+# ============================================================================
+
+# Required: Granite (baselines)
+MODEL_GRANITE_1B="ibm-granite/granite-4.0-1b"
+MODEL_GRANITE_350M="ibm-granite/granite-4.0-350m"
+MODEL_GRANITE_MICRO="ibm-granite/granite-4.0-micro"
+
+# Required: Qwen (9B exception)
+MODEL_QWEN_9B="Qwen/Qwen3.5-9B"
+
+# Required: Antares (gated)
+MODEL_ANTARES_1B="fdtn-ai/antares-1b"
+MODEL_ANTARES_350M="fdtn-ai/antares-350m"
+# Optional: Antares-3B (weights not public yet; skip if MODEL_ANTARES_3B unset)
+MODEL_ANTARES_3B="${MODEL_ANTARES_3B:-}"
+
+# Optional: Gemma-4
+MODEL_GEMMA_E2B="google/gemma-4-E2B-it"
+MODEL_GEMMA_E4B="google/gemma-4-E4B-it"
+
+# Presets
+PRESET_GRANITE=("${MODEL_GRANITE_350M}" "${MODEL_GRANITE_1B}" "${MODEL_GRANITE_MICRO}")
+PRESET_QWEN=("${MODEL_QWEN_9B}")
+PRESET_ANTARES=("${MODEL_ANTARES_1B}" "${MODEL_ANTARES_350M}")
+if [[ -n "${MODEL_ANTARES_3B}" ]]; then
+    PRESET_ANTARES+=("${MODEL_ANTARES_3B}")
+fi
+PRESET_GEMMA=("${MODEL_GEMMA_E2B}" "${MODEL_GEMMA_E4B}")
+PRESET_PUBLIC=("${PRESET_GRANITE[@]}" "${PRESET_QWEN[@]}")
+PRESET_ALL=("${PRESET_GRANITE[@]}" "${PRESET_QWEN[@]}" "${PRESET_ANTARES[@]}")
+
+# ============================================================================
+# Runner auto-detection
+# ============================================================================
+
+get_vloc_runner() {
+    local model="$1"
+    case "${model}" in
+        *antares*|fdtn-ai/*)   echo "vllm_antares" ;;
+        *Qwen*|*qwen*)         echo "vllm_qwen_3_5" ;;
+        *gemma*|*Gemma*)       echo "vllm_gemma_4" ;;
+        *)                     echo "vllm" ;;
+    esac
+}
+
+get_runner_display() {
+    local runner="$1"
+    case "${runner}" in
+        vllm_antares)   echo "Antares (raw /v1/completions)" ;;
+        vllm_qwen_3_5)  echo "Qwen3.5 (tool calling)" ;;
+        vllm_gemma_4)   echo "Gemma-4 (tool calling)" ;;
+        vllm)           echo "Generic (chat completions)" ;;
+        *)              echo "${runner}" ;;
+    esac
+}
+
+# ============================================================================
+# Defaults
+# ============================================================================
+
+MODE=""
+MODELS_INPUT=""
+CORES_INPUT="16"
+WORKERS=1
+PHASES="a"
+N_LIMIT=5
+VLOC_DIR="${VLOC_DIR:-/tmp/vloc-bench}"
+RUNNER_OVERRIDE=""
+PORT=8200
+CONTAINER_IMAGE="${VLLM_CONTAINER_IMAGE:-}"
+DRY_RUN=false
+CONTINUE_ON_ERROR=false
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ============================================================================
+# Usage
+# ============================================================================
+
+usage() {
+    cat << 'EOF'
+CVE Vulnerability Localization Benchmark Suite
+
+USAGE:
+  ./run-cve-vloc-suite.sh <mode> [options]
+
+MODES:
+  smoke           Quick gate: 5 tasks, Phase A, smallest Granite model
+  phase-a         Phase A (vulnerable code localization)
+  phase-b         Phase B (patched code verification)
+  full            Full 500-task run (WARNING: hours on CPU)
+  model-sweep     All matrix models, fixed task count per model
+
+OPTIONS:
+  --models LIST            Comma-separated models or preset
+                           Presets: granite, qwen, antares, public, all
+  --cores LIST             Comma-separated core counts (default: 16)
+  --workers NUM            Parallel VLoc workers (default: 1)
+  --phases PHASES          a, b, or ab (default: a)
+  --n-limit NUM            Max tasks per model (default: 5)
+  --vloc-dir PATH          DUT-side cache dir for data/results (default: /tmp/vloc-bench)
+  --runner RUNNER          Override auto-detected VLoc runner
+  --port PORT              vLLM port (default: 8200)
+  --container-image IMAGE  Override vLLM container image
+  --keep-server            Don't stop vLLM after the run
+  --dry-run                Show commands without executing
+  --continue-on-error      Don't stop on first failure
+  -h, --help               Show this help
+
+MODEL MATRIX:
+  Granite (baseline):  ibm-granite/granite-4.0-{350m,1b,micro}
+  Qwen (9B):           Qwen/Qwen3.5-9B
+  Antares (gated):     fdtn-ai/antares-{1b,350m}     (requires HF_TOKEN)
+  Gemma-4 (optional):  google/gemma-4-{E2B,E4B}-it
+
+ENVIRONMENT:
+  HF_TOKEN                 Required for gated models (Antares)
+  VLLM_CONTAINER_IMAGE     Override vLLM container image
+  VLOC_DIR                 VLoc Bench directory
+  VLOC_SMOKE_N             Override smoke task count
+
+EXAMPLES:
+  ./run-cve-vloc-suite.sh smoke
+  ./run-cve-vloc-suite.sh phase-a --models granite --n-limit 25 --cores 16
+  ./run-cve-vloc-suite.sh model-sweep --n-limit 10 --cores 8,16,32 --dry-run
+EOF
+    exit 0
+}
+
+# ============================================================================
+# Argument parsing
+# ============================================================================
+
+if [[ $# -eq 0 ]]; then
+    usage
+fi
+
+MODE="$1"
+shift
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --models)            MODELS_INPUT="$2"; shift 2 ;;
+        --cores)             CORES_INPUT="$2"; shift 2 ;;
+        --workers)           WORKERS="$2"; shift 2 ;;
+        --phases)            PHASES="$2"; shift 2 ;;
+        --n-limit)           N_LIMIT="$2"; shift 2 ;;
+        --vloc-dir)          VLOC_DIR="$2"; shift 2 ;;
+        --runner)            RUNNER_OVERRIDE="$2"; shift 2 ;;
+        --port)              PORT="$2"; shift 2 ;;
+        --container-image)   CONTAINER_IMAGE="$2"; shift 2 ;;
+        --dry-run)           DRY_RUN=true; shift ;;
+        --continue-on-error) CONTINUE_ON_ERROR=true; shift ;;
+        --keep-server)       KEEP_SERVER=true; shift ;;
+        -h|--help)           usage ;;
+        *)                   echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+# ============================================================================
+# Mode configuration
+# ============================================================================
+
+case "${MODE}" in
+    smoke)
+        [[ -z "${MODELS_INPUT}" ]] && MODELS_INPUT="granite"
+        N_LIMIT="${VLOC_SMOKE_N:-5}"
+        PHASES="a"
+        ;;
+    phase-a)
+        [[ -z "${MODELS_INPUT}" ]] && MODELS_INPUT="granite"
+        PHASES="a"
+        ;;
+    phase-b)
+        [[ -z "${MODELS_INPUT}" ]] && MODELS_INPUT="granite"
+        PHASES="b"
+        ;;
+    full)
+        [[ -z "${MODELS_INPUT}" ]] && MODELS_INPUT="all"
+        N_LIMIT=0
+        PHASES="ab"
+        echo -e "${YELLOW}WARNING: Full run (500 tasks, Phase A+B) can take HOURS on CPU.${NC}"
+        echo -e "${YELLOW}Cisco reference: ~13 min / 500 tasks on H100 with 16 workers.${NC}"
+        echo -e "${YELLOW}CPU with 1 worker will be 10-100x slower.${NC}"
+        echo ""
+        ;;
+    model-sweep)
+        [[ -z "${MODELS_INPUT}" ]] && MODELS_INPUT="all"
+        ;;
+    *)
+        echo "ERROR: Unknown mode: ${MODE}"
+        echo "Valid modes: smoke, phase-a, phase-b, full, model-sweep"
+        exit 1
+        ;;
+esac
+
+# ============================================================================
+# Resolve models
+# ============================================================================
+
+resolve_models() {
+    local input="$1"
+    case "${input}" in
+        granite)
+            echo "${PRESET_GRANITE[@]}"
+            ;;
+        qwen)
+            echo "${PRESET_QWEN[@]}"
+            ;;
+        antares)
+            echo "${PRESET_ANTARES[@]}"
+            ;;
+        gemma)
+            echo "${PRESET_GEMMA[@]}"
+            ;;
+        public)
+            echo "${PRESET_PUBLIC[@]}"
+            ;;
+        all)
+            echo "${PRESET_ALL[@]}"
+            ;;
+        *)
+            # Comma-separated list
+            echo "${input}" | tr ',' ' '
+            ;;
+    esac
+}
+
+IFS=' ' read -r -a MODELS <<< "$(resolve_models "${MODELS_INPUT}")"
+
+# Parse core counts
+IFS=',' read -r -a CORE_COUNTS <<< "${CORES_INPUT}"
+
+# ============================================================================
+# Pre-flight checks
+# ============================================================================
+
+echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${BOLD}CVE Vulnerability Localization Benchmark Suite${NC}"
+echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo "Mode:       ${MODE}"
+echo "Models:     ${MODELS[*]}"
+echo "Cores:      ${CORE_COUNTS[*]}"
+echo "Workers:    ${WORKERS}"
+echo "Phases:     ${PHASES}"
+echo "N-limit:    ${N_LIMIT} (0=all 500)"
+echo "VLoc dir:   ${VLOC_DIR}"
+echo "Port:       ${PORT}"
+if [[ -n "${CONTAINER_IMAGE}" ]]; then
+    echo "Image:      ${CONTAINER_IMAGE}"
+fi
+if [[ "${DRY_RUN}" == "true" ]]; then
+    echo -e "Dry run:    ${YELLOW}YES (no commands will be executed)${NC}"
+fi
+echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+
+# Check for gated models
+has_gated=false
+for model in "${MODELS[@]}"; do
+    case "${model}" in
+        *antares*|fdtn-ai/*)
+            has_gated=true
+            ;;
+    esac
+done
+
+if [[ "${has_gated}" == "true" ]] && [[ -z "${HF_TOKEN:-}" ]]; then
+    echo -e "${RED}ERROR: Model list includes gated models (Antares) but HF_TOKEN is not set.${NC}"
+    echo "  export HF_TOKEN=hf_xxxxx"
+    echo "  Apply at: https://huggingface.co/fdtn-ai/antares-1b"
+    exit 1
+fi
+
+# ============================================================================
+# Run function
+# ============================================================================
+
+run_count=0
+pass_count=0
+fail_count=0
+failed_runs=()
+
+run_single() {
+    local model="$1"
+    local cores="$2"
+    local runner
+    runner="${RUNNER_OVERRIDE:-$(get_vloc_runner "${model}")}"
+    local runner_desc
+    runner_desc="$(get_runner_display "${runner}")"
+
+    run_count=$((run_count + 1))
+
+    echo ""
+    echo -e "${BLUE}┌──────────────────────────────────────────────────────┐${NC}"
+    echo -e "${BLUE}│${NC} Run #${run_count}: ${model}"
+    echo -e "${BLUE}│${NC} Runner: ${runner} — ${runner_desc}"
+    echo -e "${BLUE}│${NC} Cores: ${cores} | Workers: ${WORKERS} | Phases: ${PHASES} | N: ${N_LIMIT}"
+    echo -e "${BLUE}└──────────────────────────────────────────────────────┘${NC}"
+
+    # Build ansible-playbook command
+    local cmd="ansible-playbook -i ${INVENTORY} ${PLAYBOOK}"
+    cmd+=" -e test_model=${model}"
+    cmd+=" -e vloc_runner=${runner}"
+    cmd+=" -e requested_cores=${cores}"
+    cmd+=" -e vloc_phases=${PHASES}"
+    cmd+=" -e vloc_workers=${WORKERS}"
+    cmd+=" -e vloc_n_limit=${N_LIMIT}"
+    cmd+=" -e vloc_dir=${VLOC_DIR}"
+    cmd+=" -e vllm_port=${PORT}"
+    if [[ "${KEEP_SERVER:-false}" == "true" ]]; then
+        cmd+=" -e cleanup_after_test=false"
+    else
+        cmd+=" -e cleanup_after_test=true"
+    fi
+
+    if [[ -n "${CONTAINER_IMAGE}" ]]; then
+        cmd+=" -e vllm_container_image=${CONTAINER_IMAGE}"
+    fi
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        echo -e "${YELLOW}[DRY RUN] ${cmd}${NC}"
+        pass_count=$((pass_count + 1))
+        return 0
+    fi
+
+    echo "Command: ${cmd}"
+    echo ""
+
+    if eval "${cmd}"; then
+        echo -e "${GREEN}PASS${NC} — ${model} @ ${cores} cores"
+        pass_count=$((pass_count + 1))
+    else
+        echo -e "${RED}FAIL${NC} — ${model} @ ${cores} cores"
+        fail_count=$((fail_count + 1))
+        failed_runs+=("${model} @ ${cores}c")
+        if [[ "${CONTINUE_ON_ERROR}" != "true" ]]; then
+            echo -e "${RED}Stopping on first failure. Use --continue-on-error to keep going.${NC}"
+            return 1
+        fi
+    fi
+}
+
+# ============================================================================
+# Execute
+# ============================================================================
+
+for model in "${MODELS[@]}"; do
+    for cores in "${CORE_COUNTS[@]}"; do
+        if ! run_single "${model}" "${cores}"; then
+            break 2
+        fi
+    done
+done
+
+# ============================================================================
+# Summary
+# ============================================================================
+
+echo ""
+echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${BOLD}Suite Complete${NC}"
+echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo "Total runs: ${run_count}"
+echo -e "Passed:     ${GREEN}${pass_count}${NC}"
+
+if [[ ${fail_count} -gt 0 ]]; then
+    echo -e "Failed:     ${RED}${fail_count}${NC}"
+    echo ""
+    echo "Failed runs:"
+    for f in "${failed_runs[@]}"; do
+        echo "  - ${f}"
+    done
+    exit 1
+fi
+
+echo ""
+echo "Results: results/llm/*/cve-vloc-*/"
+exit 0

--- a/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
+++ b/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
@@ -1123,10 +1123,18 @@ test_cve_capacity() {
 
             echo "  Shape: ${shape_name} (input=${input_len}, output=${output_len}, prompts=${prompts})"
 
+            local extra_args=""
+            case "${model}" in
+                *antares*|fdtn-ai/*)
+                    extra_args="--trust-remote-code --dtype bfloat16"
+                    ;;
+            esac
+
             if run_test "$model" "random" "$prompts" "$cores" \
                 -e "input_len=${input_len}" \
                 -e "output_len=${output_len}" \
-                -e "use_case=cve_capacity"; then
+                -e "use_case=cve_capacity" \
+                -e "vllm_extra_args=${extra_args}"; then
                 passed=$((passed + 1))
             else
                 failed=$((failed + 1))
@@ -1225,17 +1233,23 @@ main() {
             test_context_scaling "$@"
             ;;
         cve-capacity)
+            local cve_cores=""
             for arg in "$@"; do
                 if [[ "$arg" == "--include-qwen" ]]; then
                     export INCLUDE_QWEN=true
+                elif [[ "$arg" =~ ^[0-9]+$ ]]; then
+                    if [[ -n "${cve_cores}" ]]; then
+                        echo "Error: cve-capacity accepts at most one core-count argument"
+                        exit 1
+                    fi
+                    cve_cores="$arg"
+                else
+                    echo "Error: unknown argument for cve-capacity: $arg"
+                    echo "Usage: cve-capacity [cores] [--include-qwen]"
+                    exit 1
                 fi
             done
-            # Strip --include-qwen from args before passing cores
-            local cve_args=()
-            for arg in "$@"; do
-                [[ "$arg" != "--include-qwen" ]] && cve_args+=("$arg")
-            done
-            test_cve_capacity "${cve_args[@]}"
+            test_cve_capacity "${cve_cores:-16}"
             ;;
         all)
             if [ $# -lt 1 ]; then

--- a/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
+++ b/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
@@ -55,6 +55,17 @@ MODEL_QWEN_W4A16="RedHatAI/Qwen3-8B-quantized.w4a16"
 # Use it explicitly for smoke tests: --models RedHatAI/TinyLlama-1.1B-Chat-v1.0-pruned2.4
 ALL_MODELS="$MODEL_LLAMA_W8A8,$MODEL_LLAMA_W4A16,$MODEL_QWEN_W4A16"
 
+# CVE/VLoc capacity models (capacity proxy — NOT localization quality)
+MODEL_GRANITE_4_1B="ibm-granite/granite-4.0-1b"
+MODEL_GRANITE_4_350M="ibm-granite/granite-4.0-350m"
+MODEL_GRANITE_4_MICRO="ibm-granite/granite-4.0-micro"
+MODEL_ANTARES_1B="fdtn-ai/antares-1b"
+MODEL_ANTARES_350M="fdtn-ai/antares-350m"
+MODEL_QWEN_CVE="Qwen/Qwen3.5-9B"
+CVE_CAPACITY_MODELS="$MODEL_GRANITE_4_350M,$MODEL_GRANITE_4_1B,$MODEL_GRANITE_4_MICRO"
+CVE_CAPACITY_GATED="$MODEL_ANTARES_1B,$MODEL_ANTARES_350M"
+CVE_CAPACITY_OPTIONAL="$MODEL_QWEN_CVE"
+
 # Legacy aliases for backward compatibility
 MODEL_TINY="TinyLlama/TinyLlama-1.1B-Chat-v1.0"
 MODEL_LLAMA_1B="meta-llama/Llama-3.2-1B-Instruct"
@@ -137,7 +148,9 @@ MODES:
     quantization [cores] [prompts]   Quantization comparison (Llama w8a8, w4a16, Qwen w4a16)
     kv-capacity <model> [cores]      KV-cache capacity sweep (100-5000 prompts)
     context-scaling <model> [cores]  Context length scaling (1024-8192 input tokens)
-    all <model> [cores]              Run all 8 technical tests
+    cve-capacity [cores] [--include-qwen]  CVE/VLoc capacity proxy (Granite + Antares if HF_TOKEN)
+                                     NOTE: Measures throughput, NOT localization quality.
+    all <model> [cores]              Run all 8 technical tests (excludes cve-capacity)
 
 EXAMPLES:
 
@@ -1052,6 +1065,88 @@ test_all() {
 }
 
 # ==============================================================================
+# CVE CAPACITY (proxy — NOT localization quality)
+# ==============================================================================
+
+test_cve_capacity() {
+    local cores="${1:-16}"
+
+    echo -e "${BLUE}========================================${NC}"
+    echo -e "${BLUE}CVE/VLoc Model Capacity Proxy${NC}"
+    echo -e "${BLUE}========================================${NC}"
+    echo ""
+    echo -e "${YELLOW}NOTE: This measures raw throughput under representative I/O shapes.${NC}"
+    echo -e "${YELLOW}It does NOT measure vulnerability localization quality (File F1).${NC}"
+    echo -e "${YELLOW}For actual CVE localization, use run-cve-vloc-suite.sh instead.${NC}"
+    echo ""
+
+    # Build model list: Granite (always) + Antares (if HF_TOKEN) + Qwen (if --include-qwen)
+    local cve_models
+    IFS=',' read -r -a cve_models <<< "${CVE_CAPACITY_MODELS}"
+
+    if [[ -n "${HF_TOKEN:-}" ]]; then
+        local gated_models
+        IFS=',' read -r -a gated_models <<< "${CVE_CAPACITY_GATED}"
+        cve_models+=("${gated_models[@]}")
+        echo -e "  Including Antares models (HF_TOKEN set)"
+    else
+        echo -e "  ${YELLOW}Skipping Antares models (HF_TOKEN not set)${NC}"
+    fi
+
+    if [[ "${INCLUDE_QWEN:-false}" == "true" ]]; then
+        local qwen_models
+        IFS=',' read -r -a qwen_models <<< "${CVE_CAPACITY_OPTIONAL}"
+        cve_models+=("${qwen_models[@]}")
+        echo -e "  Including Qwen3.5-9B (--include-qwen)"
+    else
+        echo -e "  Qwen3.5-9B skipped (pass --include-qwen to add; heavy on CPU)"
+    fi
+    echo ""
+
+    local shapes=(
+        "small-triage:128:64:100"
+        "medium-analysis:512:256:50"
+        "deep-inspection:2048:512:25"
+    )
+
+    local total=0
+    local passed=0
+    local failed=0
+
+    for model in "${cve_models[@]}"; do
+        echo ""
+        echo -e "${BLUE}--- Model: ${model} ---${NC}"
+
+        for shape_spec in "${shapes[@]}"; do
+            IFS=':' read -r shape_name input_len output_len prompts <<< "${shape_spec}"
+            total=$((total + 1))
+
+            echo "  Shape: ${shape_name} (input=${input_len}, output=${output_len}, prompts=${prompts})"
+
+            if run_test "$model" "random" "$prompts" "$cores" \
+                -e "input_len=${input_len}" \
+                -e "output_len=${output_len}" \
+                -e "use_case=cve_capacity"; then
+                passed=$((passed + 1))
+            else
+                failed=$((failed + 1))
+                echo -e "  ${RED}FAILED: ${model} / ${shape_name}${NC}"
+            fi
+        done
+    done
+
+    echo ""
+    echo -e "${BLUE}========================================${NC}"
+    echo "CVE Capacity Results: ${passed}/${total} passed, ${failed} failed"
+    echo -e "${BLUE}========================================${NC}"
+
+    if [ ${failed} -gt 0 ]; then
+        return 1
+    fi
+    return 0
+}
+
+# ==============================================================================
 # MAIN
 # ==============================================================================
 
@@ -1128,6 +1223,19 @@ main() {
                 exit 1
             fi
             test_context_scaling "$@"
+            ;;
+        cve-capacity)
+            for arg in "$@"; do
+                if [[ "$arg" == "--include-qwen" ]]; then
+                    export INCLUDE_QWEN=true
+                fi
+            done
+            # Strip --include-qwen from args before passing cores
+            local cve_args=()
+            for arg in "$@"; do
+                [[ "$arg" != "--include-qwen" ]] && cve_args+=("$arg")
+            done
+            test_cve_capacity "${cve_args[@]}"
             ;;
         all)
             if [ $# -lt 1 ]; then

--- a/automation/test-execution/tests/scripts/test_run_cve_vloc_suite.sh
+++ b/automation/test-execution/tests/scripts/test_run_cve_vloc_suite.sh
@@ -169,6 +169,8 @@ test_usage_message() {
         "Usage shows --vloc-dir option"
     assert_contains "$usage_output" "--keep-server" \
         "Usage shows --keep-server option"
+    assert_contains "$usage_output" "--permissive" \
+        "Usage shows --permissive option"
     assert_contains "$usage_output" "HF_TOKEN" \
         "Usage mentions HF_TOKEN"
     assert_contains "$usage_output" "VLLM_CONTAINER_IMAGE" \
@@ -234,6 +236,60 @@ test_no_token_logging() {
 }
 
 # ============================================================================
+# Test 9: Dry-run command construction (behavioral)
+# ============================================================================
+
+test_dry_run_smoke_smallest_granite() {
+    local output
+    output=$("$SUITE_SCRIPT" smoke --dry-run 2>&1)
+
+    assert_contains "$output" "ibm-granite/granite-4.0-350m" \
+        "Default smoke uses Granite-4.0-350M"
+    assert_not_contains "$output" "granite-4.0-micro" \
+        "Default smoke does not include Granite Micro"
+    assert_not_contains "$output" "granite-4.0-1b" \
+        "Default smoke does not include Granite 1B"
+    assert_contains "$output" "vloc_runner=vllm" \
+        "Smoke dry-run selects generic vllm runner"
+    assert_not_contains "$output" "vloc_permissive" \
+        "Default smoke does not enable --permissive"
+    assert_contains "$output" '-e test_model=' \
+        "Extra vars are passed as -e key=value"
+}
+
+test_dry_run_antares_runner() {
+    local output
+    output=$(HF_TOKEN=dummy "$SUITE_SCRIPT" phase-a \
+        --models fdtn-ai/antares-1b --dry-run 2>&1)
+
+    assert_contains "$output" "vloc_runner=vllm_antares" \
+        "Antares model selects vllm_antares runner"
+    assert_contains "$output" "vllm_antares" \
+        "Dry-run command includes antares runner"
+}
+
+test_dry_run_container_image_and_permissive() {
+    local output
+    output=$("$SUITE_SCRIPT" smoke \
+        --container-image docker.io/vllm/vllm-openai-cpu:v0.25.1 \
+        --permissive --dry-run 2>&1)
+
+    assert_contains "$output" "vllm_container_image=docker.io/vllm/vllm-openai-cpu:v0.25.1" \
+        "Dry-run forwards --container-image as vllm_container_image"
+    assert_contains "$output" "vloc_permissive=true" \
+        "Dry-run forwards --permissive as vloc_permissive=true"
+}
+
+test_dry_run_quoted_vloc_dir() {
+    local output
+    output=$("$SUITE_SCRIPT" smoke \
+        --vloc-dir "/tmp/vloc bench" --dry-run 2>&1)
+
+    assert_contains "$output" "vloc_dir=/tmp/vloc bench" \
+        "vloc_dir with spaces is preserved as a single extra-var"
+}
+
+# ============================================================================
 # Main test execution
 # ============================================================================
 
@@ -251,6 +307,10 @@ test_model_presets
 test_playbook_reference
 test_dry_run_flag
 test_no_token_logging
+test_dry_run_smoke_smallest_granite
+test_dry_run_antares_runner
+test_dry_run_container_image_and_permissive
+test_dry_run_quoted_vloc_dir
 
 echo
 echo "=========================================="

--- a/automation/test-execution/tests/scripts/test_run_cve_vloc_suite.sh
+++ b/automation/test-execution/tests/scripts/test_run_cve_vloc_suite.sh
@@ -22,24 +22,6 @@ TESTS_RUN=0
 TESTS_PASSED=0
 TESTS_FAILED=0
 
-assert_equals() {
-    local expected="$1"
-    local actual="$2"
-    local test_name="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [[ "$expected" == "$actual" ]]; then
-        echo -e "${GREEN}✓${NC} $test_name"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-    else
-        echo -e "${RED}✗${NC} $test_name"
-        echo "  Expected: $expected"
-        echo "  Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-    fi
-}
-
 assert_contains() {
     local haystack="$1"
     local needle="$2"
@@ -71,6 +53,23 @@ assert_not_contains() {
     else
         echo -e "${RED}✗${NC} $test_name"
         echo "  Should not contain: $needle"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+assert_not_match() {
+    local haystack="$1"
+    local pattern="$2"
+    local test_name="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if ! grep -Eq -- "$pattern" <<< "$haystack"; then
+        echo -e "${GREEN}✓${NC} $test_name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}✗${NC} $test_name"
+        echo "  Should not match: $pattern"
         TESTS_FAILED=$((TESTS_FAILED + 1))
     fi
 }
@@ -163,6 +162,8 @@ test_usage_message() {
         "Usage shows full mode"
     assert_contains "$usage_output" "--models" \
         "Usage shows --models option"
+    assert_contains "$usage_output" "gemma" \
+        "Usage lists gemma preset"
     assert_contains "$usage_output" "--cores" \
         "Usage shows --cores option"
     assert_contains "$usage_output" "--vloc-dir" \
@@ -231,8 +232,8 @@ test_no_token_logging() {
     local script_content
     script_content=$(cat "$SUITE_SCRIPT")
 
-    assert_not_contains "$script_content" 'echo.*HF_TOKEN' \
-        "HF_TOKEN not echoed directly"
+    assert_not_match "$script_content" 'echo.*\$HF_TOKEN|echo.*\$\{HF_TOKEN' \
+        "HF_TOKEN value is not echoed"
 }
 
 # ============================================================================
@@ -281,12 +282,19 @@ test_dry_run_container_image_and_permissive() {
 }
 
 test_dry_run_quoted_vloc_dir() {
+    local tmp_root
+    tmp_root=$(mktemp -d)
+    local vloc_dir="${tmp_root}/vloc bench"
+    mkdir -p "${vloc_dir}"
+
     local output
     output=$("$SUITE_SCRIPT" smoke \
-        --vloc-dir "/tmp/vloc bench" --dry-run 2>&1)
+        --vloc-dir "${vloc_dir}" --dry-run 2>&1)
 
-    assert_contains "$output" "vloc_dir=/tmp/vloc bench" \
+    assert_contains "$output" "vloc_dir=${vloc_dir}" \
         "vloc_dir with spaces is preserved as a single extra-var"
+
+    rm -rf "${tmp_root}"
 }
 
 # ============================================================================

--- a/automation/test-execution/tests/scripts/test_run_cve_vloc_suite.sh
+++ b/automation/test-execution/tests/scripts/test_run_cve_vloc_suite.sh
@@ -1,0 +1,270 @@
+#!/bin/bash
+# Unit tests for run-cve-vloc-suite.sh
+#
+# Tests bash script functionality:
+# - Model constants and presets
+# - Runner auto-detection
+# - Argument parsing
+# - Mode validation
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUITE_SCRIPT="$SCRIPT_DIR/../../scripts/bash/run-cve-vloc-suite.sh"
+
+# Colors for test output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_equals() {
+    local expected="$1"
+    local actual="$2"
+    local test_name="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [[ "$expected" == "$actual" ]]; then
+        echo -e "${GREEN}✓${NC} $test_name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}✗${NC} $test_name"
+        echo "  Expected: $expected"
+        echo "  Actual:   $actual"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local test_name="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [[ "$haystack" == *"$needle"* ]]; then
+        echo -e "${GREEN}✓${NC} $test_name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}✗${NC} $test_name"
+        echo "  Expected to contain: $needle"
+        echo "  Got: ${haystack:0:200}"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local test_name="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [[ "$haystack" != *"$needle"* ]]; then
+        echo -e "${GREEN}✓${NC} $test_name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}✗${NC} $test_name"
+        echo "  Should not contain: $needle"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# ============================================================================
+# Test 1: Script exists and is executable
+# ============================================================================
+
+test_script_exists() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ -f "$SUITE_SCRIPT" ]]; then
+        echo -e "${GREEN}✓${NC} Script exists"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}✗${NC} Script not found at: $SUITE_SCRIPT"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+test_script_executable() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ -x "$SUITE_SCRIPT" ]]; then
+        echo -e "${GREEN}✓${NC} Script is executable"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}✗${NC} Script is not executable"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# ============================================================================
+# Test 2: Model constants are defined in the script
+# ============================================================================
+
+test_model_constants() {
+    local script_content
+    script_content=$(cat "$SUITE_SCRIPT")
+
+    assert_contains "$script_content" 'MODEL_GRANITE_1B="ibm-granite/granite-4.0-1b"' \
+        "MODEL_GRANITE_1B defined"
+    assert_contains "$script_content" 'MODEL_GRANITE_350M="ibm-granite/granite-4.0-350m"' \
+        "MODEL_GRANITE_350M defined"
+    assert_contains "$script_content" 'MODEL_GRANITE_MICRO="ibm-granite/granite-4.0-micro"' \
+        "MODEL_GRANITE_MICRO defined"
+    assert_contains "$script_content" 'MODEL_QWEN_9B="Qwen/Qwen3.5-9B"' \
+        "MODEL_QWEN_9B defined"
+    assert_contains "$script_content" 'MODEL_ANTARES_1B="fdtn-ai/antares-1b"' \
+        "MODEL_ANTARES_1B defined"
+    assert_contains "$script_content" 'MODEL_ANTARES_350M="fdtn-ai/antares-350m"' \
+        "MODEL_ANTARES_350M defined"
+}
+
+# ============================================================================
+# Test 3: Runner auto-detection function exists
+# ============================================================================
+
+test_runner_detection() {
+    local script_content
+    script_content=$(cat "$SUITE_SCRIPT")
+
+    assert_contains "$script_content" 'get_vloc_runner()' \
+        "get_vloc_runner function defined"
+    assert_contains "$script_content" 'vllm_antares' \
+        "Antares runner referenced"
+    assert_contains "$script_content" 'vllm_qwen_3_5' \
+        "Qwen runner referenced"
+    assert_contains "$script_content" 'vllm_gemma_4' \
+        "Gemma runner referenced"
+}
+
+# ============================================================================
+# Test 4: Usage message shows all modes and key options
+# ============================================================================
+
+test_usage_message() {
+    local usage_output
+    usage_output=$("$SUITE_SCRIPT" 2>&1 || true)
+
+    assert_contains "$usage_output" "CVE Vulnerability Localization" \
+        "Usage shows title"
+    assert_contains "$usage_output" "smoke" \
+        "Usage shows smoke mode"
+    assert_contains "$usage_output" "phase-a" \
+        "Usage shows phase-a mode"
+    assert_contains "$usage_output" "phase-b" \
+        "Usage shows phase-b mode"
+    assert_contains "$usage_output" "model-sweep" \
+        "Usage shows model-sweep mode"
+    assert_contains "$usage_output" "full" \
+        "Usage shows full mode"
+    assert_contains "$usage_output" "--models" \
+        "Usage shows --models option"
+    assert_contains "$usage_output" "--cores" \
+        "Usage shows --cores option"
+    assert_contains "$usage_output" "--vloc-dir" \
+        "Usage shows --vloc-dir option"
+    assert_contains "$usage_output" "--keep-server" \
+        "Usage shows --keep-server option"
+    assert_contains "$usage_output" "HF_TOKEN" \
+        "Usage mentions HF_TOKEN"
+    assert_contains "$usage_output" "VLLM_CONTAINER_IMAGE" \
+        "Usage mentions VLLM_CONTAINER_IMAGE"
+}
+
+# ============================================================================
+# Test 5: Preset model lists defined
+# ============================================================================
+
+test_model_presets() {
+    local script_content
+    script_content=$(cat "$SUITE_SCRIPT")
+
+    assert_contains "$script_content" 'PRESET_GRANITE=' \
+        "PRESET_GRANITE defined"
+    assert_contains "$script_content" 'PRESET_QWEN=' \
+        "PRESET_QWEN defined"
+    assert_contains "$script_content" 'PRESET_ANTARES=' \
+        "PRESET_ANTARES defined"
+    assert_contains "$script_content" 'PRESET_PUBLIC=' \
+        "PRESET_PUBLIC defined"
+    assert_contains "$script_content" 'PRESET_ALL=' \
+        "PRESET_ALL defined"
+}
+
+# ============================================================================
+# Test 6: Playbook reference is correct
+# ============================================================================
+
+test_playbook_reference() {
+    local script_content
+    script_content=$(cat "$SUITE_SCRIPT")
+
+    assert_contains "$script_content" 'llm-benchmark-cve-vloc.yml' \
+        "References correct playbook"
+}
+
+# ============================================================================
+# Test 7: Dry-run mode is supported
+# ============================================================================
+
+test_dry_run_flag() {
+    local script_content
+    script_content=$(cat "$SUITE_SCRIPT")
+
+    assert_contains "$script_content" 'DRY_RUN' \
+        "DRY_RUN variable used"
+    assert_contains "$script_content" '--dry-run' \
+        "--dry-run flag handled"
+}
+
+# ============================================================================
+# Test 8: Security — HF_TOKEN not in logged commands
+# ============================================================================
+
+test_no_token_logging() {
+    local script_content
+    script_content=$(cat "$SUITE_SCRIPT")
+
+    assert_not_contains "$script_content" 'echo.*HF_TOKEN' \
+        "HF_TOKEN not echoed directly"
+}
+
+# ============================================================================
+# Main test execution
+# ============================================================================
+
+echo "=========================================="
+echo "run-cve-vloc-suite.sh Unit Tests"
+echo "=========================================="
+echo
+
+test_script_exists
+test_script_executable
+test_model_constants
+test_runner_detection
+test_usage_message
+test_model_presets
+test_playbook_reference
+test_dry_run_flag
+test_no_token_logging
+
+echo
+echo "=========================================="
+echo "Test Results"
+echo "=========================================="
+echo "Tests run:    $TESTS_RUN"
+echo -e "Tests passed: ${GREEN}$TESTS_PASSED${NC}"
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    echo -e "Tests failed: ${RED}$TESTS_FAILED${NC}"
+    exit 1
+else
+    echo -e "Tests failed: $TESTS_FAILED"
+    echo
+    echo -e "${GREEN}✓ All tests passed!${NC}"
+    exit 0
+fi

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -9,6 +9,7 @@ for the vLLM CPU performance evaluation project.
 | File | Description |
 |------|-------------|
 | [full-testing-deck.md](full-testing-deck.md) | Full testing methodology (Marp source; ~37 slides) |
+| [cve-testing-deck.md](cve-testing-deck.md) | CVE vulnerability localization testing (Marp source; ~15 slides) |
 
 Marp sources are **excluded from the MkDocs site build** (front matter would
 conflict). Preview or export with Marp CLI as below. CI → GitHub Pages HTML

--- a/docs/design/cve-testing-deck.md
+++ b/docs/design/cve-testing-deck.md
@@ -88,7 +88,7 @@ Smoke testing (5-25 tasks) is the practical default for CPU CI.
 ```text
 Track 1: Online VLoc (Quality)          Track 2: Offline Capacity (Throughput)
 ─────────────────────────────           ────────────────────────────────────────
-                                        
+
  vLLM serve ──► VLoc Bench CLI          vllm bench throughput
       │              │                       │
       │         Docker Sandbox               │

--- a/docs/design/cve-testing-deck.md
+++ b/docs/design/cve-testing-deck.md
@@ -1,0 +1,296 @@
+---
+marp: true
+theme: default
+paginate: true
+size: 16:9
+style: |
+  section {
+    font-size: 28px;
+  }
+  h1 {
+    font-size: 1.6em;
+  }
+  h2 {
+    font-size: 1.25em;
+  }
+  table {
+    font-size: 0.72em;
+  }
+  th, td {
+    padding: 0.25em 0.45em;
+  }
+  pre, code {
+    font-size: 0.78em;
+  }
+  ul, ol {
+    font-size: 0.92em;
+  }
+  blockquote {
+    font-size: 0.85em;
+  }
+---
+
+<!-- markdownlint-disable MD024 MD025 -->
+
+# CVE Vulnerability Localization
+
+## CPU Testing with VLoc Bench
+
+Maryam Tahhan
+
+---
+
+## What is VLoc Bench?
+
+**Cisco Vulnerability Localization Benchmark** — an agentic evaluation harness
+for LLM-driven CVE localization.
+
+- **500 real CVE tasks** from GitHub Security Advisories (GHSA)
+- **Agent loop:** LLM uses terminal commands (grep, find, cat) in a Docker sandbox
+- **Goal:** Identify which files contain the vulnerability
+- **15 tool calls / 20 turns** budget per task
+- **Two phases:** A (find vulnerabilities) and B (verify patches)
+
+> Source: [cisco-foundation-ai/vulnerability-localization-benchmark](https://github.com/cisco-foundation-ai/vulnerability-localization-benchmark)
+
+---
+
+## Why CPU Evaluation?
+
+- Establish CPU baseline for vulnerability-focused models
+- Compare specialized (Antares) vs general-purpose (Granite, Qwen) on CPU
+- Understand capacity constraints before production deployment
+- Complement GPU reference numbers (Cisco H100 benchmarks)
+
+**CPU reality check:** Expect **10-100x slower** than GPU with fewer parallel workers.
+Smoke testing (5-25 tasks) is the practical default for CPU CI.
+
+---
+
+## Model Matrix
+
+| Family | Model | Size | File F1 (ref) | Runner | Access |
+|--------|-------|------|---------------|--------|--------|
+| **Granite** | granite-4.0-350m | 350M | 0.001 | `vllm` | Public |
+| **Granite** | granite-4.0-1b | 1B | 0.0 | `vllm` | Public |
+| **Granite** | granite-4.0-micro | ~3B | 0.0 | `vllm` | Public |
+| **Qwen** | Qwen3.5-9B | 9B | 0.043 | `vllm_qwen_3_5` | Public |
+| **Antares** | antares-1b | 1B | 0.209 | `vllm_antares` | Gated |
+| **Antares** | antares-350m | 350M | 0.135 | `vllm_antares` | Gated |
+
+> Granite = untrained baseline (~0 File F1). Antares = specialized for vuln localization.
+> Ref scores from VLoc leaderboard (GPU, 500 tasks, 16 workers).
+
+---
+
+## Two-Track Architecture
+
+```text
+Track 1: Online VLoc (Quality)          Track 2: Offline Capacity (Throughput)
+─────────────────────────────           ────────────────────────────────────────
+                                        
+ vLLM serve ──► VLoc Bench CLI          vllm bench throughput
+      │              │                       │
+      │         Docker Sandbox               │
+      │         ┌──────────┐            Random I/O shapes:
+      │         │ grep     │              • small-triage  (128→64)
+      │         │ find     │              • medium-analysis (512→256)
+      │         │ cat      │              • deep-inspection (2048→512)
+      │         └──────────┘                 │
+      │              │                       │
+ File F1, TNR    tasks/hr              tok/s, items/hr
+
+ Measures: Localization quality        Measures: Raw model capacity
+```
+
+---
+
+## Online Track: VLoc Agent Loop
+
+```text
+1. System prompt + CWE description → LLM
+2. LLM generates tool call:
+   <tool_call>{"name":"terminal","arguments":{"command":"grep -r 'eval(' ."}} </tool_call>
+3. Sandbox executes command → returns output
+4. LLM reasons, issues next command (up to 15 terminal calls)
+5. LLM submits:
+   <tool_call>{"name":"submit_vulnerable_files","arguments":{"files":["src/app.py"]}} </tool_call>
+6. Score against ground truth → File F1
+```
+
+**Runner types:**
+- `vllm_antares` — raw `/v1/completions` with `<think>` prefix
+- `vllm_qwen_3_5` — `/v1/chat/completions` with `qwen3_coder` tool parser
+- `vllm` — generic chat completions (Granite)
+
+---
+
+## Offline Track: Capacity Shapes
+
+Measures **throughput**, not localization quality.
+
+| Shape | Input | Output | Prompts | Analogy |
+|-------|-------|--------|---------|---------|
+| small-triage | 128 | 64 | 100 | Quick classification |
+| medium-analysis | 512 | 256 | 50 | File-level analysis |
+| deep-inspection | 2048 | 512 | 25 | Function-level deep scan |
+
+> Tagged `use_case=cve_capacity` — never `cve_localization`.
+> These are synthetic random tokens, not real CVE data.
+
+---
+
+## Why Both Tracks?
+
+| | Online VLoc | Offline Capacity |
+|---|---|---|
+| **Measures** | Can this model find vulnerabilities? | How fast can this model process text? |
+| **Metric** | File F1 (quality) | tok/s, items/hr (throughput) |
+| **Data** | Real CVE repositories | Synthetic random tokens |
+| **Agent loop** | Yes (15 tool calls) | No |
+| **Sandbox** | Docker, no network | None |
+| **Label** | `cve_localization` | `cve_capacity` |
+
+**Rule:** Never label offline capacity as "CVE scanning quality."
+
+---
+
+## Metrics — Online VLoc
+
+**Phase A (Vulnerable Code):**
+- **File F1** — harmonic mean of precision and recall on identified files
+- **Precision** — fraction of submitted files that are truly vulnerable
+- **Recall** — fraction of vulnerable files that were found
+
+**Phase B (Patched Code):**
+- **True Negative Rate** — correctly says "no vulnerability" on patched code
+- **False Positive Rate** — incorrectly flags patched code as vulnerable
+
+**Throughput:**
+- **Tasks/hr** — tasks completed per hour (depends on CPU cores, workers)
+
+---
+
+## Reference Scores (VLoc Leaderboard)
+
+| Model | Size | File F1 | Notes |
+|-------|------|---------|-------|
+| GPT-5.5 (xhigh) | — | 0.229 | Frontier API |
+| **Antares-3B-GRPO** | 3B | **0.223** | Open-weights, specialized |
+| **Antares-1B-GRPO** | 1B | **0.209** | Open-weights, specialized |
+| **Antares-350M-GRPO** | 350M | **0.135** | Open-weights, specialized |
+| Qwen3.5-9B | 9B | 0.043 | General-purpose |
+| Gemma-4-E2B | 2B | 0.039 | General-purpose |
+| Granite-4.0-350M | 350M | 0.001 | Untrained baseline |
+| Granite-4.0-1B | 1B | 0.0 | Untrained baseline |
+
+> Antares outperforms models up to 122B on this task. CPU scores may differ from GPU.
+
+---
+
+## Running Smoke Tests
+
+### Step 1: Verify model serving
+
+```bash
+cd tests/cve-scanning
+./smoke-model-serve.sh                    # Smallest Granite
+./smoke-model-serve.sh --all-matrix       # All required models
+```
+
+### Step 2: Verify VLoc harness
+
+```bash
+./smoke-vloc-harness.sh                   # Clone + install + sandbox + dataset
+```
+
+### Step 3: Run VLoc (5 tasks)
+
+```bash
+cd automation/test-execution/scripts/bash
+./run-cve-vloc-suite.sh smoke             # 5 tasks, Granite, Phase A
+```
+
+---
+
+## Running Full Suite
+
+```bash
+# Phase A with specific model families
+./run-cve-vloc-suite.sh phase-a --models granite --n-limit 25 --cores 16
+
+# Antares evaluation (requires HF_TOKEN)
+export HF_TOKEN=hf_xxxxx
+./run-cve-vloc-suite.sh phase-a --models antares --n-limit 25
+
+# All models, core sweep
+./run-cve-vloc-suite.sh model-sweep --n-limit 10 --cores 8,16,32
+
+# Offline capacity proxy
+./run-offline-batch-suite.sh cve-capacity 16
+```
+
+---
+
+## CPU vs GPU Runtime
+
+| Scenario | GPU (H100, 16 workers) | CPU (16 cores, 1 worker) |
+|----------|------------------------|--------------------------|
+| 500 tasks, Phase A | ~13 min | **Hours** (estimated) |
+| 25 tasks, Phase A | <1 min | ~30-60 min (estimated) |
+| 5 tasks, Phase A | seconds | ~5-15 min (estimated) |
+
+**Recommendations for CPU:**
+- Default to `--n-limit 5` for CI smoke tests
+- Use `--workers 1` (CPU contention with multiple workers)
+- Start with `--max-model-len 4096` (reduce memory)
+- Qwen3.5-9B needs ~20 GB RAM — may not fit smaller systems
+
+---
+
+## Prerequisites
+
+- **Python** >= 3.11 (VLoc Bench CLI)
+- **Podman** or **Docker** (vLLM container + VLoc sandbox)
+- **HF_TOKEN** for Antares models (gated, Cisco HF form)
+- **Disk:** ~10 GB for full VLoc dataset (500 task zips)
+- **RAM:** 2-20 GB depending on model (see matrix)
+- **vLLM image:** `docker.io/vllm/vllm-openai-cpu:v0.25.1`
+
+### vLLM serve flags per runner
+
+| Runner | Extra vLLM flags |
+|--------|------------------|
+| `vllm` (Granite) | (none) |
+| `vllm_antares` | `--trust-remote-code` |
+| `vllm_qwen_3_5` | `--enable-auto-tool-choice --tool-call-parser qwen3_coder` |
+| `vllm_gemma_4` | `--enable-auto-tool-choice --tool-call-parser gemma4` |
+
+---
+
+## Results Schema
+
+```text
+results/llm/<model>/cve-vloc-<timestamp>/<config>/
+├── test-metadata.json      # Config, environment, runner
+├── results.json            # File F1, Precision, Recall, TNR, tasks/hr
+└── vloc-output/            # Raw VLoc Bench output
+    ├── aggregate.json      # Aggregated scores
+    ├── GHSA-xxxx_phase_a.json       # Per-task scores
+    └── GHSA-xxxx_phase_a_trace.json # Full conversation trace
+```
+
+Results tagged with `test_type: "cve-vloc"` and `use_case: "cve_localization"`.
+
+Offline capacity results use `test_type: "offline-batch"` and `use_case: "cve_capacity"`.
+
+---
+
+## Future Work
+
+- **CI integration:** Smoke tests in GitHub Actions (5 tasks, Granite)
+- **Phase B:** Patched-code verification (True Negative Rate)
+- **More models:** Gemma-4-E2B/E4B (optional, tool-calling via gemma4 parser)
+- **Dashboard:** Streamlit page for VLoc results visualization
+- **Core sweep:** Systematic CPU core scaling for capacity planning
+- **Comparison:** CPU vs GPU File F1 (do models behave differently on CPU?)

--- a/docs/design/cve-testing-deck.md
+++ b/docs/design/cve-testing-deck.md
@@ -208,7 +208,7 @@ cd tests/cve-scanning
 
 ```bash
 cd automation/test-execution/scripts/bash
-./run-cve-vloc-suite.sh smoke             # 5 tasks, Granite, Phase A
+./run-cve-vloc-suite.sh smoke             # 5 tasks, Granite-4.0-350M, Phase A
 ```
 
 ---

--- a/docs/design/cve-testing-deck.md
+++ b/docs/design/cve-testing-deck.md
@@ -114,7 +114,7 @@ Track 1: Online VLoc (Quality)          Track 2: Offline Capacity (Throughput)
 3. Sandbox executes command → returns output
 4. LLM reasons, issues next command (up to 15 terminal calls)
 5. LLM submits:
-   <tool_call>{"name":"submit_vulnerable_files","arguments":{"files":["src/app.py"]}} </tool_call>
+   <tool_call>{"name":"submit_vulnerable_files","arguments":{"ranked_files":["src/app.py"]}} </tool_call>
 6. Score against ground truth → File F1
 ```
 

--- a/docs/methodology/cve-vloc.md
+++ b/docs/methodology/cve-vloc.md
@@ -1,0 +1,143 @@
+---
+layout: default
+title: CVE Vulnerability Localization Methodology
+---
+
+## CVE Vulnerability Localization — Methodology
+
+### Overview
+
+This document describes the methodology for evaluating LLM vulnerability
+localization on CPU using the Cisco
+[Vulnerability Localization Benchmark (VLoc Bench)](https://github.com/cisco-foundation-ai/vulnerability-localization-benchmark).
+
+Two distinct measurement tracks exist:
+
+| Track | Measures | Tooling | Tag |
+|-------|----------|---------|-----|
+| **Online VLoc** | Localization quality (File F1, TNR) | vLLM serve → VLoc Bench CLI | `cve_localization` |
+| **Offline capacity** | Raw throughput (tok/s, items/hr) | `vllm bench throughput` | `cve_capacity` |
+
+> Offline capacity results must **never** be labeled as localization quality.
+
+---
+
+### Online VLoc Protocol
+
+#### Agent Loop
+
+Each task presents the model with a CVE description (CWE type) and a code
+repository mounted in a Docker sandbox. The model uses terminal commands
+(grep, find, cat) to locate vulnerable files, then submits its findings.
+
+```text
+1. System prompt + CWE description → model
+2. Model generates tool call (e.g., grep -r 'eval(' .)
+3. Sandbox executes command → returns output
+4. Repeat up to 15 terminal calls / 20 turns
+5. Model submits: file list (Phase A) or "no vulnerability" (Phase B)
+6. Score against ground truth
+```
+
+#### Phases
+
+- **Phase A (Vulnerable):** pre-fix commit. Success = high File F1.
+- **Phase B (Patched):** post-fix commit. Success = high True Negative Rate.
+
+#### Runners
+
+| Runner | Endpoint | Models |
+|--------|----------|--------|
+| `vllm` | `/v1/chat/completions` | Granite-4.0 (generic chat) |
+| `vllm_antares` | `/v1/completions` (raw text) | Antares family |
+| `vllm_qwen_3_5` | `/v1/chat/completions` + tool parser | Qwen3.5-9B |
+| `vllm_gemma_4` | `/v1/chat/completions` + tool parser | Gemma-4 (optional) |
+
+#### Sandbox
+
+- Docker container based on `ubuntu:24.04`
+- No network access (isolation)
+- 2 CPU cores, 4 GB RAM per sandbox
+- Repository mounted at `/workspace/repo/`
+- Command timeout: 10 seconds
+- Container destroyed after each task
+
+---
+
+### Metrics
+
+#### Online VLoc Metrics
+
+| Metric | Definition |
+|--------|-----------|
+| **File F1** | Harmonic mean of file-level precision and recall |
+| **Precision** | Fraction of submitted files that are truly vulnerable |
+| **Recall** | Fraction of vulnerable files that were found |
+| **True Negative Rate** | Fraction of patched repos correctly cleared (Phase B) |
+| **Tasks/hr** | Task completion rate |
+
+#### Offline Capacity Metrics
+
+| Metric | Definition |
+|--------|-----------|
+| **Throughput (tok/s)** | Total tokens processed per second |
+| **Items/hr** | Requests processed per hour |
+| **Avg latency** | Mean time per request |
+
+---
+
+### Model Matrix Rationale
+
+The matrix includes three required families:
+
+1. **Granite-4.0** (350M, 1B, Micro): IBM base checkpoints with near-zero
+   File F1. Included as untrained baselines to quantify specialization benefit.
+
+2. **Qwen3.5-9B**: General-purpose model with tool-calling support. 9B
+   exceeds the ≤8B target but is the smallest Qwen entry on the VLoc
+   leaderboard. Provides a general-purpose comparison point.
+
+3. **Antares** (350M, 1B): Cisco's purpose-trained vulnerability localization
+   models built on the Granite-4.0 backbone. Demonstrate that specialization
+   enables 1B models to match or exceed 100B+ general-purpose models.
+
+Optional: Gemma-4-E2B/E4B for additional comparison.
+
+---
+
+### CPU Considerations
+
+- **Memory:** Model size + KV cache. Start with `--max-model-len 4096`
+  to reduce memory pressure. Qwen3.5-9B may need 20+ GB RAM.
+
+- **Runtime:** CPU is 10-100x slower than GPU. Cisco's reference is ~13 min
+  for 500 tasks on H100 with 16 workers. On CPU with 1 worker, expect hours
+  for a full run. Default to `--n-limit 5` for smoke tests.
+
+- **Workers:** VLoc supports parallel workers (`--workers N`), but on CPU
+  each worker competes for inference capacity. Start with `--workers 1`.
+
+- **Context length:** Antares supports 128K but CPU memory is limited. Use
+  8K-32K for smoke testing. Real tasks rarely need full context.
+
+---
+
+### Offline vs Online — When to Use Which
+
+| Question | Track |
+|----------|-------|
+| Can this model actually find vulnerabilities? | **Online VLoc** |
+| How fast can this model process text on N cores? | **Offline capacity** |
+| What's the optimal core count for this model? | **Offline capacity** (core sweep) |
+| Does specialization (Antares) help vs base (Granite)? | **Online VLoc** |
+| Can we serve Qwen3.5-9B on this CPU system? | **Smoke test** (Phase 0) |
+
+---
+
+### Cross-References
+
+- [Test documentation](../../tests/cve-scanning/cve-scanning.md) — how to run
+- [Slide deck](../design/cve-testing-deck.md) — presentation overview
+- [Offline batch methodology](offline-batch.md) — offline capacity protocol
+- [VLoc Bench upstream](https://github.com/cisco-foundation-ai/vulnerability-localization-benchmark) — benchmark source
+- [VLoc leaderboard](https://cisco-foundation-ai.github.io/vulnerability-localization-benchmark/) — reference scores

--- a/docs/methodology/cve-vloc.md
+++ b/docs/methodology/cve-vloc.md
@@ -27,40 +27,112 @@ Two distinct measurement tracks exist:
 #### Agent Loop
 
 Each task presents the model with a CVE description (CWE type) and a code
-repository mounted in a Docker sandbox. The model uses terminal commands
-(grep, find, cat) to locate vulnerable files, then submits its findings.
+repository mounted in a Docker sandbox. The model explores the code via
+terminal commands, then submits its findings. The loop is interactive — each
+tool call depends on the previous output, so it cannot be batched.
 
 ```text
-1. System prompt + CWE description → model
-2. Model generates tool call (e.g., grep -r 'eval(' .)
-3. Sandbox executes command → returns output
-4. Repeat up to 15 terminal calls / 20 turns
-5. Model submits: file list (Phase A) or "no vulnerability" (Phase B)
-6. Score against ground truth
+┌─────────────────────────────────────────────────────────────┐
+│  System prompt: "You are a security vulnerability          │
+│  localization agent. You have read-only terminal access    │
+│  to a codebase."                                           │
+│                                                            │
+│  User prompt: "Analyze this codebase for [CWE class].     │
+│  The repository is at /workspace/repo/."                   │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+                           ▼
+              ┌────────────────────────┐
+              │  Model generates a     │◄──────────────────┐
+              │  tool call             │                    │
+              └──────────┬─────────────┘                    │
+                         │                                  │
+            ┌────────────┼───────────────┐                  │
+            ▼            ▼               ▼                  │
+      ┌──────────┐ ┌───────────┐ ┌──────────────┐          │
+      │ terminal │ │ submit_   │ │ submit_no_   │          │
+      │ command  │ │ vulnerable│ │ vulnerability│          │
+      │          │ │ _files    │ │ _found       │          │
+      └────┬─────┘ └─────┬─────┘ └──────┬───────┘          │
+           │              │              │                  │
+           ▼              ▼              ▼                  │
+      Sandbox runs   Score against   Score: true            │
+      command,       ground truth    negative (Phase B)     │
+      returns output (File F1)       or false positive      │
+           │                                                │
+           └── "[N tool-calls remaining]" ──────────────────┘
+                 (up to 15 terminal calls / 20 turns)
 ```
+
+#### Three Tools
+
+The model has access to exactly three tools (OpenAI function-calling schema):
+
+| Tool | Purpose | Parameters |
+|------|---------|------------|
+| `terminal` | Run a read-only command in the sandbox | `command` (string), `max_chars` (int, default 2000) |
+| `submit_vulnerable_files` | Submit ranked list of vulnerable file paths | `ranked_files` (array of strings) |
+| `submit_no_vulnerability_found` | Declare codebase is not vulnerable | (none) |
+
+**Allowed terminal commands:** `ls`, `tree`, `find`, `pwd`, `du`, `file`,
+`stat`, `cat`, `head`, `tail`, `sed`, `nl`, `wc`, `grep`, `rg`, `ag`,
+`xargs`, `sort`, `uniq`, `cut`, `awk`, `basename`, `dirname`, `realpath`,
+`diff`, `echo`. Pipes between allowed commands are permitted.
+
+**Denied:** `python`, `bash`, `sh`, `node`, `perl`, `ruby`, subshells
+(`$()`, backticks), redirects (`>`, `>>`), chaining (`&&`, `||`).
+Enforcement is runtime — the sandbox validates commands against an allowlist.
+
+#### Budget
+
+| Limit | Default | Effect when exhausted |
+|-------|---------|----------------------|
+| Terminal calls | 15 | Model receives: "Terminal call budget exhausted. Please submit your answer now." |
+| Conversation turns | 20 | Loop force-stops; model gets zero credit |
+| Consecutive no-tool turns | 3 | Loop force-stops |
+| Command timeout | 10 s | Command killed, error returned |
+| Output truncation | 2000 chars | Output clipped to `max_chars` |
 
 #### Phases
 
-- **Phase A (Vulnerable):** pre-fix commit. Success = high File F1.
-- **Phase B (Patched):** post-fix commit. Success = high True Negative Rate.
+| Aspect | Phase A (Vulnerable) | Phase B (Patched) |
+|--------|---------------------|-------------------|
+| Code version | Pre-fix commit (`pre_push.zip`) | Post-fix commit (`post_push.zip`) |
+| Correct answer | Submit the vulnerable file(s) | Submit "no vulnerability found" |
+| Primary metric | File F1 (precision/recall) | True Negative Rate |
+| Failure mode | Missing or wrong files (low F1) | False positive (flagging patched code) |
+
+The same CWE prompt is used for both phases — the model must determine from
+the code itself whether the vulnerability is present or has been fixed.
 
 #### Runners
 
-| Runner | Endpoint | Models |
-|--------|----------|--------|
-| `vllm` | `/v1/chat/completions` | Granite-4.0 (generic chat) |
-| `vllm_antares` | `/v1/completions` (raw text) | Antares family |
-| `vllm_qwen_3_5` | `/v1/chat/completions` + tool parser | Qwen3.5-9B |
-| `vllm_gemma_4` | `/v1/chat/completions` + tool parser | Gemma-4 (optional) |
+Each runner shares the same system prompt and tool schemas. They differ in
+API endpoint, tool-calling mechanism, and generation parameters.
+
+| Runner | Endpoint | Tool calling | Temperature | Models |
+|--------|----------|-------------|-------------|--------|
+| `vllm` | `/v1/chat/completions` | Native OpenAI | 0.3 | Granite-4.0 |
+| `vllm_antares` | `/v1/completions` (raw) | XML tags in prompt | 0.3 | Antares |
+| `vllm_qwen_3_5` | `/v1/chat/completions` | Native + tool parser | 0.6 | Qwen3.5-9B |
+| `vllm_gemma_4` | `/v1/chat/completions` | Native + tool parser | 1.0 | Gemma-4 |
+
+**Antares** is architecturally distinct: it uses the raw `/v1/completions`
+endpoint with a manually constructed chat template
+(`<|start_of_role|>system<|end_of_role|>...`) and XML-based tool call parsing
+(`<tool_call>{json}</tool_call>`). It also injects `<think>` at the start of
+each generation to trigger chain-of-thought reasoning.
 
 #### Sandbox
 
 - Docker container based on `ubuntu:24.04`
-- No network access (isolation)
+- No network access (`--network=none`, fully isolated)
 - 2 CPU cores, 4 GB RAM per sandbox
-- Repository mounted at `/workspace/repo/`
+- Repository unzipped to `/workspace/repo/`
+- Commands run as user `agent` in working directory `/workspace/repo`
 - Command timeout: 10 seconds
 - Container destroyed after each task
+- If the container dies mid-task, the agent loop rebuilds it automatically
 
 #### Containerized Harness Architecture
 
@@ -103,7 +175,23 @@ scope bus` errors.
 | **True Negative Rate** | Fraction of patched repos correctly cleared (Phase B) |
 | **Tasks/hr** | Task completion rate |
 
-#### Offline Capacity Metrics
+**Scoring details:**
+
+- Ground truth files are filtered to source code only (`.go`, `.java`, `.py`,
+  `.js`, `.ts`, `.jsx`, `.tsx`, `.rs`, `.rb`, `.php`, `.c`, `.cpp`, `.h`,
+  `.hpp`, `.cs`, `.scala`, `.kt`, `.swift`) — test files are excluded.
+- File F1 = 2 × (precision × recall) / (precision + recall).
+- If the model abstains (submits nothing), File F1 = 0.
+- Phase B True Negative = model called `submit_no_vulnerability_found`.
+- Aggregate scores: `mean_file_f1` and `true_negative_rate` across all tasks.
+
+#### Offline Capacity Metrics (approximation)
+
+> **Important:** Offline capacity runs are an **approximation** of serving
+> throughput. They measure raw inference speed under synthetic or extracted
+> prompts — they do NOT run the VLoc agent loop and cannot measure
+> localization quality. See [Why online and offline measure different
+> things](#online-vs-offline--why-they-measure-different-things) below.
 
 | Metric | Definition |
 |--------|-----------|
@@ -149,7 +237,41 @@ Optional: Gemma-4-E2B/E4B for additional comparison.
 
 ---
 
-### Offline vs Online — When to Use Which
+### Online vs Offline — Why They Measure Different Things
+
+The VLoc agent loop is inherently **interactive**: each tool call depends on
+the previous model output and sandbox response. This multi-turn reasoning
+chain cannot be batched or parallelized — the model must see `grep` results
+before deciding what to `cat` next.
+
+Offline capacity runs bypass this loop entirely. They send single-shot
+prompts through `vllm bench throughput` and measure raw tok/s. This answers
+"can the CPU sustain inference at a useful rate?" but says nothing about
+whether the model can actually localize vulnerabilities.
+
+```text
+Online VLoc (quality):   prompt → model → tool call → sandbox → model → ... → submit → score
+Offline capacity (speed): prompt → model → output → measure tok/s (no tools, no reasoning chain)
+```
+
+#### Dataset Reuse for Offline Runs
+
+To make offline capacity runs more representative than random token shapes,
+the VLoc dataset can be reused as input. The CVE descriptions and CWE
+prompts from the 500 tasks provide realistic prompt lengths and content.
+However, results are still an **approximation** — the offline run processes
+each prompt as a single-shot completion, not a multi-turn agent conversation.
+
+| Offline input source | Realism | What it measures |
+|---------------------|---------|------------------|
+| Random token shapes | Low | Pure throughput ceiling |
+| VLoc CVE prompts (extracted) | Medium | Throughput on CVE-shaped text |
+| Full agent loop (online VLoc) | High | End-to-end localization + throughput |
+
+Tag offline runs as `use_case=cve_capacity` to distinguish them from online
+localization results (`use_case=cve_localization`).
+
+#### When to Use Which
 
 | Question | Track |
 |----------|-------|

--- a/docs/methodology/cve-vloc.md
+++ b/docs/methodology/cve-vloc.md
@@ -133,6 +133,10 @@ each generation to trigger chain-of-thought reasoning.
 - Command timeout: 10 seconds
 - Container destroyed after each task
 - If the container dies mid-task, the agent loop rebuilds it automatically
+- Command allowlist is **enforced by default** (denied: `python`, `bash`,
+  subshells, redirects, `&&` / `||`). Pass `--permissive` /
+  `-e vloc_permissive=true` only for debugging — that skip is **not**
+  comparable to the published leaderboard protocol.
 
 #### Containerized Harness Architecture
 
@@ -141,7 +145,7 @@ DUT. Three images are involved:
 
 | Image | Purpose | Built from |
 |-------|---------|------------|
-| `vloc-bench-harness:latest` | CLI, agent loop, model runners | `automation/test-execution/containers/vloc-bench/Dockerfile` |
+| `vloc-bench-harness:latest` | CLI, agent loop, model runners | `automation/test-execution/containers/vloc-bench/Dockerfile` (VLoc commit pinned via `VLOC_REF`) |
 | `vulnerability-localization-benchmark-sandbox:latest` | Per-task code sandbox | Upstream VLoc `Dockerfile` (extracted from harness image) |
 | `docker.io/vllm/vllm-openai-cpu:v0.25.1` | Model serving | Pre-built upstream |
 
@@ -233,7 +237,8 @@ Optional: Gemma-4-E2B/E4B for additional comparison.
   each worker competes for inference capacity. Start with `--workers 1`.
 
 - **Context length:** Antares supports 128K but CPU memory is limited. Use
-  8K-32K for smoke testing. Real tasks rarely need full context.
+  8K-32K for smoke testing. Real tasks rarely need full context. Qwen3.5-9B
+  defaults to `--max-model-len 4096`.
 
 ---
 

--- a/docs/methodology/cve-vloc.md
+++ b/docs/methodology/cve-vloc.md
@@ -62,6 +62,33 @@ repository mounted in a Docker sandbox. The model uses terminal commands
 - Command timeout: 10 seconds
 - Container destroyed after each task
 
+#### Containerized Harness Architecture
+
+VLoc Bench runs entirely in containers — nothing is installed natively on the
+DUT. Three images are involved:
+
+| Image | Purpose | Built from |
+|-------|---------|------------|
+| `vloc-bench-harness:latest` | CLI, agent loop, model runners | `automation/test-execution/containers/vloc-bench/Dockerfile` |
+| `vulnerability-localization-benchmark-sandbox:latest` | Per-task code sandbox | Upstream VLoc `Dockerfile` (extracted from harness image) |
+| `docker.io/vllm/vllm-openai-cpu:v0.25.1` | Model serving | Pre-built upstream |
+
+The harness container spawns sandbox containers on the **host** via Podman
+socket passthrough (sibling containers, not Docker-in-Docker). The host's
+Podman socket is mounted into the harness at `/var/run/docker.sock`.
+
+**Prerequisites for socket passthrough:**
+
+```bash
+systemctl --user enable --now podman.socket
+# For headless / CI systems where no interactive session exists:
+loginctl enable-linger <user>
+```
+
+Without `linger`, the user systemd instance (and its sockets) is torn down
+when no interactive session is active, causing `Failed to connect to user
+scope bus` errors.
+
 ---
 
 ### Metrics

--- a/tests/cve-scanning/cve-scanning.md
+++ b/tests/cve-scanning/cve-scanning.md
@@ -74,11 +74,17 @@ vLLM flags: `--enable-auto-tool-choice --tool-call-parser gemma4`
     `automation/test-execution/containers/vloc-bench/Dockerfile` (built on first
     run if not present)
   - **VLoc sandbox:** `vulnerability-localization-benchmark-sandbox:latest` —
-    built from the upstream VLoc Bench Dockerfile (one per CVE task, spawned by
-    the harness via Podman socket passthrough)
-- **Podman socket** (for VLoc sandbox spawning): the harness container uses
+    built from the upstream VLoc Bench `Dockerfile` (extracted from the harness
+    image). One sandbox container per CVE task, spawned by the harness via
+    Podman socket passthrough (sibling containers, not Docker-in-Docker).
+    The name must match `sandbox.image` in the harness's `configs/default.yaml`.
+- **Podman user socket** (for VLoc sandbox spawning): the harness container uses
   Docker CLI to spawn sandbox containers on the host via socket passthrough.
-  Enable with `systemctl --user enable --now podman.socket`.
+  ```bash
+  systemctl --user enable --now podman.socket
+  # For headless / CI systems (no interactive session):
+  loginctl enable-linger $(whoami)
+  ```
 - **HF_TOKEN** for gated models (Antares family):
   1. Apply at <https://huggingface.co/fdtn-ai/antares-1b>
   2. `export HF_TOKEN=hf_xxxxx`
@@ -110,18 +116,26 @@ export HF_TOKEN=hf_xxxxx
 ./smoke-model-serve.sh --all-matrix
 ```
 
-#### Step 2: Verify VLoc Bench harness
+#### Step 2: Verify VLoc Bench harness (containerized)
 
 ```bash
-# Clone, install, build sandbox, download dataset
+# Build harness + sandbox images, check Podman socket, download dataset
 ./smoke-vloc-harness.sh
 
 # Quick check (skip dataset download)
 ./smoke-vloc-harness.sh --skip-dataset
 
-# Use Docker instead of Podman for sandbox
+# Use Docker instead of Podman for sandbox spawning
 ./smoke-vloc-harness.sh --container-engine docker
+
+# Custom data cache directory
+./smoke-vloc-harness.sh --data-dir /data/vloc-dataset
 ```
+
+> **Note:** The smoke script builds images from
+> `automation/test-execution/containers/vloc-bench/Dockerfile` and downloads
+> the dataset via the harness container (`--output-dir`), matching the
+> Ansible playbook path exactly. Nothing is installed natively.
 
 #### Step 3: Run online VLoc Bench
 
@@ -179,22 +193,41 @@ podman logs vllm-smoke-<model>-<pid>
 #### VLoc Bench CLI errors
 
 ```bash
-# Verify import
-cd /tmp/vloc-bench
-PYTHONPATH=src .venv/bin/python3 -c "import vulnerability_localization_benchmark.cli"
+# Verify CLI importable inside the harness container
+podman run --rm vloc-bench-harness:latest \
+  python3 -c "import vulnerability_localization_benchmark.cli"
 
-# Check runner module exists
-ls src/vulnerability_localization_benchmark/model_runners/
+# List available model runners
+podman run --rm vloc-bench-harness:latest \
+  ls /opt/vloc-bench/src/vulnerability_localization_benchmark/model_runners/
 ```
 
 #### Sandbox build fails
 
 ```bash
-# VLoc sandbox is based on ubuntu:24.04
-# If Podman fails, try Docker:
-docker build -t vulnerability-localization-benchmark-sandbox /tmp/vloc-bench
+# Extract Dockerfile from harness image, then build:
+podman run --rm vloc-bench-harness:latest cat /opt/vloc-bench/Dockerfile \
+  > /tmp/vloc-sandbox-Dockerfile
+podman build -t vulnerability-localization-benchmark-sandbox:latest \
+  -f /tmp/vloc-sandbox-Dockerfile /tmp
 
-# If both fail, check network access and base image availability
+# If Podman fails, try Docker:
+docker build -t vulnerability-localization-benchmark-sandbox:latest \
+  -f /tmp/vloc-sandbox-Dockerfile /tmp
+```
+
+#### Podman socket issues
+
+```bash
+# Enable user socket (required for sandbox spawning)
+systemctl --user enable --now podman.socket
+
+# For headless / CI systems, enable linger so the socket
+# persists without an interactive session
+loginctl enable-linger $(whoami)
+
+# Verify socket
+ls -la /run/user/$(id -u)/podman/podman.sock
 ```
 
 #### Dataset download slow or fails

--- a/tests/cve-scanning/cve-scanning.md
+++ b/tests/cve-scanning/cve-scanning.md
@@ -71,8 +71,8 @@ vLLM flags: `--enable-auto-tool-choice --tool-call-parser gemma4`
   - **vLLM serving:** `docker.io/vllm/vllm-openai-cpu:v0.25.1` (override with
     `VLLM_CONTAINER_IMAGE`)
   - **VLoc harness:** `vloc-bench-harness:latest` — built from
-    `automation/test-execution/containers/vloc-bench/Dockerfile` (built on first
-    run if not present)
+    `automation/test-execution/containers/vloc-bench/Dockerfile` (VLoc commit
+    pinned via `VLOC_REF`; rebuild the image after bumping the pin)
   - **VLoc sandbox:** `vulnerability-localization-benchmark-sandbox:latest` —
     built from the upstream VLoc Bench `Dockerfile` (extracted from the harness
     image). One sandbox container per CVE task, spawned by the harness via
@@ -143,7 +143,7 @@ export HF_TOKEN=hf_xxxxx
 cd automation/test-execution/scripts/bash
 
 # Smoke: 5 tasks, Phase A, Granite baseline
-./run-cve-vloc-suite.sh smoke --models granite --cores 8
+./run-cve-vloc-suite.sh smoke --cores 8
 
 # Phase A with Antares
 export HF_TOKEN=hf_xxxxx
@@ -152,6 +152,11 @@ export HF_TOKEN=hf_xxxxx
 # Full matrix sweep (all required models, 25 tasks each)
 ./run-cve-vloc-suite.sh model-sweep --n-limit 25 --cores 16
 ```
+
+The suite matches the published leaderboard protocol by default (sandbox
+command allowlist on). Pass `--permissive` only to debug sandbox command
+validation; those scores are not leaderboard-comparable. Override the vLLM
+image with `--container-image` or `VLLM_CONTAINER_IMAGE`.
 
 ---
 
@@ -162,7 +167,7 @@ export HF_TOKEN=hf_xxxxx
 | Granite-4.0-350M | 4096 | auto | — | ~2 GB |
 | Granite-4.0-1B | 4096 | auto | — | ~4 GB |
 | Granite-4.0-Micro | 4096 | auto | — | ~8 GB |
-| Qwen3.5-9B | 2048 | auto | `--enable-auto-tool-choice --tool-call-parser qwen3_coder` | ~20 GB |
+| Qwen3.5-9B | 4096 | auto | `--enable-auto-tool-choice --tool-call-parser qwen3_coder` | ~20 GB |
 | Antares-1B | 8192 | bfloat16 | `--trust-remote-code` | ~4 GB |
 | Antares-350M | 8192 | bfloat16 | `--trust-remote-code` | ~2 GB |
 

--- a/tests/cve-scanning/cve-scanning.md
+++ b/tests/cve-scanning/cve-scanning.md
@@ -1,0 +1,248 @@
+---
+layout: default
+title: CVE Scanning / VLoc Bench
+---
+
+## CVE Vulnerability Localization Testing
+
+This test suite integrates the
+[Cisco Vulnerability Localization Benchmark (VLoc Bench)](https://github.com/cisco-foundation-ai/vulnerability-localization-benchmark)
+for evaluating LLM-driven vulnerability localization on CPU with vLLM.
+
+### Two measurement tracks
+
+| Track | What it measures | Tooling | Key metric |
+|-------|------------------|---------|------------|
+| **Online VLoc** | Real vulnerability localization quality | vLLM serve → VLoc Bench CLI (agent loop + Docker sandbox) | File F1 |
+| **Offline capacity** | Raw model throughput under fixed I/O shapes | `vllm bench throughput` | tok/s, items/hr |
+
+> **Important:** Offline capacity runs measure throughput, not localization
+> quality. Do not label offline results as "CVE scanning quality." Reserve
+> CVE / localization language for the online VLoc agent path.
+
+---
+
+### Model Matrix
+
+#### Required: Granite (baselines, ≤8B)
+
+| Model | Size | Phase A File F1 (ref) | HF ID | VLoc Runner | Gated |
+|-------|------|-----------------------|-------|-------------|-------|
+| Granite-4.0-350M | 350M | 0.001 | `ibm-granite/granite-4.0-350m` | `vllm` | No |
+| Granite-4.0-1B | 1B | 0.0 | `ibm-granite/granite-4.0-1b` | `vllm` | No |
+| Granite-4.0-Micro | ~3B | 0.0 | `ibm-granite/granite-4.0-micro` | `vllm` | No |
+
+These are Granite base checkpoints with near-zero File F1—included as
+baselines to show specialization vs Antares.
+
+#### Required: Qwen (9B exception to ≤8B)
+
+| Model | Size | Phase A File F1 (ref) | HF ID | VLoc Runner | Gated |
+|-------|------|-----------------------|-------|-------------|-------|
+| Qwen3.5-9B | 9B | 0.043 | `Qwen/Qwen3.5-9B` | `vllm_qwen_3_5` | No |
+
+vLLM flags: `--enable-auto-tool-choice --tool-call-parser qwen3_coder`
+
+#### Required: Antares (gated — needs HF_TOKEN)
+
+| Model | Size | Phase A File F1 (ref) | HF ID | VLoc Runner | Gated |
+|-------|------|-----------------------|-------|-------------|-------|
+| Antares-1B-GRPO | 1B | 0.209 | `fdtn-ai/antares-1b` | `vllm_antares` | Yes |
+| Antares-350M-GRPO | 350M | 0.135 | `fdtn-ai/antares-350m` | `vllm_antares` | Yes |
+
+Antares uses raw `/v1/completions` (not chat completions). Requires
+`HF_TOKEN` and approval via the
+[Cisco HuggingFace form](https://huggingface.co/fdtn-ai/antares-1b).
+
+#### Optional: Gemma-4
+
+| Model | Size | Phase A File F1 (ref) | HF ID | VLoc Runner | Gated |
+|-------|------|-----------------------|-------|-------------|-------|
+| Gemma-4-E2B | 2B | 0.039 | `google/gemma-4-E2B-it` | `vllm_gemma_4` | No |
+| Gemma-4-E4B | 4B | 0.034 | `google/gemma-4-E4B-it` | `vllm_gemma_4` | No |
+
+vLLM flags: `--enable-auto-tool-choice --tool-call-parser gemma4`
+
+---
+
+### Prerequisites
+
+- **Podman** ≥ 4.0 (or Docker) — three container images are used:
+  - **vLLM serving:** `docker.io/vllm/vllm-openai-cpu:v0.25.1` (override with
+    `VLLM_CONTAINER_IMAGE`)
+  - **VLoc harness:** `vloc-bench-harness:latest` — built from
+    `automation/test-execution/containers/vloc-bench/Dockerfile` (built on first
+    run if not present)
+  - **VLoc sandbox:** `vulnerability-localization-benchmark-sandbox:latest` —
+    built from the upstream VLoc Bench Dockerfile (one per CVE task, spawned by
+    the harness via Podman socket passthrough)
+- **Podman socket** (for VLoc sandbox spawning): the harness container uses
+  Docker CLI to spawn sandbox containers on the host via socket passthrough.
+  Enable with `systemctl --user enable --now podman.socket`.
+- **HF_TOKEN** for gated models (Antares family):
+  1. Apply at <https://huggingface.co/fdtn-ai/antares-1b>
+  2. `export HF_TOKEN=hf_xxxxx`
+- **Disk space:** ~10 GB for the full VLoc dataset (500 tasks, pre/post zips)
+- **Memory:** varies by model—see [CPU serving notes](#cpu-serving-notes) below
+- **No native installation required:** VLoc Bench runs entirely in containers.
+  Python, git, and all dependencies are inside the harness container image.
+
+---
+
+### Quick Start — Smoke Tests
+
+#### Step 1: Verify model serving
+
+```bash
+cd tests/cve-scanning
+
+# Test smallest public model (Granite-4.0-350M)
+./smoke-model-serve.sh
+
+# Test a specific model
+./smoke-model-serve.sh --model ibm-granite/granite-4.0-1b
+
+# Test Antares (requires HF_TOKEN)
+export HF_TOKEN=hf_xxxxx
+./smoke-model-serve.sh --model fdtn-ai/antares-1b --dtype bfloat16
+
+# Test all required matrix models
+./smoke-model-serve.sh --all-matrix
+```
+
+#### Step 2: Verify VLoc Bench harness
+
+```bash
+# Clone, install, build sandbox, download dataset
+./smoke-vloc-harness.sh
+
+# Quick check (skip dataset download)
+./smoke-vloc-harness.sh --skip-dataset
+
+# Use Docker instead of Podman for sandbox
+./smoke-vloc-harness.sh --container-engine docker
+```
+
+#### Step 3: Run online VLoc Bench
+
+```bash
+cd automation/test-execution/scripts/bash
+
+# Smoke: 5 tasks, Phase A, Granite baseline
+./run-cve-vloc-suite.sh smoke --models granite --cores 8
+
+# Phase A with Antares
+export HF_TOKEN=hf_xxxxx
+./run-cve-vloc-suite.sh phase-a --models antares --n-limit 25 --cores 16
+
+# Full matrix sweep (all required models, 25 tasks each)
+./run-cve-vloc-suite.sh model-sweep --n-limit 25 --cores 16
+```
+
+---
+
+### CPU Serving Notes
+
+| Model | Recommended `--max-model-len` | `--dtype` | Extra args | Memory estimate |
+|-------|-------------------------------|-----------|------------|-----------------|
+| Granite-4.0-350M | 4096 | auto | — | ~2 GB |
+| Granite-4.0-1B | 4096 | auto | — | ~4 GB |
+| Granite-4.0-Micro | 4096 | auto | — | ~8 GB |
+| Qwen3.5-9B | 2048 | auto | `--enable-auto-tool-choice --tool-call-parser qwen3_coder` | ~20 GB |
+| Antares-1B | 8192 | bfloat16 | `--trust-remote-code` | ~4 GB |
+| Antares-350M | 8192 | bfloat16 | `--trust-remote-code` | ~2 GB |
+
+> **Note:** CPU serving is significantly slower than GPU. Cisco's reference
+> numbers (500 tasks in ~13 min on H100) assume GPU with 16 parallel workers.
+> On CPU, expect **hours** for a full 500-task run. Default to `--n-limit 5`
+> for smoke testing.
+
+> **Context length:** Antares supports 128K context, but start with 8K on CPU
+> to reduce memory. Increase if tasks require deeper file inspection.
+
+---
+
+### Troubleshooting
+
+#### Model won't load / container exits immediately
+
+```bash
+# Check container logs
+podman logs vllm-smoke-<model>-<pid>
+
+# Common issues:
+# - OOM: reduce --max-model-len or --cores
+# - Gated model: set HF_TOKEN
+# - Architecture mismatch: ensure CPU image, not GPU
+```
+
+#### VLoc Bench CLI errors
+
+```bash
+# Verify import
+cd /tmp/vloc-bench
+PYTHONPATH=src .venv/bin/python3 -c "import vulnerability_localization_benchmark.cli"
+
+# Check runner module exists
+ls src/vulnerability_localization_benchmark/model_runners/
+```
+
+#### Sandbox build fails
+
+```bash
+# VLoc sandbox is based on ubuntu:24.04
+# If Podman fails, try Docker:
+docker build -t vulnerability-localization-benchmark-sandbox /tmp/vloc-bench
+
+# If both fail, check network access and base image availability
+```
+
+#### Dataset download slow or fails
+
+- The full dataset is ~500 zip files from GitHub
+- Network-dependent; may take 10-30+ minutes
+- If rate-limited, retry with `--force-clone`
+- For CI, consider pre-caching the dataset
+
+---
+
+### Test ID Naming Convention
+
+```text
+CVE-VLOC-{MODEL}      — Online VLoc localization run
+CVE-CAP-{MODEL}       — Offline capacity proxy run
+```
+
+Model abbreviations:
+
+| Abbreviation | Model |
+|-------------|-------|
+| GRANITE350M | ibm-granite/granite-4.0-350m |
+| GRANITE1B | ibm-granite/granite-4.0-1b |
+| GRANITEMICRO | ibm-granite/granite-4.0-micro |
+| QWEN9B | Qwen/Qwen3.5-9B |
+| ANTARES1B | fdtn-ai/antares-1b |
+| ANTARES350M | fdtn-ai/antares-350m |
+
+Examples:
+
+- `CVE-VLOC-GRANITE1B` — Online VLoc Phase A with Granite-4.0-1B
+- `CVE-VLOC-ANTARES1B` — Online VLoc Phase A with Antares-1B
+- `CVE-CAP-GRANITE350M` — Offline capacity with Granite-4.0-350M
+
+---
+
+### Results Schema
+
+Online VLoc results are stored under
+`results/llm/<model>/cve-vloc-<timestamp>/<config>/` with:
+
+- `test-metadata.json` — test configuration and environment
+- `results.json` — metrics (File F1, Precision, Recall, TNR, tasks/hr)
+- VLoc Bench output (per-task JSON + aggregate)
+
+Offline capacity results follow the offline-batch schema with
+`use_case=cve_capacity`.
+
+See [methodology](../../docs/methodology/cve-vloc.md) for metric definitions
+and the distinction between online VLoc and offline capacity results.

--- a/tests/cve-scanning/cve-scanning.md
+++ b/tests/cve-scanning/cve-scanning.md
@@ -170,7 +170,7 @@ export HF_TOKEN=hf_xxxxx
 > numbers (500 tasks in ~13 min on H100) assume GPU with 16 parallel workers.
 > On CPU, expect **hours** for a full 500-task run. Default to `--n-limit 5`
 > for smoke testing.
-
+>
 > **Context length:** Antares supports 128K context, but start with 8K on CPU
 > to reduce memory. Increase if tasks require deeper file inspection.
 

--- a/tests/cve-scanning/cve-scanning.md
+++ b/tests/cve-scanning/cve-scanning.md
@@ -13,7 +13,7 @@ for evaluating LLM-driven vulnerability localization on CPU with vLLM.
 
 | Track | What it measures | Tooling | Key metric |
 |-------|------------------|---------|------------|
-| **Online VLoc** | Real vulnerability localization quality | vLLM serve → VLoc Bench CLI (agent loop + Docker sandbox) | File F1 |
+| **Online VLoc** | Real vulnerability localization quality | vLLM serve → VLoc Bench CLI (agent loop + Docker sandbox) | File F1, TNR |
 | **Offline capacity** | Raw model throughput under fixed I/O shapes | `vllm bench throughput` | tok/s, items/hr |
 
 > **Important:** Offline capacity runs measure throughput, not localization

--- a/tests/cve-scanning/smoke-model-serve.sh
+++ b/tests/cve-scanning/smoke-model-serve.sh
@@ -282,22 +282,25 @@ test_model() {
     podman rm -f "${CONTAINER_NAME}" 2>/dev/null || true
 
     # Build vLLM command (entrypoint is "vllm serve", so pass model + args only)
-    local vllm_cmd="${model} --dtype ${dtype} --max-model-len ${max_len} --host 0.0.0.0 --port ${PORT}"
+    local vllm_cmd=("${model}" --dtype "${dtype}" --max-model-len "${max_len}" --host 0.0.0.0 --port "${PORT}")
     if [[ -n "${extra_args}" ]]; then
-        vllm_cmd="${vllm_cmd} ${extra_args}"
+        local extra_arr
+        read -r -a extra_arr <<< "${extra_args}"
+        vllm_cmd+=("${extra_arr[@]}")
     fi
 
     # Build environment args
     local env_args=()
     env_args+=(-e "OMP_NUM_THREADS=${CORES}")
     if [[ -n "${HF_TOKEN:-}" ]]; then
-        env_args+=(-e "HF_TOKEN=${HF_TOKEN}")
+        env_args+=(-e "HF_TOKEN")
     fi
 
     # Granite hybrid patch (TODO: remove when vLLM > v0.25.1)
     local patch_args=()
     if is_granite_hybrid "${model}"; then
-        if apply_granite_patch; then
+        if apply_granite_patch && \
+           [[ -f "${VLLM_PATCH_DIR}/granitemoehybrid.py" ]]; then
             patch_args=(-v "${VLLM_PATCH_DIR}/granitemoehybrid.py:${VLLM_PATCH_TARGET}:z")
         fi
     fi
@@ -324,7 +327,7 @@ test_model() {
         "${patch_args[@]}" \
         "${env_args[@]}" \
         "${CONTAINER_IMAGE}" \
-        ${vllm_cmd} 2>&1; then
+        "${vllm_cmd[@]}" 2>&1; then
         fail "Container failed to start"
         echo "--- Container logs ---"
         podman logs "${CONTAINER_NAME}" 2>&1 | tail -30 || true

--- a/tests/cve-scanning/smoke-model-serve.sh
+++ b/tests/cve-scanning/smoke-model-serve.sh
@@ -1,0 +1,494 @@
+#!/bin/bash
+# ==============================================================================
+# CVE/VLoc Bench — Smoke Test: vLLM Model Serve
+# ==============================================================================
+# Verifies that a model from the VLoc Bench matrix can be served on vLLM CPU.
+# Starts a Podman container, waits for health, tests /v1/models and a trivial
+# completion, then tears down.
+#
+# Usage:
+#   ./smoke-model-serve.sh [options]
+#
+# Options:
+#   --model MODEL           HuggingFace model ID (default: ibm-granite/granite-4.0-350m)
+#   --max-model-len LEN     Max context length (default: 4096)
+#   --dtype DTYPE            Model dtype (default: auto)
+#   --port PORT              vLLM listen port (default: 8200)
+#   --cores CORES            CPU cores to allocate (default: 8)
+#   --timeout SECONDS        Health-check timeout (default: 300)
+#   --container-image IMAGE  vLLM container image
+#   --keep                   Don't remove container on exit
+#   --all-matrix             Test all required matrix models sequentially
+#   -h, --help               Show this help
+#
+# Environment variables:
+#   HF_TOKEN                 HuggingFace token (required for gated models like Antares)
+#   VLLM_CONTAINER_IMAGE     Override container image
+#
+# Examples:
+#   # Quick smoke with smallest public model
+#   ./smoke-model-serve.sh
+#
+#   # Test Antares (requires HF_TOKEN)
+#   export HF_TOKEN=hf_xxxxx
+#   ./smoke-model-serve.sh --model fdtn-ai/antares-1b --dtype bfloat16
+#
+#   # Test all required matrix models
+#   ./smoke-model-serve.sh --all-matrix
+#
+# Exit codes:
+#   0  All tests passed
+#   1  One or more tests failed
+# ==============================================================================
+
+set -euo pipefail
+
+# Handle Ctrl+C gracefully
+CONTAINER_NAME=""
+cleanup() {
+    if [[ -n "${CONTAINER_NAME}" ]] && [[ "${KEEP_CONTAINER:-false}" != "true" ]]; then
+        echo -e "\nCleaning up container ${CONTAINER_NAME}..."
+        podman rm -f "${CONTAINER_NAME}" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+trap 'echo -e "\n\nInterrupted by user."; exit 130' SIGINT SIGTERM
+
+# Colors
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; }
+info() { echo -e "  ${BLUE}INFO${NC} $1"; }
+warn() { echo -e "  ${YELLOW}WARN${NC} $1"; }
+
+# ============================================================================
+# Model matrix
+# ============================================================================
+
+# Required: Granite (baselines)
+MODEL_GRANITE_1B="ibm-granite/granite-4.0-1b"
+MODEL_GRANITE_350M="ibm-granite/granite-4.0-350m"
+MODEL_GRANITE_MICRO="ibm-granite/granite-4.0-micro"
+
+# Required: Qwen (9B exception to ≤8B rule)
+MODEL_QWEN_9B="Qwen/Qwen3.5-9B"
+
+# Required: Antares (gated — needs HF_TOKEN)
+MODEL_ANTARES_1B="fdtn-ai/antares-1b"
+MODEL_ANTARES_350M="fdtn-ai/antares-350m"
+
+# Optional: Gemma-4
+MODEL_GEMMA_E2B="google/gemma-4-E2B-it"
+MODEL_GEMMA_E4B="google/gemma-4-E4B-it"
+
+# Required models for --all-matrix (ordered smallest to largest)
+REQUIRED_MODELS=(
+    "${MODEL_GRANITE_350M}"
+    "${MODEL_GRANITE_1B}"
+    "${MODEL_GRANITE_MICRO}"
+    "${MODEL_ANTARES_350M}"
+    "${MODEL_ANTARES_1B}"
+    "${MODEL_QWEN_9B}"
+)
+
+# ============================================================================
+# Defaults
+# ============================================================================
+
+DEFAULT_CONTAINER_IMAGE="docker.io/vllm/vllm-openai-cpu:v0.25.1"
+MODEL="${MODEL_GRANITE_350M}"
+MAX_MODEL_LEN=4096
+DTYPE="auto"
+PORT=8200
+CORES=8
+TIMEOUT=300
+CONTAINER_IMAGE="${VLLM_CONTAINER_IMAGE:-${DEFAULT_CONTAINER_IMAGE}}"
+KEEP_CONTAINER="false"
+ALL_MATRIX="false"
+
+# ============================================================================
+# Argument parsing
+# ============================================================================
+
+usage() {
+    sed -n '2,/^# ===/p' "$0" | head -n -1 | sed 's/^# \?//'
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --model)       MODEL="$2"; shift 2 ;;
+        --max-model-len) MAX_MODEL_LEN="$2"; shift 2 ;;
+        --dtype)       DTYPE="$2"; shift 2 ;;
+        --port)        PORT="$2"; shift 2 ;;
+        --cores)       CORES="$2"; shift 2 ;;
+        --timeout)     TIMEOUT="$2"; shift 2 ;;
+        --container-image) CONTAINER_IMAGE="$2"; shift 2 ;;
+        --keep)        KEEP_CONTAINER="true"; shift ;;
+        --all-matrix)  ALL_MATRIX="true"; shift ;;
+        -h|--help)     usage ;;
+        *)             echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+# ============================================================================
+# Per-model vLLM argument configuration
+# ============================================================================
+
+get_vllm_extra_args() {
+    local model="$1"
+    case "${model}" in
+        *antares*)
+            echo "--trust-remote-code"
+            ;;
+        *Qwen*|*qwen*)
+            echo "--enable-auto-tool-choice --tool-call-parser qwen3_coder"
+            ;;
+        *gemma*)
+            echo "--enable-auto-tool-choice --tool-call-parser gemma4"
+            ;;
+        *)
+            echo ""
+            ;;
+    esac
+}
+
+get_default_dtype() {
+    local model="$1"
+    case "${model}" in
+        *antares*)
+            echo "bfloat16"
+            ;;
+        *)
+            echo "auto"
+            ;;
+    esac
+}
+
+get_default_max_model_len() {
+    local model="$1"
+    case "${model}" in
+        *Qwen*|*qwen*)
+            echo "2048"
+            ;;
+        *)
+            echo "4096"
+            ;;
+    esac
+}
+
+is_gated_model() {
+    local model="$1"
+    case "${model}" in
+        *antares*|fdtn-ai/*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+is_granite_hybrid() {
+    local model="$1"
+    case "${model}" in
+        *granite-4.0*|ibm-granite/granite-4*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Granite hybrid patch — delegates to shared script.
+# TODO: Remove when vLLM > v0.25.1 ships with PR #47867.
+VLLM_PATCH_DIR="/tmp/vllm-patch"
+VLLM_PATCH_TARGET="/opt/venv/lib/python3.12/site-packages/vllm/model_executor/models/granitemoehybrid.py"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PATCH_SCRIPT="${SCRIPT_DIR}/../../automation/test-execution/scripts/bash/patch-vllm-granite-hybrid.sh"
+
+apply_granite_patch() {
+    if [[ -f "${VLLM_PATCH_DIR}/granitemoehybrid.py" ]] && \
+       grep -q '"full_attention"' "${VLLM_PATCH_DIR}/granitemoehybrid.py" 2>/dev/null; then
+        return 0
+    fi
+    info "Applying Granite hybrid patch (vLLM PR #47867 backport)..."
+    if [[ -x "${PATCH_SCRIPT}" ]]; then
+        CONTAINER_ENGINE="${CONTAINER_ENGINE:-podman}" \
+        VLLM_CONTAINER_IMAGE="${CONTAINER_IMAGE}" \
+            "${PATCH_SCRIPT}" --output-dir "${VLLM_PATCH_DIR}" --container-image "${CONTAINER_IMAGE}"
+    else
+        warn "Patch script not found at ${PATCH_SCRIPT} — applying inline"
+        mkdir -p "${VLLM_PATCH_DIR}"
+        local engine="${CONTAINER_ENGINE:-podman}"
+        "${engine}" run --rm --entrypoint cat "${CONTAINER_IMAGE}" "${VLLM_PATCH_TARGET}" \
+            > "${VLLM_PATCH_DIR}/granitemoehybrid.py"
+        sed -i \
+            '/"mamba": GraniteMoeHybridMambaDecoderLayer,/a\    # Transformers >= 5.13.0 (vLLM PR #47867 backport)\n    "full_attention": GraniteMoeHybridAttentionDecoderLayer,\n    "linear_attention": GraniteMoeHybridMambaDecoderLayer,' \
+            "${VLLM_PATCH_DIR}/granitemoehybrid.py"
+        if ! grep -q '"full_attention"' "${VLLM_PATCH_DIR}/granitemoehybrid.py"; then
+            fail "Granite patch failed"
+            return 1
+        fi
+    fi
+}
+
+# ============================================================================
+# Test a single model
+# ============================================================================
+
+test_model() {
+    local model="$1"
+    local max_len="${2:-$(get_default_max_model_len "${model}")}"
+    local dtype="${3:-$(get_default_dtype "${model}")}"
+    local extra_args
+    extra_args="$(get_vllm_extra_args "${model}")"
+    local model_safe
+    model_safe="$(echo "${model}" | tr '/' '-' | tr '[:upper:]' '[:lower:]')"
+    CONTAINER_NAME="vllm-smoke-${model_safe}-$$"
+    local test_passed=true
+
+    echo ""
+    echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${BOLD}Testing: ${model}${NC}"
+    echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    info "Container: ${CONTAINER_IMAGE}"
+    info "Max model len: ${max_len}"
+    info "Dtype: ${dtype}"
+    info "Cores: ${CORES} (cpuset: 0-$((CORES - 1)))"
+    info "Port: ${PORT}"
+    if [[ -n "${extra_args}" ]]; then
+        info "Extra args: ${extra_args}"
+    fi
+
+    # Check HF_TOKEN for gated models
+    if is_gated_model "${model}"; then
+        if [[ -z "${HF_TOKEN:-}" ]]; then
+            fail "Model ${model} is gated — HF_TOKEN not set"
+            fail "Apply at https://huggingface.co/${model} and export HF_TOKEN=hf_xxxxx"
+            return 1
+        fi
+        info "HF_TOKEN is set (gated model)"
+    fi
+
+    # Remove any existing container with this name
+    podman rm -f "${CONTAINER_NAME}" 2>/dev/null || true
+
+    # Build vLLM command (entrypoint is "vllm serve", so pass model + args only)
+    local vllm_cmd="${model} --dtype ${dtype} --max-model-len ${max_len} --host 0.0.0.0 --port ${PORT}"
+    if [[ -n "${extra_args}" ]]; then
+        vllm_cmd="${vllm_cmd} ${extra_args}"
+    fi
+
+    # Build environment args
+    local env_args=()
+    env_args+=(-e "OMP_NUM_THREADS=${CORES}")
+    if [[ -n "${HF_TOKEN:-}" ]]; then
+        env_args+=(-e "HF_TOKEN=${HF_TOKEN}")
+    fi
+
+    # Granite hybrid patch (TODO: remove when vLLM > v0.25.1)
+    local patch_args=()
+    if is_granite_hybrid "${model}"; then
+        if apply_granite_patch; then
+            patch_args=(-v "${VLLM_PATCH_DIR}/granitemoehybrid.py:${VLLM_PATCH_TARGET}:z")
+        fi
+    fi
+
+    # Start container
+    # cpuset may not be delegated to rootless cgroup slices
+    local cpuset_args=()
+    local user_cgroup="/sys/fs/cgroup/user.slice/user-$(id -u).slice/user@$(id -u).service/cgroup.controllers"
+    if [[ $(id -u) -eq 0 ]] || \
+       ([ -f "$user_cgroup" ] && grep -q cpuset "$user_cgroup" 2>/dev/null); then
+        cpuset_args=(--cpuset-cpus "0-$((CORES - 1))")
+    else
+        warn "cpuset not delegated to user cgroup — skipping CPU pinning"
+    fi
+
+    info "Starting vLLM container..."
+    if ! podman run -d \
+        --name "${CONTAINER_NAME}" \
+        "${cpuset_args[@]}" \
+        --shm-size 4g \
+        --network host \
+        --security-opt seccomp=unconfined \
+        -v "${HOME}/.cache/huggingface:/root/.cache/huggingface:z" \
+        "${patch_args[@]}" \
+        "${env_args[@]}" \
+        "${CONTAINER_IMAGE}" \
+        ${vllm_cmd} 2>&1; then
+        fail "Container failed to start"
+        echo "--- Container logs ---"
+        podman logs "${CONTAINER_NAME}" 2>&1 | tail -30 || true
+        return 1
+    fi
+
+    # Wait for health
+    info "Waiting for health endpoint (timeout: ${TIMEOUT}s)..."
+    local elapsed=0
+    local interval=5
+    local healthy=false
+    while [[ ${elapsed} -lt ${TIMEOUT} ]]; do
+        if curl -sf "http://localhost:${PORT}/health" >/dev/null 2>&1; then
+            healthy=true
+            break
+        fi
+
+        # Check if container is still running
+        if ! podman inspect "${CONTAINER_NAME}" --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
+            fail "Container exited before becoming healthy"
+            echo "--- Container logs (last 50 lines) ---"
+            podman logs "${CONTAINER_NAME}" 2>&1 | tail -50
+            return 1
+        fi
+
+        sleep "${interval}"
+        elapsed=$((elapsed + interval))
+        if (( elapsed % 30 == 0 )); then
+            info "Still waiting... ${elapsed}s / ${TIMEOUT}s"
+        fi
+    done
+
+    if [[ "${healthy}" != "true" ]]; then
+        fail "Health check timed out after ${TIMEOUT}s"
+        echo "--- Container logs (last 50 lines) ---"
+        podman logs "${CONTAINER_NAME}" 2>&1 | tail -50
+        return 1
+    fi
+    pass "Health endpoint responded in ${elapsed}s"
+
+    # Test /v1/models
+    info "Testing /v1/models..."
+    local models_response
+    if models_response=$(curl -sf "http://localhost:${PORT}/v1/models" 2>&1); then
+        local model_ids
+        model_ids=$(echo "${models_response}" | python3 -c "import sys,json; print(', '.join(m['id'] for m in json.load(sys.stdin)['data']))" 2>/dev/null || echo "parse-error")
+        pass "/v1/models — available: ${model_ids}"
+    else
+        fail "/v1/models endpoint failed"
+        test_passed=false
+    fi
+
+    # Test /v1/chat/completions (works for all models)
+    info "Testing /v1/chat/completions..."
+    local chat_response
+    if chat_response=$(curl -sf "http://localhost:${PORT}/v1/chat/completions" \
+        -H "Content-Type: application/json" \
+        -d '{
+            "model": "'"${model}"'",
+            "messages": [{"role": "user", "content": "Say hello in one word."}],
+            "max_tokens": 16,
+            "temperature": 0.0
+        }' 2>&1); then
+        local reply
+        reply=$(echo "${chat_response}" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'][:80])" 2>/dev/null || echo "parse-error")
+        pass "/v1/chat/completions — reply: ${reply}"
+    else
+        fail "/v1/chat/completions failed"
+        test_passed=false
+    fi
+
+    # For Antares: also test /v1/completions (raw text endpoint)
+    if [[ "${model}" == *antares* ]]; then
+        info "Testing /v1/completions (Antares raw text)..."
+        local completions_response
+        if completions_response=$(curl -sf "http://localhost:${PORT}/v1/completions" \
+            -H "Content-Type: application/json" \
+            -d '{
+                "model": "'"${model}"'",
+                "prompt": "<|start_of_role|>user<|end_of_role|>Say hello.<|start_of_role|>assistant<|end_of_role|><think>\n",
+                "max_tokens": 64,
+                "temperature": 0.3,
+                "stop": ["<|end_of_text|>", "<|start_of_role|>"]
+            }' 2>&1); then
+            local raw_reply
+            raw_reply=$(echo "${completions_response}" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['text'][:80])" 2>/dev/null || echo "parse-error")
+            pass "/v1/completions (Antares) — reply: ${raw_reply}"
+        else
+            fail "/v1/completions (Antares) failed"
+            test_passed=false
+        fi
+    fi
+
+    # Test /version
+    local version_response
+    if version_response=$(curl -sf "http://localhost:${PORT}/version" 2>&1); then
+        local vllm_ver
+        vllm_ver=$(echo "${version_response}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version','unknown'))" 2>/dev/null || echo "unknown")
+        info "vLLM version: ${vllm_ver}"
+    fi
+
+    # Cleanup container
+    if [[ "${KEEP_CONTAINER}" != "true" ]]; then
+        podman rm -f "${CONTAINER_NAME}" 2>/dev/null || true
+        CONTAINER_NAME=""
+    else
+        info "Container kept: ${CONTAINER_NAME}"
+        CONTAINER_NAME=""
+    fi
+
+    if [[ "${test_passed}" == "true" ]]; then
+        pass "Model ${model} — ALL CHECKS PASSED"
+        return 0
+    else
+        fail "Model ${model} — SOME CHECKS FAILED"
+        return 1
+    fi
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+echo -e "${BOLD}CVE/VLoc Bench — Model Serve Smoke Test${NC}"
+echo "Container image: ${CONTAINER_IMAGE}"
+echo ""
+
+if [[ "${ALL_MATRIX}" == "true" ]]; then
+    total=0
+    passed=0
+    failed=0
+    failed_models=()
+
+    echo "Testing all required matrix models (${#REQUIRED_MODELS[@]} models)..."
+
+    for model in "${REQUIRED_MODELS[@]}"; do
+        total=$((total + 1))
+        if test_model "${model}"; then
+            passed=$((passed + 1))
+        else
+            failed=$((failed + 1))
+            failed_models+=("${model}")
+        fi
+    done
+
+    echo ""
+    echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${BOLD}Matrix Results: ${passed}/${total} passed, ${failed} failed${NC}"
+    echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+    if [[ ${failed} -gt 0 ]]; then
+        echo -e "${RED}Failed models:${NC}"
+        for m in "${failed_models[@]}"; do
+            echo "  - ${m}"
+        done
+        exit 1
+    fi
+
+    pass "All matrix models served successfully"
+    exit 0
+else
+    if test_model "${MODEL}" "${MAX_MODEL_LEN}" "${DTYPE}"; then
+        exit 0
+    else
+        exit 1
+    fi
+fi

--- a/tests/cve-scanning/smoke-model-serve.sh
+++ b/tests/cve-scanning/smoke-model-serve.sh
@@ -215,10 +215,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PATCH_SCRIPT="${SCRIPT_DIR}/../../automation/test-execution/scripts/bash/patch-vllm-granite-hybrid.sh"
 
 apply_granite_patch() {
-    if [[ -f "${VLLM_PATCH_DIR}/granitemoehybrid.py" ]] && \
-       grep -q '"full_attention"' "${VLLM_PATCH_DIR}/granitemoehybrid.py" 2>/dev/null; then
-        return 0
-    fi
     info "Applying Granite hybrid patch (vLLM PR #47867 backport)..."
     if [[ -x "${PATCH_SCRIPT}" ]]; then
         CONTAINER_ENGINE="${CONTAINER_ENGINE:-podman}" \

--- a/tests/cve-scanning/smoke-model-serve.sh
+++ b/tests/cve-scanning/smoke-model-serve.sh
@@ -175,7 +175,7 @@ get_default_max_model_len() {
     local model="$1"
     case "${model}" in
         *Qwen*|*qwen*)
-            echo "2048"
+            echo "4096"
             ;;
         *)
             echo "4096"
@@ -198,7 +198,7 @@ is_gated_model() {
 is_granite_hybrid() {
     local model="$1"
     case "${model}" in
-        *granite-4.0*|ibm-granite/granite-4*)
+        *granite-4.0*|ibm-granite/granite-4*|*antares*|fdtn-ai/*)
             return 0
             ;;
         *)

--- a/tests/cve-scanning/smoke-vloc-harness.sh
+++ b/tests/cve-scanning/smoke-vloc-harness.sh
@@ -198,14 +198,15 @@ else
         pass "Sandbox image already exists: ${SANDBOX_IMAGE}"
     else
         info "Extracting sandbox Dockerfile from harness image..."
+        sandbox_build_dir=$(mktemp -d)
         if "${CONTAINER_ENGINE}" run --rm "${HARNESS_IMAGE}" \
-            cat /opt/vloc-bench/Dockerfile > /tmp/vloc-sandbox-Dockerfile 2>/dev/null; then
+            cat /opt/vloc-bench/Dockerfile > "${sandbox_build_dir}/Dockerfile" 2>/dev/null; then
             pass "Sandbox Dockerfile extracted"
 
             info "Building sandbox image..."
             build_start=$(date +%s)
             if "${CONTAINER_ENGINE}" build -t "${SANDBOX_IMAGE}" \
-                -f /tmp/vloc-sandbox-Dockerfile /tmp 2>&1; then
+                "${sandbox_build_dir}" 2>&1; then
                 build_end=$(date +%s)
                 build_time=$((build_end - build_start))
                 pass "Sandbox image built in ${build_time}s: ${SANDBOX_IMAGE}"
@@ -213,11 +214,11 @@ else
                 fail "Sandbox image build failed"
                 overall_pass=false
             fi
-            rm -f /tmp/vloc-sandbox-Dockerfile
         else
             fail "Could not extract Dockerfile from harness image"
             overall_pass=false
         fi
+        rm -rf "${sandbox_build_dir}"
     fi
 
     # Verify image
@@ -257,12 +258,15 @@ else
                 --entrypoint python3 \
                 "${HARNESS_IMAGE}" \
                 data/downloader_and_verifier.py --output-dir data/ghsa-vulns 2>&1; then
-                dl_end=$(date +%s)
-                dl_time=$((dl_end - dl_start))
+                dl_ok=true
+            else
+                dl_ok=false
+            fi
+            dl_end=$(date +%s)
+            dl_time=$((dl_end - dl_start))
+            if [[ "${dl_ok}" == true ]]; then
                 pass "Dataset download completed in ${dl_time}s"
             else
-                dl_end=$(date +%s)
-                dl_time=$((dl_end - dl_start))
                 fail "Dataset download failed after ${dl_time}s"
                 overall_pass=false
             fi

--- a/tests/cve-scanning/smoke-vloc-harness.sh
+++ b/tests/cve-scanning/smoke-vloc-harness.sh
@@ -1,0 +1,326 @@
+#!/bin/bash
+# ==============================================================================
+# CVE/VLoc Bench — Smoke Test: VLoc Harness Setup
+# ==============================================================================
+# Verifies that the Cisco Vulnerability Localization Benchmark harness can be
+# set up: clone repo, install dependencies, build sandbox image, download +
+# verify dataset.
+#
+# Usage:
+#   ./smoke-vloc-harness.sh [options]
+#
+# Options:
+#   --vloc-dir DIR          VLoc Bench checkout directory (default: /tmp/vloc-bench)
+#   --skip-dataset          Skip dataset download (only test clone + install + sandbox)
+#   --skip-sandbox          Skip sandbox image build
+#   --container-engine CMD  Container engine: podman or docker (default: podman)
+#   --force-clone           Remove existing checkout and re-clone
+#   -h, --help              Show this help
+#
+# Environment variables:
+#   VLOC_DIR                Override VLoc Bench directory
+#   VLOC_CONTAINER_ENGINE   Override container engine (podman/docker)
+#
+# Exit codes:
+#   0  All checks passed
+#   1  One or more checks failed
+# ==============================================================================
+
+set -euo pipefail
+
+trap 'echo -e "\n\nInterrupted by user."; exit 130' SIGINT SIGTERM
+
+# Colors
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; }
+info() { echo -e "  ${BLUE}INFO${NC} $1"; }
+warn() { echo -e "  ${YELLOW}WARN${NC} $1"; }
+
+# ============================================================================
+# Defaults
+# ============================================================================
+
+VLOC_REPO="https://github.com/cisco-foundation-ai/vulnerability-localization-benchmark.git"
+VLOC_DIR="${VLOC_DIR:-/tmp/vloc-bench}"
+SKIP_DATASET="false"
+SKIP_SANDBOX="false"
+CONTAINER_ENGINE="${VLOC_CONTAINER_ENGINE:-podman}"
+FORCE_CLONE="false"
+SANDBOX_IMAGE="vulnerability-localization-benchmark-sandbox"
+
+# ============================================================================
+# Argument parsing
+# ============================================================================
+
+usage() {
+    sed -n '2,/^# ===/p' "$0" | head -n -1 | sed 's/^# \?//'
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --vloc-dir)          VLOC_DIR="$2"; shift 2 ;;
+        --skip-dataset)      SKIP_DATASET="true"; shift ;;
+        --skip-sandbox)      SKIP_SANDBOX="true"; shift ;;
+        --container-engine)  CONTAINER_ENGINE="$2"; shift 2 ;;
+        --force-clone)       FORCE_CLONE="true"; shift ;;
+        -h|--help)           usage ;;
+        *)                   echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+# ============================================================================
+# Checks
+# ============================================================================
+
+overall_pass=true
+
+echo -e "${BOLD}CVE/VLoc Bench — Harness Setup Smoke Test${NC}"
+echo ""
+
+# ---------- Prerequisites ----------
+
+echo -e "${BOLD}[1/5] Prerequisites${NC}"
+
+# Python ≥3.11
+if command -v python3 >/dev/null 2>&1; then
+    py_ver=$(python3 --version 2>&1 | awk '{print $2}')
+    py_major=$(echo "${py_ver}" | cut -d. -f1)
+    py_minor=$(echo "${py_ver}" | cut -d. -f2)
+    if [[ ${py_major} -ge 3 ]] && [[ ${py_minor} -ge 11 ]]; then
+        pass "Python ${py_ver} (≥3.11)"
+    else
+        fail "Python ${py_ver} — need ≥3.11"
+        overall_pass=false
+    fi
+else
+    fail "python3 not found"
+    overall_pass=false
+fi
+
+# Container engine
+if command -v "${CONTAINER_ENGINE}" >/dev/null 2>&1; then
+    ce_ver=$("${CONTAINER_ENGINE}" --version 2>&1 | head -1)
+    pass "${CONTAINER_ENGINE}: ${ce_ver}"
+else
+    fail "${CONTAINER_ENGINE} not found"
+    overall_pass=false
+fi
+
+# Git
+if command -v git >/dev/null 2>&1; then
+    pass "git: $(git --version)"
+else
+    fail "git not found"
+    overall_pass=false
+fi
+
+# pip
+if python3 -m pip --version >/dev/null 2>&1; then
+    pass "pip available"
+else
+    fail "pip not available (python3 -m pip)"
+    overall_pass=false
+fi
+
+# ---------- Clone / update repo ----------
+
+echo ""
+echo -e "${BOLD}[2/5] VLoc Bench repository${NC}"
+
+if [[ "${FORCE_CLONE}" == "true" ]] && [[ -d "${VLOC_DIR}" ]]; then
+    info "Removing existing checkout: ${VLOC_DIR}"
+    rm -rf "${VLOC_DIR}"
+fi
+
+if [[ -d "${VLOC_DIR}/.git" ]]; then
+    info "Existing checkout found at ${VLOC_DIR}"
+    vloc_commit=$(git -C "${VLOC_DIR}" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+    pass "VLoc Bench already cloned (commit: ${vloc_commit})"
+else
+    info "Cloning ${VLOC_REPO} to ${VLOC_DIR}..."
+    if git clone --depth 1 "${VLOC_REPO}" "${VLOC_DIR}" 2>&1; then
+        vloc_commit=$(git -C "${VLOC_DIR}" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+        pass "Cloned VLoc Bench (commit: ${vloc_commit})"
+    else
+        fail "Failed to clone VLoc Bench repo"
+        overall_pass=false
+    fi
+fi
+
+# Check key files exist
+for f in "pyproject.toml" "Dockerfile" "configs/default.yaml" "data/downloader_and_verifier.py"; do
+    if [[ -f "${VLOC_DIR}/${f}" ]]; then
+        pass "Found ${f}"
+    else
+        fail "Missing expected file: ${f}"
+        overall_pass=false
+    fi
+done
+
+# Check model runners
+for runner in "vllm.py" "vllm_antares.py" "vllm_qwen_3_5.py"; do
+    runner_path="${VLOC_DIR}/src/vulnerability_localization_benchmark/model_runners/${runner}"
+    if [[ -f "${runner_path}" ]]; then
+        pass "Runner found: ${runner}"
+    else
+        warn "Runner not found: ${runner} (check upstream repo structure)"
+    fi
+done
+
+# ---------- Install dependencies ----------
+
+echo ""
+echo -e "${BOLD}[3/5] Python dependencies${NC}"
+
+VENV_DIR="${VLOC_DIR}/.venv"
+if [[ ! -d "${VENV_DIR}" ]]; then
+    info "Creating virtual environment at ${VENV_DIR}..."
+    if python3 -m venv "${VENV_DIR}" 2>&1; then
+        pass "Virtual environment created"
+    else
+        fail "Failed to create virtual environment"
+        overall_pass=false
+    fi
+else
+    pass "Virtual environment exists at ${VENV_DIR}"
+fi
+
+info "Installing VLoc Bench package..."
+if "${VENV_DIR}/bin/pip" install -e "${VLOC_DIR}" --quiet 2>&1; then
+    pass "VLoc Bench installed (pip install -e .)"
+else
+    fail "pip install -e . failed"
+    echo "--- pip output ---"
+    "${VENV_DIR}/bin/pip" install -e "${VLOC_DIR}" 2>&1 | tail -20
+    overall_pass=false
+fi
+
+# Verify CLI module is importable
+if "${VENV_DIR}/bin/python3" -c "import vulnerability_localization_benchmark.cli" 2>/dev/null; then
+    pass "CLI module importable"
+else
+    # Try with PYTHONPATH
+    if PYTHONPATH="${VLOC_DIR}/src" "${VENV_DIR}/bin/python3" -c "import vulnerability_localization_benchmark.cli" 2>/dev/null; then
+        pass "CLI module importable (with PYTHONPATH=src)"
+    else
+        fail "Cannot import vulnerability_localization_benchmark.cli"
+        overall_pass=false
+    fi
+fi
+
+# ---------- Sandbox image ----------
+
+echo ""
+echo -e "${BOLD}[4/5] Sandbox container image${NC}"
+
+if [[ "${SKIP_SANDBOX}" == "true" ]]; then
+    warn "Skipped sandbox build (--skip-sandbox)"
+else
+    # Check if image already exists
+    if "${CONTAINER_ENGINE}" image exists "${SANDBOX_IMAGE}" 2>/dev/null; then
+        pass "Sandbox image already exists: ${SANDBOX_IMAGE}"
+    else
+        info "Building sandbox image with ${CONTAINER_ENGINE}..."
+        build_start=$(date +%s)
+        if "${CONTAINER_ENGINE}" build -t "${SANDBOX_IMAGE}" "${VLOC_DIR}" 2>&1; then
+            build_end=$(date +%s)
+            build_time=$((build_end - build_start))
+            pass "Sandbox image built in ${build_time}s: ${SANDBOX_IMAGE}"
+        else
+            fail "Sandbox image build failed"
+            echo "--- Build output (last 20 lines) ---"
+            "${CONTAINER_ENGINE}" build -t "${SANDBOX_IMAGE}" "${VLOC_DIR}" 2>&1 | tail -20
+            overall_pass=false
+        fi
+    fi
+
+    # Verify image
+    if "${CONTAINER_ENGINE}" image exists "${SANDBOX_IMAGE}" 2>/dev/null; then
+        img_size=$("${CONTAINER_ENGINE}" image inspect "${SANDBOX_IMAGE}" --format '{{.Size}}' 2>/dev/null || echo "unknown")
+        info "Sandbox image size: ${img_size} bytes"
+    fi
+fi
+
+# ---------- Dataset ----------
+
+echo ""
+echo -e "${BOLD}[5/5] Dataset download & verification${NC}"
+
+if [[ "${SKIP_DATASET}" == "true" ]]; then
+    warn "Skipped dataset download (--skip-dataset)"
+else
+    # Check manifest
+    manifest="${VLOC_DIR}/data/manifest.csv"
+    if [[ -f "${manifest}" ]]; then
+        line_count=$(wc -l < "${manifest}" | tr -d ' ')
+        pass "Manifest found: ${line_count} lines (expect ~501 = header + 500 tasks)"
+    else
+        fail "Manifest not found: ${manifest}"
+        overall_pass=false
+    fi
+
+    # Run downloader
+    info "Running dataset downloader..."
+    info "This may take several minutes depending on network speed."
+    info "Dataset requires ~5-10 GB of disk space."
+    dl_start=$(date +%s)
+    if cd "${VLOC_DIR}" && \
+       PYTHONPATH=src "${VENV_DIR}/bin/python3" data/downloader_and_verifier.py --source-dir data/ 2>&1; then
+        dl_end=$(date +%s)
+        dl_time=$((dl_end - dl_start))
+        pass "Dataset download completed in ${dl_time}s"
+    else
+        dl_end=$(date +%s)
+        dl_time=$((dl_end - dl_start))
+        fail "Dataset download/verify failed after ${dl_time}s"
+        overall_pass=false
+    fi
+
+    # Check dataset size
+    if [[ -d "${VLOC_DIR}/data/ghsa-vulns" ]]; then
+        ds_count=$(find "${VLOC_DIR}/data/ghsa-vulns" -name "*.zip" | wc -l | tr -d ' ')
+        ds_size=$(du -sh "${VLOC_DIR}/data/ghsa-vulns" 2>/dev/null | cut -f1)
+        pass "Dataset: ${ds_count} zip files, ${ds_size} on disk"
+    else
+        warn "ghsa-vulns directory not found (may use different structure)"
+    fi
+fi
+
+# ============================================================================
+# Summary
+# ============================================================================
+
+echo ""
+echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+if [[ "${overall_pass}" == "true" ]]; then
+    echo -e "${GREEN}${BOLD}PASS${NC} — VLoc Bench harness is ready"
+    echo ""
+    echo "VLoc directory: ${VLOC_DIR}"
+    echo "Virtual env:    ${VENV_DIR}"
+    echo "Sandbox image:  ${SANDBOX_IMAGE}"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Start a vLLM server with a matrix model (see smoke-model-serve.sh)"
+    echo "  2. Run VLoc Bench:"
+    echo "     cd ${VLOC_DIR}"
+    echo "     PYTHONPATH=src ${VENV_DIR}/bin/python3 -m vulnerability_localization_benchmark.cli \\"
+    echo "       --config configs/default.yaml \\"
+    echo "       --api-base http://localhost:8200/v1 \\"
+    echo "       --model-name <model> \\"
+    echo "       --runner vllm \\"
+    echo "       --phases a --n-limit 5 --workers 1 \\"
+    echo "       --output-dir results/smoke"
+    exit 0
+else
+    echo -e "${RED}${BOLD}FAIL${NC} — VLoc Bench harness setup incomplete"
+    echo "Review the failures above and fix before proceeding."
+    exit 1
+fi

--- a/tests/cve-scanning/smoke-vloc-harness.sh
+++ b/tests/cve-scanning/smoke-vloc-harness.sh
@@ -1,24 +1,29 @@
 #!/bin/bash
 # ==============================================================================
-# CVE/VLoc Bench — Smoke Test: VLoc Harness Setup
+# CVE/VLoc Bench — Smoke Test: Containerized Harness Setup
 # ==============================================================================
-# Verifies that the Cisco Vulnerability Localization Benchmark harness can be
-# set up: clone repo, install dependencies, build sandbox image, download +
-# verify dataset.
+# Verifies the containerized VLoc Bench pipeline used by the Ansible playbook:
+#   1. Build vloc-bench-harness image (from automation/test-execution/containers/)
+#   2. Podman user socket is active (for sandbox container spawning)
+#   3. Build sandbox image (extracted from harness image)
+#   4. Dataset download via harness container (--output-dir, not native)
+#
+# This mirrors the real path taken by llm-benchmark-cve-vloc.yml.
+# Nothing is installed natively — all tooling runs inside containers.
 #
 # Usage:
 #   ./smoke-vloc-harness.sh [options]
 #
 # Options:
-#   --vloc-dir DIR          VLoc Bench checkout directory (default: /tmp/vloc-bench)
-#   --skip-dataset          Skip dataset download (only test clone + install + sandbox)
+#   --data-dir DIR          Host directory for dataset cache (default: /tmp/vloc-bench/data)
+#   --skip-dataset          Skip dataset download (only test images + socket)
 #   --skip-sandbox          Skip sandbox image build
 #   --container-engine CMD  Container engine: podman or docker (default: podman)
-#   --force-clone           Remove existing checkout and re-clone
+#   --harness-image NAME    Harness image name (default: vloc-bench-harness:latest)
+#   --sandbox-image NAME    Sandbox image name (default: vulnerability-localization-benchmark-sandbox:latest)
 #   -h, --help              Show this help
 #
 # Environment variables:
-#   VLOC_DIR                Override VLoc Bench directory
 #   VLOC_CONTAINER_ENGINE   Override container engine (podman/docker)
 #
 # Exit codes:
@@ -47,13 +52,15 @@ warn() { echo -e "  ${YELLOW}WARN${NC} $1"; }
 # Defaults
 # ============================================================================
 
-VLOC_REPO="https://github.com/cisco-foundation-ai/vulnerability-localization-benchmark.git"
-VLOC_DIR="${VLOC_DIR:-/tmp/vloc-bench}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}/../.."
+DOCKERFILE_DIR="${REPO_ROOT}/automation/test-execution/containers/vloc-bench"
+DATA_DIR="/tmp/vloc-bench/data"
 SKIP_DATASET="false"
 SKIP_SANDBOX="false"
 CONTAINER_ENGINE="${VLOC_CONTAINER_ENGINE:-podman}"
-FORCE_CLONE="false"
-SANDBOX_IMAGE="vulnerability-localization-benchmark-sandbox"
+HARNESS_IMAGE="vloc-bench-harness:latest"
+SANDBOX_IMAGE="vulnerability-localization-benchmark-sandbox:latest"
 
 # ============================================================================
 # Argument parsing
@@ -66,11 +73,12 @@ usage() {
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --vloc-dir)          VLOC_DIR="$2"; shift 2 ;;
+        --data-dir)          DATA_DIR="$2"; shift 2 ;;
         --skip-dataset)      SKIP_DATASET="true"; shift ;;
         --skip-sandbox)      SKIP_SANDBOX="true"; shift ;;
         --container-engine)  CONTAINER_ENGINE="$2"; shift 2 ;;
-        --force-clone)       FORCE_CLONE="true"; shift ;;
+        --harness-image)     HARNESS_IMAGE="$2"; shift 2 ;;
+        --sandbox-image)     SANDBOX_IMAGE="$2"; shift 2 ;;
         -h|--help)           usage ;;
         *)                   echo "Unknown option: $1"; usage ;;
     esac
@@ -82,28 +90,12 @@ done
 
 overall_pass=true
 
-echo -e "${BOLD}CVE/VLoc Bench — Harness Setup Smoke Test${NC}"
+echo -e "${BOLD}CVE/VLoc Bench — Containerized Harness Smoke Test${NC}"
 echo ""
 
-# ---------- Prerequisites ----------
+# ---------- Step 1: Prerequisites ----------
 
-echo -e "${BOLD}[1/5] Prerequisites${NC}"
-
-# Python ≥3.11
-if command -v python3 >/dev/null 2>&1; then
-    py_ver=$(python3 --version 2>&1 | awk '{print $2}')
-    py_major=$(echo "${py_ver}" | cut -d. -f1)
-    py_minor=$(echo "${py_ver}" | cut -d. -f2)
-    if [[ ${py_major} -ge 3 ]] && [[ ${py_minor} -ge 11 ]]; then
-        pass "Python ${py_ver} (≥3.11)"
-    else
-        fail "Python ${py_ver} — need ≥3.11"
-        overall_pass=false
-    fi
-else
-    fail "python3 not found"
-    overall_pass=false
-fi
+echo -e "${BOLD}[1/4] Prerequisites${NC}"
 
 # Container engine
 if command -v "${CONTAINER_ENGINE}" >/dev/null 2>&1; then
@@ -114,183 +106,176 @@ else
     overall_pass=false
 fi
 
-# Git
-if command -v git >/dev/null 2>&1; then
-    pass "git: $(git --version)"
+# Dockerfile exists
+if [[ -f "${DOCKERFILE_DIR}/Dockerfile" ]]; then
+    pass "Harness Dockerfile found: ${DOCKERFILE_DIR}/Dockerfile"
 else
-    fail "git not found"
+    fail "Harness Dockerfile not found at ${DOCKERFILE_DIR}/Dockerfile"
     overall_pass=false
 fi
 
-# pip
-if python3 -m pip --version >/dev/null 2>&1; then
-    pass "pip available"
-else
-    fail "pip not available (python3 -m pip)"
-    overall_pass=false
+# Podman user socket (only relevant for podman)
+if [[ "${CONTAINER_ENGINE}" == "podman" ]]; then
+    socket_path="/run/user/$(id -u)/podman/podman.sock"
+    if [[ -S "${socket_path}" ]]; then
+        pass "Podman user socket active: ${socket_path}"
+    else
+        # Try to start it
+        if systemctl --user start podman.socket 2>/dev/null; then
+            if [[ -S "${socket_path}" ]]; then
+                pass "Podman user socket started: ${socket_path}"
+            else
+                fail "Podman socket not found after start: ${socket_path}"
+                warn "Run: systemctl --user enable --now podman.socket"
+                warn "For headless DUTs also: loginctl enable-linger \$(whoami)"
+                overall_pass=false
+            fi
+        else
+            fail "Cannot start Podman user socket"
+            warn "Run: systemctl --user enable --now podman.socket"
+            warn "For headless DUTs also: loginctl enable-linger \$(whoami)"
+            overall_pass=false
+        fi
+    fi
 fi
 
-# ---------- Clone / update repo ----------
+# ---------- Step 2: Build / check harness image ----------
 
 echo ""
-echo -e "${BOLD}[2/5] VLoc Bench repository${NC}"
+echo -e "${BOLD}[2/4] VLoc harness container image${NC}"
 
-if [[ "${FORCE_CLONE}" == "true" ]] && [[ -d "${VLOC_DIR}" ]]; then
-    info "Removing existing checkout: ${VLOC_DIR}"
-    rm -rf "${VLOC_DIR}"
-fi
-
-if [[ -d "${VLOC_DIR}/.git" ]]; then
-    info "Existing checkout found at ${VLOC_DIR}"
-    vloc_commit=$(git -C "${VLOC_DIR}" rev-parse --short HEAD 2>/dev/null || echo "unknown")
-    pass "VLoc Bench already cloned (commit: ${vloc_commit})"
+if "${CONTAINER_ENGINE}" image exists "${HARNESS_IMAGE}" 2>/dev/null; then
+    pass "Harness image already exists: ${HARNESS_IMAGE}"
 else
-    info "Cloning ${VLOC_REPO} to ${VLOC_DIR}..."
-    if git clone --depth 1 "${VLOC_REPO}" "${VLOC_DIR}" 2>&1; then
-        vloc_commit=$(git -C "${VLOC_DIR}" rev-parse --short HEAD 2>/dev/null || echo "unknown")
-        pass "Cloned VLoc Bench (commit: ${vloc_commit})"
+    info "Building harness image from ${DOCKERFILE_DIR}/ ..."
+    build_start=$(date +%s)
+    if "${CONTAINER_ENGINE}" build -t "${HARNESS_IMAGE}" "${DOCKERFILE_DIR}/" 2>&1; then
+        build_end=$(date +%s)
+        build_time=$((build_end - build_start))
+        pass "Harness image built in ${build_time}s: ${HARNESS_IMAGE}"
     else
-        fail "Failed to clone VLoc Bench repo"
+        fail "Harness image build failed"
         overall_pass=false
     fi
 fi
 
-# Check key files exist
-for f in "pyproject.toml" "Dockerfile" "configs/default.yaml" "data/downloader_and_verifier.py"; do
-    if [[ -f "${VLOC_DIR}/${f}" ]]; then
-        pass "Found ${f}"
+# Verify key files inside harness image
+if "${CONTAINER_ENGINE}" image exists "${HARNESS_IMAGE}" 2>/dev/null; then
+    if "${CONTAINER_ENGINE}" run --rm "${HARNESS_IMAGE}" \
+        python3 -c "import vulnerability_localization_benchmark.cli" 2>/dev/null; then
+        pass "CLI module importable inside harness image"
     else
-        fail "Missing expected file: ${f}"
+        fail "Cannot import VLoc CLI inside harness image"
         overall_pass=false
     fi
-done
 
-# Check model runners
-for runner in "vllm.py" "vllm_antares.py" "vllm_qwen_3_5.py"; do
-    runner_path="${VLOC_DIR}/src/vulnerability_localization_benchmark/model_runners/${runner}"
-    if [[ -f "${runner_path}" ]]; then
-        pass "Runner found: ${runner}"
+    if "${CONTAINER_ENGINE}" run --rm "${HARNESS_IMAGE}" \
+        test -f /opt/vloc-bench/configs/default.yaml 2>/dev/null; then
+        pass "configs/default.yaml present in harness image"
     else
-        warn "Runner not found: ${runner} (check upstream repo structure)"
+        fail "configs/default.yaml missing from harness image"
+        overall_pass=false
     fi
-done
 
-# ---------- Install dependencies ----------
+    if "${CONTAINER_ENGINE}" run --rm "${HARNESS_IMAGE}" \
+        docker --version 2>/dev/null; then
+        pass "Docker CLI available inside harness image (for socket passthrough)"
+    else
+        fail "Docker CLI not found in harness image"
+        overall_pass=false
+    fi
+fi
+
+# ---------- Step 3: Sandbox image ----------
 
 echo ""
-echo -e "${BOLD}[3/5] Python dependencies${NC}"
-
-VENV_DIR="${VLOC_DIR}/.venv"
-if [[ ! -d "${VENV_DIR}" ]]; then
-    info "Creating virtual environment at ${VENV_DIR}..."
-    if python3 -m venv "${VENV_DIR}" 2>&1; then
-        pass "Virtual environment created"
-    else
-        fail "Failed to create virtual environment"
-        overall_pass=false
-    fi
-else
-    pass "Virtual environment exists at ${VENV_DIR}"
-fi
-
-info "Installing VLoc Bench package..."
-if "${VENV_DIR}/bin/pip" install -e "${VLOC_DIR}" --quiet 2>&1; then
-    pass "VLoc Bench installed (pip install -e .)"
-else
-    fail "pip install -e . failed"
-    echo "--- pip output ---"
-    "${VENV_DIR}/bin/pip" install -e "${VLOC_DIR}" 2>&1 | tail -20
-    overall_pass=false
-fi
-
-# Verify CLI module is importable
-if "${VENV_DIR}/bin/python3" -c "import vulnerability_localization_benchmark.cli" 2>/dev/null; then
-    pass "CLI module importable"
-else
-    # Try with PYTHONPATH
-    if PYTHONPATH="${VLOC_DIR}/src" "${VENV_DIR}/bin/python3" -c "import vulnerability_localization_benchmark.cli" 2>/dev/null; then
-        pass "CLI module importable (with PYTHONPATH=src)"
-    else
-        fail "Cannot import vulnerability_localization_benchmark.cli"
-        overall_pass=false
-    fi
-fi
-
-# ---------- Sandbox image ----------
-
-echo ""
-echo -e "${BOLD}[4/5] Sandbox container image${NC}"
+echo -e "${BOLD}[3/4] Sandbox container image${NC}"
 
 if [[ "${SKIP_SANDBOX}" == "true" ]]; then
     warn "Skipped sandbox build (--skip-sandbox)"
 else
-    # Check if image already exists
     if "${CONTAINER_ENGINE}" image exists "${SANDBOX_IMAGE}" 2>/dev/null; then
         pass "Sandbox image already exists: ${SANDBOX_IMAGE}"
     else
-        info "Building sandbox image with ${CONTAINER_ENGINE}..."
-        build_start=$(date +%s)
-        if "${CONTAINER_ENGINE}" build -t "${SANDBOX_IMAGE}" "${VLOC_DIR}" 2>&1; then
-            build_end=$(date +%s)
-            build_time=$((build_end - build_start))
-            pass "Sandbox image built in ${build_time}s: ${SANDBOX_IMAGE}"
+        info "Extracting sandbox Dockerfile from harness image..."
+        if "${CONTAINER_ENGINE}" run --rm "${HARNESS_IMAGE}" \
+            cat /opt/vloc-bench/Dockerfile > /tmp/vloc-sandbox-Dockerfile 2>/dev/null; then
+            pass "Sandbox Dockerfile extracted"
+
+            info "Building sandbox image..."
+            build_start=$(date +%s)
+            if "${CONTAINER_ENGINE}" build -t "${SANDBOX_IMAGE}" \
+                -f /tmp/vloc-sandbox-Dockerfile /tmp 2>&1; then
+                build_end=$(date +%s)
+                build_time=$((build_end - build_start))
+                pass "Sandbox image built in ${build_time}s: ${SANDBOX_IMAGE}"
+            else
+                fail "Sandbox image build failed"
+                overall_pass=false
+            fi
+            rm -f /tmp/vloc-sandbox-Dockerfile
         else
-            fail "Sandbox image build failed"
-            echo "--- Build output (last 20 lines) ---"
-            "${CONTAINER_ENGINE}" build -t "${SANDBOX_IMAGE}" "${VLOC_DIR}" 2>&1 | tail -20
+            fail "Could not extract Dockerfile from harness image"
             overall_pass=false
         fi
     fi
 
     # Verify image
     if "${CONTAINER_ENGINE}" image exists "${SANDBOX_IMAGE}" 2>/dev/null; then
-        img_size=$("${CONTAINER_ENGINE}" image inspect "${SANDBOX_IMAGE}" --format '{{.Size}}' 2>/dev/null || echo "unknown")
+        img_size=$("${CONTAINER_ENGINE}" image inspect "${SANDBOX_IMAGE}" \
+            --format '{{.Size}}' 2>/dev/null || echo "unknown")
         info "Sandbox image size: ${img_size} bytes"
     fi
 fi
 
-# ---------- Dataset ----------
+# ---------- Step 4: Dataset download ----------
 
 echo ""
-echo -e "${BOLD}[5/5] Dataset download & verification${NC}"
+echo -e "${BOLD}[4/4] Dataset download via harness container${NC}"
 
 if [[ "${SKIP_DATASET}" == "true" ]]; then
     warn "Skipped dataset download (--skip-dataset)"
 else
-    # Check manifest
-    manifest="${VLOC_DIR}/data/manifest.csv"
-    if [[ -f "${manifest}" ]]; then
-        line_count=$(wc -l < "${manifest}" | tr -d ' ')
-        pass "Manifest found: ${line_count} lines (expect ~501 = header + 500 tasks)"
-    else
-        fail "Manifest not found: ${manifest}"
+    if ! "${CONTAINER_ENGINE}" image exists "${HARNESS_IMAGE}" 2>/dev/null; then
+        fail "Cannot download dataset — harness image not available"
         overall_pass=false
-    fi
-
-    # Run downloader
-    info "Running dataset downloader..."
-    info "This may take several minutes depending on network speed."
-    info "Dataset requires ~5-10 GB of disk space."
-    dl_start=$(date +%s)
-    if cd "${VLOC_DIR}" && \
-       PYTHONPATH=src "${VENV_DIR}/bin/python3" data/downloader_and_verifier.py --source-dir data/ 2>&1; then
-        dl_end=$(date +%s)
-        dl_time=$((dl_end - dl_start))
-        pass "Dataset download completed in ${dl_time}s"
     else
-        dl_end=$(date +%s)
-        dl_time=$((dl_end - dl_start))
-        fail "Dataset download/verify failed after ${dl_time}s"
-        overall_pass=false
-    fi
+        mkdir -p "${DATA_DIR}"
 
-    # Check dataset size
-    if [[ -d "${VLOC_DIR}/data/ghsa-vulns" ]]; then
-        ds_count=$(find "${VLOC_DIR}/data/ghsa-vulns" -name "*.zip" | wc -l | tr -d ' ')
-        ds_size=$(du -sh "${VLOC_DIR}/data/ghsa-vulns" 2>/dev/null | cut -f1)
-        pass "Dataset: ${ds_count} zip files, ${ds_size} on disk"
-    else
-        warn "ghsa-vulns directory not found (may use different structure)"
+        # Check if dataset is already cached
+        zip_count=$(find "${DATA_DIR}" -maxdepth 1 -name "*.zip" 2>/dev/null | wc -l | tr -d ' ')
+        if [[ "${zip_count}" -gt 0 ]]; then
+            ds_size=$(du -sh "${DATA_DIR}" 2>/dev/null | cut -f1)
+            pass "Dataset already cached: ${zip_count} zip files, ${ds_size}"
+        else
+            info "Downloading dataset via harness container..."
+            info "This may take several minutes depending on network speed."
+            info "Dataset requires ~5-10 GB of disk space."
+            dl_start=$(date +%s)
+            if "${CONTAINER_ENGINE}" run --rm \
+                -v "${DATA_DIR}":/opt/vloc-bench/data/ghsa-vulns:z \
+                --entrypoint python3 \
+                "${HARNESS_IMAGE}" \
+                data/downloader_and_verifier.py --output-dir data/ghsa-vulns 2>&1; then
+                dl_end=$(date +%s)
+                dl_time=$((dl_end - dl_start))
+                pass "Dataset download completed in ${dl_time}s"
+            else
+                dl_end=$(date +%s)
+                dl_time=$((dl_end - dl_start))
+                fail "Dataset download failed after ${dl_time}s"
+                overall_pass=false
+            fi
+        fi
+
+        # Verify dataset
+        zip_count=$(find "${DATA_DIR}" -maxdepth 1 -name "*.zip" 2>/dev/null | wc -l | tr -d ' ')
+        if [[ "${zip_count}" -gt 0 ]]; then
+            ds_size=$(du -sh "${DATA_DIR}" 2>/dev/null | cut -f1)
+            pass "Dataset: ${zip_count} zip files, ${ds_size} on disk"
+        else
+            warn "No zip files found in ${DATA_DIR} — download may still be in progress or path differs"
+        fi
     fi
 fi
 
@@ -301,26 +286,22 @@ fi
 echo ""
 echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 if [[ "${overall_pass}" == "true" ]]; then
-    echo -e "${GREEN}${BOLD}PASS${NC} — VLoc Bench harness is ready"
+    echo -e "${GREEN}${BOLD}PASS${NC} — Containerized VLoc Bench harness is ready"
     echo ""
-    echo "VLoc directory: ${VLOC_DIR}"
-    echo "Virtual env:    ${VENV_DIR}"
-    echo "Sandbox image:  ${SANDBOX_IMAGE}"
+    echo "Harness image: ${HARNESS_IMAGE}"
+    echo "Sandbox image: ${SANDBOX_IMAGE}"
+    echo "Data cache:    ${DATA_DIR}"
     echo ""
     echo "Next steps:"
     echo "  1. Start a vLLM server with a matrix model (see smoke-model-serve.sh)"
-    echo "  2. Run VLoc Bench:"
-    echo "     cd ${VLOC_DIR}"
-    echo "     PYTHONPATH=src ${VENV_DIR}/bin/python3 -m vulnerability_localization_benchmark.cli \\"
-    echo "       --config configs/default.yaml \\"
-    echo "       --api-base http://localhost:8200/v1 \\"
-    echo "       --model-name <model> \\"
-    echo "       --runner vllm \\"
-    echo "       --phases a --n-limit 5 --workers 1 \\"
-    echo "       --output-dir results/smoke"
+    echo "  2. Run VLoc Bench via the Ansible playbook:"
+    echo "     cd automation/test-execution/ansible"
+    echo "     ansible-playbook -i inventory/hosts.yml llm-benchmark-cve-vloc.yml \\"
+    echo "       -e test_model=ibm-granite/granite-4.0-350m \\"
+    echo "       -e vloc_runner=vllm -e requested_cores=8"
     exit 0
 else
-    echo -e "${RED}${BOLD}FAIL${NC} — VLoc Bench harness setup incomplete"
+    echo -e "${RED}${BOLD}FAIL${NC} — Containerized VLoc Bench harness setup incomplete"
     echo "Review the failures above and fix before proceeding."
     exit 1
 fi

--- a/tests/tests.md
+++ b/tests/tests.md
@@ -53,7 +53,7 @@ All test cases use a hierarchical naming scheme:
 
 See individual test suite README files for complete test case listings.
 
-## Test Suites
+## Suite Overviews
 
 ### Test Suite: Concurrent Load
 

--- a/tests/tests.md
+++ b/tests/tests.md
@@ -17,6 +17,7 @@ This directory contains per-suite methodology and configuration documentation.
 | Offline Batch | [offline-batch.md](offline-batch/offline-batch.md) | `offline-batch` |
 | Embedding | [embedding-models.md](embedding-models/embedding-models.md) | `embedding` |
 | Audio | [audio-models/](audio-models/) | `audio` |
+| CVE Scanning / VLoc Bench | [cve-scanning.md](cve-scanning/cve-scanning.md) | Ansible |
 | Resource Contention | [resource-contention.md](resource-contention/resource-contention.md) | Planned |
 
 Sub-pages for embedding: [baseline-sweep.md](embedding-models/baseline-sweep.md),
@@ -30,9 +31,85 @@ All test cases use a hierarchical naming scheme:
 - **Offline Batch**: `OFFLINE-{USE-CASE}-{model}`
 - **Embedding**: `EMB-{TYPE}-{model}-{workload}`
 
-See the [Test Suites Overview](../docs/test-suites.md#test-id-naming-convention)
-for examples and the full prefix table.
-# Running Tests
+**Components:**
+
+- **Suite Prefix**: `CONC` (Concurrent Load), `SCALE` (Scalability), `OFFLINE` (Offline Batch), `CVE` (CVE Scanning), `CONT` (Resource Contention), `EMB` (Embedding)
+- **Type** (not used for CONC suite): `SWEEP`, `SYNC` (Synchronous), `POISSON`, `BASELINE`, `LATENCY`
+- **Use Case** (offline batch): `SUMM` (Summarization), `CLASS` (Classification), `TRANS` (Translation), `ENTITY` (Entity Extraction), `DATAGEN` (Dataset Generation), `ETL` (ETL Pipelines), `CODEGEN` (Code Generation), `LONGSUM` (Long-Doc Summarization), `RAG` (Batch RAG), `PREFIX` (Shared-Prefix), `LABEL` (Ultra-Short Labeling)
+- **Model**: Short abbreviation (e.g., `LLAMA32`, `QWEN06`, `GRANITE32`, `GRANITE-EN`, `GRANITE-ML`)
+- **Workload**: `CHAT`, `RAG`, `CODE`, `SUMM`, `EMB` (embedding), `EMB512` (512-token embedding)
+
+**Examples:**
+
+- `CONC-LLAMA32-CHAT`: Concurrent Load suite, Llama-3.2-1B, Chat workload
+- `SCALE-SWEEP-QWEN06-CODE`: Scalability suite, Sweep test, Qwen3-0.6B, CodeGen workload
+- `SCALE-POISSON-GRANITE32-CHAT`: Scalability suite, Poisson distribution, Granite-3.2-2B, Chat
+- `OFFLINE-SUMM-LLAMA38`: Offline Batch suite, Summarization use case, Llama-3.1-8B
+- `OFFLINE-CLASS-QWEN38`: Offline Batch suite, Classification use case, Qwen3-8B
+- `CVE-VLOC-GRANITE1B`: CVE Scanning suite, VLoc localization, Granite-4.0-1B
+- `CVE-CAP-ANTARES1B`: CVE Scanning suite, Capacity proxy, Antares-1B
+- `EMB-BASELINE-GRANITE-EN-EMB512`: Embedding suite, Baseline test, Granite English model
+- `EMB-LATENCY-GRANITE-ML-EMB512`: Embedding suite, Latency test, Granite Multilingual model
+
+See individual test suite README files for complete test case listings.
+
+## Test Suites
+
+### Test Suite: Concurrent Load
+
+Tests model performance under various concurrent request loads.
+
+- **Concurrency levels**: 1, 2, 4, 8, 16, 32
+- **Metrics focus**: P95 latency, TTFT, throughput
+- **Goal**: Understand how models scale with parallel requests
+
+### Test Suite: Scalability
+
+Characterizes maximum throughput and performance curves.
+
+- **Test types**: Sweep, Synchronous baseline, Poisson distribution
+- **Metrics focus**: Maximum capacity, saturation points
+- **Goal**: Determine optimal operating range
+
+### Test Suite: Offline Batch
+
+Tests vLLM batch processing performance using the native Python API (not server mode).
+
+- **Test types**: Use cases (11 scenarios), Technical benchmarks (batch/core/I/O scaling, KV-cache capacity, context scaling)
+- **Metrics focus**: Throughput (req/s, tokens/s), total batch time, processing capacity
+- **Goal**: Optimize bulk processing for ETL, dataset generation, document processing
+- **Use cases**: Summarization, Classification, Translation, Entity Extraction, Dataset Generation, ETL Pipelines, Code Generation, Long-Document Summarization, Batch RAG, Shared-Prefix/Template Batch, Ultra-Short Labeling
+
+See [Offline Batch Test Suite](offline-batch/offline-batch.md) for detailed documentation.
+
+### Test Suite: CVE Scanning / VLoc Bench
+
+Evaluates LLM vulnerability localization using the Cisco VLoc Bench harness.
+
+- **Online track**: VLoc Bench agent loop (Docker sandbox + tool calls) against vLLM-served models
+- **Offline track**: `vllm bench throughput` capacity proxy with representative I/O shapes
+- **Metrics focus**: File F1, Precision, Recall (online); tok/s, items/hr (offline)
+- **Model families**: Granite-4.0 (baseline), Qwen3.5-9B, Antares (specialized)
+- **Goal**: Evaluate vulnerability localization quality and model capacity on CPU
+
+See [CVE Scanning Test Suite](cve-scanning/cve-scanning.md) for detailed documentation.
+
+### Test Suite: Resource Contention (Planned)
+
+Multi-tenant and resource sharing scenarios.
+
+### Embedding Models
+
+Performance evaluation for embedding models on CPU.
+
+- **Test types**: Baseline (sweep), Latency (concurrent)
+- **Metrics focus**: Request throughput (RPS), P95/P99 latency
+- **Goal**: Establish baseline performance and optimal concurrency levels
+- **Architecture**: Two-node (DUT + Load Generator)
+
+See [Embedding Models Test Suite](embedding-models/embedding-models.md) for detailed documentation.
+
+## Running Tests
 
 ```bash
 # Recommended: cpueval CLI

--- a/tests/tests.md
+++ b/tests/tests.md
@@ -34,7 +34,7 @@ All test cases use a hierarchical naming scheme:
 **Components:**
 
 - **Suite Prefix**: `CONC` (Concurrent Load), `SCALE` (Scalability), `OFFLINE` (Offline Batch), `CVE` (CVE Scanning), `CONT` (Resource Contention), `EMB` (Embedding)
-- **Type** (not used for CONC suite): `SWEEP`, `SYNC` (Synchronous), `POISSON`, `BASELINE`, `LATENCY`
+- **Type** (not used for CONC suite): `SWEEP`, `SYNC` (Synchronous), `POISSON`, `BASELINE`, `LATENCY`; CVE-specific: `VLOC` (localization), `CAP` (capacity)
 - **Use Case** (offline batch): `SUMM` (Summarization), `CLASS` (Classification), `TRANS` (Translation), `ENTITY` (Entity Extraction), `DATAGEN` (Dataset Generation), `ETL` (ETL Pipelines), `CODEGEN` (Code Generation), `LONGSUM` (Long-Doc Summarization), `RAG` (Batch RAG), `PREFIX` (Shared-Prefix), `LABEL` (Ultra-Short Labeling)
 - **Model**: Short abbreviation (e.g., `LLAMA32`, `QWEN06`, `GRANITE32`, `GRANITE-EN`, `GRANITE-ML`)
 - **Workload**: `CHAT`, `RAG`, `CODE`, `SUMM`, `EMB` (embedding), `EMB512` (512-token embedding)
@@ -88,7 +88,7 @@ Evaluates LLM vulnerability localization using the Cisco VLoc Bench harness.
 
 - **Online track**: VLoc Bench agent loop (Docker sandbox + tool calls) against vLLM-served models
 - **Offline track**: `vllm bench throughput` capacity proxy with representative I/O shapes
-- **Metrics focus**: File F1, Precision, Recall (online); tok/s, items/hr (offline)
+- **Metrics focus**: File F1, Precision, Recall, TNR (online); tok/s, items/hr (offline)
 - **Model families**: Granite-4.0 (baseline), Qwen3.5-9B, Antares (specialized)
 - **Goal**: Evaluate vulnerability localization quality and model capacity on CPU
 


### PR DESCRIPTION
## Summary
- Adds an online CVE/VLoc track: serve a matrix model with vLLM on CPU, then run Cisco VLoc Bench in containers (harness + per-task sandbox via Podman socket passthrough). Primary scores are Phase A File F1 and Phase B True Negative Rate; results land under `results/llm/*/cve-vloc-*/`.
- Adds `run-cve-vloc-suite.sh` (smoke / phase-a / phase-b / full / model-sweep), playbook `llm-benchmark-cve-vloc.yml`, a Streamlit CVE VLoc page with GPU leaderboard comparison, and an offline `cve-capacity` mode in the batch suite that is explicitly **not** localization quality.
- Default protocol matches the published leaderboard (sandbox command allowlist on). `--permissive` is opt-in. `--container-image` is honored. Empty/failed dataset runs fail the play instead of recording zeros as success.
## How to run
```bash
# Smoke: 5 tasks, Phase A, Granite-4.0-350M
./automation/test-execution/scripts/bash/run-cve-vloc-suite.sh smoke
# Phase A, Granite family
./automation/test-execution/scripts/bash/run-cve-vloc-suite.sh phase-a \
  --models granite --n-limit 25 --cores 16
# Antares (gated — each model needs its own HF grant)
export HF_TOKEN=hf_xxxxx
./automation/test-execution/scripts/bash/run-cve-vloc-suite.sh phase-a \
  --models antares --n-limit 25