### PR TITLE
fix: add RHAIIS 3.5 support for quay.io/aipcc/rhaiis image

### DIFF
--- a/automation/test-execution/ansible/roles/vllm_server/tasks/start-embedding.yml
+++ b/automation/test-execution/ansible/roles/vllm_server/tasks/start-embedding.yml
@@ -34,7 +34,7 @@
 
 - name: Detect Red Hat AI vLLM image
   ansible.builtin.set_fact:
-    is_redhat_ai_image: "{{ 'registry.redhat.io/rhaii' in (container_cfg.image | lower) or 'quay.io/intel_on_openshift' in (container_cfg.image | lower) }}"
+    is_redhat_ai_image: "{{ 'rhaii' in (container_cfg.image | lower) }}"
 
 - name: Prepare base environment variables
   ansible.builtin.set_fact:

--- a/automation/test-execution/ansible/roles/vllm_server/tasks/start-llm.yml
+++ b/automation/test-execution/ansible/roles/vllm_server/tasks/start-llm.yml
@@ -159,7 +159,7 @@
 
 - name: Detect Red Hat AI vLLM image
   ansible.builtin.set_fact:
-    is_redhat_ai_image: "{{ 'registry.redhat.io/rhaii' in (container_cfg.image | lower) or 'quay.io/intel_on_openshift' in (container_cfg.image | lower) }}"
+    is_redhat_ai_image: "{{ 'rhaii' in (container_cfg.image | lower) }}"
 
 - name: Prepare base environment variables
   ansible.builtin.set_fact:
@@ -285,6 +285,20 @@
 - name: Set effective container image (use backend or default)
   ansible.builtin.set_fact:
     effective_container_image: "{{ backend_image | default(container_cfg.image) }}"
+
+- name: Recompute Red Hat AI image detection from effective container image
+  ansible.builtin.set_fact:
+    is_redhat_ai_image: "{{ 'rhaii' in (effective_container_image | lower) }}"
+
+- name: Re-apply Red Hat AI image specific environment variables (after backend image resolution)
+  ansible.builtin.set_fact:
+    vllm_env_vars: "{{ vllm_env_vars | combine({'HF_HOME': '/opt/app-root/src/.cache/huggingface', 'HF_HUB_OFFLINE': '0'}) }}"
+  when: is_redhat_ai_image
+  no_log: true
+
+- name: Re-set container cache path from effective image type
+  ansible.builtin.set_fact:
+    container_cache_path: "{{ '/opt/app-root/src/.cache/huggingface' if is_redhat_ai_image else '/root/.cache/huggingface' }}"
 
 - name: Extract effective max-model-len for validation
   ansible.builtin.set_fact:

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/config_manager.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/config_manager.py
@@ -101,21 +101,21 @@ class DashboardConfig:
 def normalize_vllm_version(version_string):
     """Normalize vLLM version for display.
 
-    Maps the current RHAIIS vLLM version to a user-friendly display name.
-    Future versions are displayed as-is.
+    Maps RHAIIS vLLM version strings to user-friendly display names.
+    Future versions are displayed as-is until a new mapping is added.
 
     Args:
         version_string: Raw vLLM version from metadata
 
     Returns:
-        "RHAIIS_3.4" for current version, original string otherwise
+        Friendly RHAIIS label, or the original string if unmapped
     """
     if not version_string or version_string == 'unknown':
         return 'unknown'
 
-    # Current RHAIIS 3.4 version
-    if version_string == '0.18.0+rhaiv.7':
-        return 'RHAIIS_3.4'
+    _RHAIIS_VERSION_MAP = {
+        '0.18.0+rhaiv.7': 'RHAIIS_3.4',
+        '0.24.0+rhaiv.2': 'RHAIIS_3.5',
+    }
 
-    # All other versions (past or future) display as-is
-    return version_string
+    return _RHAIIS_VERSION_MAP.get(version_string, version_string)

--- a/automation/test-execution/scripts/bash/run-rhaiis-concurrent-load.sh
+++ b/automation/test-execution/scripts/bash/run-rhaiis-concurrent-load.sh
@@ -332,29 +332,14 @@ if [[ -n "${TENSOR_PARALLEL}" ]]; then
     fi
 fi
 
-# Check for LD_PRELOAD (CRITICAL for RHAIIS performance)
+# Check for LD_PRELOAD
+# RHAIIS 3.5.0+ bakes LD_PRELOAD into the container image, so host-level setting
+# is no longer required. Warn if unset but do not block.
 if [ -z "${LD_PRELOAD:-}" ]; then
-    log_error "LD_PRELOAD is not set!"
-    log_error ""
-    log_error "⚠️  CRITICAL: For optimal RHAIIS performance, you MUST set:"
-    log_error "  export LD_PRELOAD=/usr/lib64/libomp.so"
-    log_error ""
-    log_error "Without this, you will see significantly degraded latency (5-10x slower)."
-    log_error ""
-
-    # Skip prompt in non-interactive mode or when CI/NONINTERACTIVE is set
-    if [[ -t 0 ]] && [[ "${NONINTERACTIVE:-}" != "true" ]] && [[ "${CI:-}" != "true" ]]; then
-        read -p "Continue anyway? [y/N] " -n 1 -r
-        echo
-        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-            log_info "Aborted. Please set LD_PRELOAD and try again."
-            exit 0
-        fi
-        log_warning "Continuing without LD_PRELOAD - performance will be poor!"
-    else
-        log_error "Aborting in non-interactive mode. Set LD_PRELOAD or NONINTERACTIVE=true to override."
-        exit 1
-    fi
+    log_warning "LD_PRELOAD is not set on the host."
+    log_warning "RHAIIS 3.5.0+ sets LD_PRELOAD inside the container automatically."
+    log_warning "For older images, set on the host:"
+    log_warning "  export LD_PRELOAD=/usr/lib64/libtcmalloc_minimal.so.4:/usr/lib64/libomp.so"
     echo ""
 fi
 


### PR DESCRIPTION
- Extend is_redhat_ai_image detection to recognize rhaiis images, ensuring HF_HUB_OFFLINE is overridden to 0 and HF_HOME is set correctly so the container can locate or download model weights
- Downgrade LD_PRELOAD check from blocking error to warning; RHAIIS 3.5.0+ bakes LD_PRELOAD into the container image so the host-level check is no longer required, and the suggested value is corrected to include both libtcmalloc_minimal.so.4 and libomp.so