### PR TITLE
fix: use normalize_vllm_version in Offline Batch page

### DIFF
--- a/automation/cli/src/cpueval/cli.py
+++ b/automation/cli/src/cpueval/cli.py
@@ -12,6 +12,7 @@ from cpueval.paths import get_profiles_dir
 from cpueval.results import (
     run_results_command,
     run_dashboard_command,
+    run_dashboard_stop_command,
     save_last_run_hint,
     find_latest_result,
 )
@@ -380,10 +381,21 @@ def results(
     raise typer.Exit(exit_code)
 
 
-@app.command()
-def dashboard():
-    """Launch the results dashboard."""
+dashboard_app = typer.Typer(help="Manage the results dashboard", no_args_is_help=True)
+app.add_typer(dashboard_app, name="dashboard")
+
+
+@dashboard_app.command("start")
+def dashboard_start():
+    """Start the results dashboard (background, port 8501)."""
     exit_code = run_dashboard_command()
+    raise typer.Exit(exit_code)
+
+
+@dashboard_app.command("stop")
+def dashboard_stop():
+    """Stop the running results dashboard."""
+    exit_code = run_dashboard_stop_command()
     raise typer.Exit(exit_code)
 
 

--- a/automation/cli/src/cpueval/paths.py
+++ b/automation/cli/src/cpueval/paths.py
@@ -52,6 +52,18 @@ def get_dashboard_script() -> Path:
     )
 
 
+def get_dashboard_stop_script() -> Path:
+    """Get the dashboard stop script."""
+    return (
+        get_repo_root()
+        / "automation"
+        / "test-execution"
+        / "dashboard-examples"
+        / "vllm_dashboard"
+        / "stop-dashboard.sh"
+    )
+
+
 def get_conversion_script() -> Path:
     """Get the batch conversion script."""
     return (

--- a/automation/cli/src/cpueval/results.py
+++ b/automation/cli/src/cpueval/results.py
@@ -13,6 +13,7 @@ from cpueval.paths import (
     get_llm_results_dir,
     get_audio_results_dir,
     get_dashboard_script,
+    get_dashboard_stop_script,
     get_conversion_script,
     get_repo_root,
     find_latest_result,
@@ -390,3 +391,13 @@ def run_results_command(
 def run_dashboard_command() -> int:
     """Launch the dashboard."""
     return run_results_command(open_dashboard=True)
+
+
+def run_dashboard_stop_command() -> int:
+    """Stop the running dashboard."""
+    console = Console()
+    stop_script = get_dashboard_stop_script()
+    if not stop_script.exists():
+        console.print(f"[red]Stop script not found: {stop_script}[/red]")
+        return 1
+    return subprocess.run([str(stop_script)]).returncode

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/4_📦_Offline_Batch.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/4_📦_Offline_Batch.py
@@ -18,7 +18,7 @@ import streamlit as st
 
 # Add parent directory to path for config_manager import
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from config_manager import DashboardConfig  # noqa: E402
+from config_manager import DashboardConfig, normalize_vllm_version  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -159,15 +159,6 @@ def is_technical_use_case(use_case_key: str) -> bool:
     belongs to a technical benchmark rather than a product-oriented use case.
     """
     return use_case_key in TECHNICAL_USE_CASES
-
-
-def normalize_version(version: str) -> str:
-    """Strip a single leading 'v'/'V' for consistent version comparison."""
-    if not version:
-        return 'unknown'
-    if version[:1] in ('v', 'V') and len(version) > 1:
-        return version[1:]
-    return version
 
 
 def format_duration(seconds: float) -> str:
@@ -399,7 +390,7 @@ def load_benchmark_results(results_base_dir: str) -> pd.DataFrame:
                             'container_image': metadata['environment'].get(
                                 'container_image', 'unknown'
                             ),
-                            'vllm_version': normalize_version(
+                            'vllm_version': normalize_vllm_version(
                                 metadata['environment'].get(
                                     'vllm_version', 'unknown'
                                 )

--- a/automation/test-execution/tests/dashboard/test_offline_batch_page.py
+++ b/automation/test-execution/tests/dashboard/test_offline_batch_page.py
@@ -48,7 +48,7 @@ compute_items_per_hour = _ns["compute_items_per_hour"]
 compute_time_for_batch = _ns["compute_time_for_batch"]
 is_technical_use_case = _ns["is_technical_use_case"]
 format_duration = _ns["format_duration"]
-normalize_version = _ns["normalize_version"]
+normalize_version = _ns["normalize_vllm_version"]
 USE_CASE_REFERENCE = _ns["USE_CASE_REFERENCE"]
 
 
@@ -144,13 +144,7 @@ class TestFormatDuration:
 
 
 class TestNormalizeVersion:
-    """Test the normalize_version helper."""
-
-    def test_strip_v_prefix(self):
-        assert normalize_version("v0.25.1") == "0.25.1"
-
-    def test_no_prefix(self):
-        assert normalize_version("0.25.1") == "0.25.1"
+    """Test the normalize_vllm_version helper (aliased as normalize_version)."""
 
     def test_empty_string(self):
         assert normalize_version("") == "unknown"
@@ -158,17 +152,20 @@ class TestNormalizeVersion:
     def test_none(self):
         assert normalize_version(None) == "unknown"
 
-    def test_rhaiis_version(self):
-        assert normalize_version("0.18.0+rhaiv.7") == "0.18.0+rhaiv.7"
+    def test_unknown_string(self):
+        assert normalize_version("unknown") == "unknown"
 
-    def test_v_only(self):
-        assert normalize_version("v") == "v"
+    def test_rhaiis_34_version(self):
+        assert normalize_version("0.18.0+rhaiv.7") == "RHAIIS_3.4"
 
-    def test_double_v_strips_one(self):
-        assert normalize_version("vv1.0") == "v1.0"
+    def test_rhaiis_35_version(self):
+        assert normalize_version("0.24.0+rhaiv.2") == "RHAIIS_3.5"
 
-    def test_uppercase_v(self):
-        assert normalize_version("V0.25.1") == "0.25.1"
+    def test_unmapped_version_passthrough(self):
+        assert normalize_version("0.25.1") == "0.25.1"
+
+    def test_v_prefix_passthrough(self):
+        assert normalize_version("v0.25.1") == "v0.25.1"
 
 
 class TestUseCaseReference:


### PR DESCRIPTION
The Offline Batch page had its own normalize_version helper that only stripped a leading 'v', so RHAIIS version strings like 0.24.0+rhaiv.2 were displayed raw instead of being mapped to RHAIIS_3.5.

Replace the local function with normalize_vllm_version from config_manager (already used by Client Metrics, Server Metrics, and Embedding Metrics) and remove the now-unused normalize_version definition.