### PR TITLE
feat(ansible): add parallel vLLM instance support

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run fast integration tests
         run: |
           cd automation/test-execution/ansible/tests
-          pytest -m "integration and not slow and not e2e and not requires_numa" -v --tb=short
+          pytest -m "integration and not slow and not e2e and not requires_numa and not requires_container" -v --tb=short
 
   integration-standard:
     name: Integration Tests (Standard)

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ results/*.csv
 !automation/test-execution/grafana/dashboards/*.json
 *.csv
 
+# Local test harnesses (not for commit)
+run-parallel-3inst.sh
+
 # Log directories
 logs/
 

--- a/automation/test-execution/README.md
+++ b/automation/test-execution/README.md
@@ -253,6 +253,8 @@ DUT-only suites (`audio-benchmark.yml`, `llm-benchmark-offline-batch.yml`) detec
 topology on the DUT and use `allocate-cores-from-count.yml` to pin the container
 cpuset. Set `VLLM_NUMA_NODES` to restrict each parallel instance to a subset of nodes
 (e.g. `"0,1"`). Socket pinning via `-e vllm_numa_node=<N>` is also supported.
+When `VLLM_NUMA_NODES` is unset, core allocation still runs through `allocate-cores-from-count.yml`
+and may not start from core 0 on multi-socket hosts.
 
 #### VLLM_NUMA_NODE vs VLLM_NUMA_NODES
 
@@ -290,6 +292,10 @@ VLLM_CONTAINER_NAME=vllm-audio-0 VLLM_NUMA_NODES="0,1" \
 VLLM_CONTAINER_NAME=vllm-batch-0 VLLM_NUMA_NODES="2,3" \
   ./scripts/bash/run-offline-batch-suite.sh use-cases --cores 32
 ```
+
+**Container cleanup:** `llm-benchmark-auto.yml` removes the vLLM container after each run by
+default (`cleanup_after_test: true`); pass `-e cleanup_after_test=false` to keep it for debugging.
+`llm-benchmark.yml` still defaults to `cleanup_after_test: false`.
 
 ## Testing
 

--- a/automation/test-execution/README.md
+++ b/automation/test-execution/README.md
@@ -226,6 +226,34 @@ export VLLM_ENDPOINT_URL=http://your-endpoint:8000
 export HF_TOKEN=hf_your_token_here
 ```
 
+### Parallel vLLM Instances
+
+Run multiple vLLM benchmark instances simultaneously on the same host by assigning each a unique container name, port, and NUMA node set via environment variables. The bash suite scripts forward these to Ansible as `-e` overrides.
+
+| Variable | Description | Default |
+|---|---|---|
+| `VLLM_CONTAINER_NAME` | Container name for this instance | `vllm-server` |
+| `VLLM_PORT` | Host port for the vLLM API server | `8000` (`vllm_port` in `group_vars/all/endpoints.yml`) |
+| `VLLM_NUMA_NODES` | Comma-separated NUMA node IDs to pin this instance to | all nodes |
+
+`vllm_port` is the Ansible/inventory source of truth and can also be overridden directly with `-e vllm_port=8001`.
+
+**Two-instance example** (run in separate terminals):
+
+```bash
+# Instance 0 — NUMA nodes 0,1, port 8000
+VLLM_CONTAINER_NAME=vllm-0 VLLM_PORT=8000 VLLM_NUMA_NODES="0,1" \
+  ./scripts/bash/run-audio-suite.sh --models whisper-small --cores 32
+
+# Instance 1 — NUMA nodes 2,3, port 8001
+VLLM_CONTAINER_NAME=vllm-1 VLLM_PORT=8001 VLLM_NUMA_NODES="2,3" \
+  ./scripts/bash/run-audio-suite.sh --models whisper-small --cores 32
+```
+
+The same variables are supported by all suite scripts:
+`run-audio-suite.sh`, `run-concurrent-load-suite.sh`, `run-embedding-suite.sh`,
+`run-offline-batch-suite.sh`, `run-rhaiis-concurrent-load.sh`, and `run-mteb-model-sweep.sh`.
+
 ## Testing
 
 Run unit tests:

--- a/automation/test-execution/README.md
+++ b/automation/test-execution/README.md
@@ -228,7 +228,7 @@ export HF_TOKEN=hf_your_token_here
 
 ### Parallel vLLM Instances
 
-Run multiple vLLM benchmark instances simultaneously on the same host by assigning each a unique container name, port, and NUMA node set via environment variables. The bash suite scripts forward these to Ansible as `-e` overrides.
+Run multiple vLLM benchmark instances simultaneously on the same host by assigning each a unique container name and port via environment variables. NUMA node pinning (`VLLM_NUMA_NODES`) is additionally supported for the concurrent-load suites; see the capability matrix below. The bash suite scripts forward these to Ansible as `-e` overrides.
 
 | Variable | Description | Default |
 |---|---|---|

--- a/automation/test-execution/README.md
+++ b/automation/test-execution/README.md
@@ -238,21 +238,47 @@ Run multiple vLLM benchmark instances simultaneously on the same host by assigni
 
 `vllm_port` is the Ansible/inventory source of truth and can also be overridden directly with `-e vllm_port=8001`.
 
+#### Variable support per suite
+
+| Suite script → Playbook | `VLLM_CONTAINER_NAME` | `VLLM_PORT` | `VLLM_NUMA_NODES` |
+|---|---|---|---|
+| `run-concurrent-load-suite.sh` → `llm-benchmark-concurrent-load.yml` | ✓ | ✓ | ✓ |
+| `run-rhaiis-concurrent-load.sh` → `llm-benchmark-concurrent-load.yml` | ✓ | ✓ | ✓ |
+| `run-audio-suite.sh` → `audio-benchmark.yml` | ✓ | ✓ | ✗ (cpuset hardcoded; see note) |
+| `run-embedding-suite.sh` → `embedding-benchmark.yml` | ✓ | ✓ | ✗ (not wired to NUMA allocator) |
+| `run-mteb-model-sweep.sh` → `mteb-benchmark.yml` | ✓ | ✓ | ✗ (not wired to NUMA allocator) |
+| `run-offline-batch-suite.sh` → `llm-benchmark-offline-batch.yml` | ✓ | N/A (batch job, no server port) | ✗ (cpuset hardcoded; see note) |
+
+**Note on `VLLM_NUMA_NODES` for audio and offline-batch**: these playbooks
+currently hardcode the cpuset to cores `0–(N-1)`. `VLLM_NUMA_NODES` is accepted
+as an Ansible variable but has no effect on cpuset allocation. For NUMA-pinned
+parallel instances, use `run-concurrent-load-suite.sh` or
+`run-rhaiis-concurrent-load.sh`.
+
+#### VLLM_NUMA_NODE vs VLLM_NUMA_NODES
+
+Two separate variables control NUMA affinity; they are **not** interchangeable:
+
+| Variable | Type | Purpose |
+|---|---|---|
+| `VLLM_NUMA_NODE` | single integer | Socket-pinning: start vLLM on the specified NUMA node (`vllm_numa_node`). Used in `run-rhaiis-concurrent-load.sh`. |
+| `VLLM_NUMA_NODES` | comma-separated integers | Multi-node filtering for parallel instances: restrict a single vLLM instance to a *subset* of NUMA nodes (`vllm_numa_nodes`), e.g. `"0,1"`. |
+
+When both are provided, `VLLM_NUMA_NODES` takes precedence — the Ansible
+`allocate-cores-from-count.yml` task file clears the socket-pinning override
+(`_vllm_numa_node_value`) when `vllm_numa_nodes` is active.
+
 **Two-instance example** (run in separate terminals):
 
 ```bash
 # Instance 0 — NUMA nodes 0,1, port 8000
 VLLM_CONTAINER_NAME=vllm-0 VLLM_PORT=8000 VLLM_NUMA_NODES="0,1" \
-  ./scripts/bash/run-audio-suite.sh --models whisper-small --cores 32
+  ./scripts/bash/run-concurrent-load-suite.sh --models llama --cores 32
 
 # Instance 1 — NUMA nodes 2,3, port 8001
 VLLM_CONTAINER_NAME=vllm-1 VLLM_PORT=8001 VLLM_NUMA_NODES="2,3" \
-  ./scripts/bash/run-audio-suite.sh --models whisper-small --cores 32
+  ./scripts/bash/run-concurrent-load-suite.sh --models llama --cores 32
 ```
-
-The same variables are supported by all suite scripts:
-`run-audio-suite.sh`, `run-concurrent-load-suite.sh`, `run-embedding-suite.sh`,
-`run-offline-batch-suite.sh`, `run-rhaiis-concurrent-load.sh`, and `run-mteb-model-sweep.sh`.
 
 ## Testing
 

--- a/automation/test-execution/README.md
+++ b/automation/test-execution/README.md
@@ -228,7 +228,7 @@ export HF_TOKEN=hf_your_token_here
 
 ### Parallel vLLM Instances
 
-Run multiple vLLM benchmark instances simultaneously on the same host by assigning each a unique container name and port via environment variables. NUMA node pinning (`VLLM_NUMA_NODES`) is additionally supported for the concurrent-load suites; see the capability matrix below. The bash suite scripts forward these to Ansible as `-e` overrides.
+Run multiple vLLM benchmark instances simultaneously on the same host by assigning each a unique container name, port, and (where supported) NUMA node set via environment variables. The bash suite scripts forward these to Ansible as `-e` overrides.
 
 | Variable | Description | Default |
 |---|---|---|
@@ -244,16 +244,15 @@ Run multiple vLLM benchmark instances simultaneously on the same host by assigni
 |---|---|---|---|
 | `run-concurrent-load-suite.sh` → `llm-benchmark-concurrent-load.yml` | ✓ | ✓ | ✓ |
 | `run-rhaiis-concurrent-load.sh` → `llm-benchmark-concurrent-load.yml` | ✓ | ✓ | ✓ |
-| `run-audio-suite.sh` → `audio-benchmark.yml` | ✓ | ✓ | ✗ (cpuset hardcoded; see note) |
+| `run-audio-suite.sh` → `audio-benchmark.yml` | ✓ | ✓ | ✓ |
 | `run-embedding-suite.sh` → `embedding-benchmark.yml` | ✓ | ✓ | ✗ (not wired to NUMA allocator) |
 | `run-mteb-model-sweep.sh` → `mteb-benchmark.yml` | ✓ | ✓ | ✗ (not wired to NUMA allocator) |
-| `run-offline-batch-suite.sh` → `llm-benchmark-offline-batch.yml` | ✓ | N/A (batch job, no server port) | ✗ (cpuset hardcoded; see note) |
+| `run-offline-batch-suite.sh` → `llm-benchmark-offline-batch.yml` | ✓ | N/A (batch job, no server port) | ✓ |
 
-**Note on `VLLM_NUMA_NODES` for audio and offline-batch**: these playbooks
-currently hardcode the cpuset to cores `0–(N-1)`. `VLLM_NUMA_NODES` is accepted
-as an Ansible variable but has no effect on cpuset allocation. For NUMA-pinned
-parallel instances, use `run-concurrent-load-suite.sh` or
-`run-rhaiis-concurrent-load.sh`.
+DUT-only suites (`audio-benchmark.yml`, `llm-benchmark-offline-batch.yml`) detect NUMA
+topology on the DUT and use `allocate-cores-from-count.yml` to pin the container
+cpuset. Set `VLLM_NUMA_NODES` to restrict each parallel instance to a subset of nodes
+(e.g. `"0,1"`). Socket pinning via `-e vllm_numa_node=<N>` is also supported.
 
 #### VLLM_NUMA_NODE vs VLLM_NUMA_NODES
 
@@ -278,6 +277,18 @@ VLLM_CONTAINER_NAME=vllm-0 VLLM_PORT=8000 VLLM_NUMA_NODES="0,1" \
 # Instance 1 — NUMA nodes 2,3, port 8001
 VLLM_CONTAINER_NAME=vllm-1 VLLM_PORT=8001 VLLM_NUMA_NODES="2,3" \
   ./scripts/bash/run-concurrent-load-suite.sh --models llama --cores 32
+```
+
+**DUT-only parallel example** (audio + offline-batch on the same host):
+
+```bash
+# Audio instance on NUMA nodes 0,1
+VLLM_CONTAINER_NAME=vllm-audio-0 VLLM_NUMA_NODES="0,1" \
+  ./scripts/bash/run-audio-suite.sh --models whisper-small --cores 32
+
+# Offline-batch instance on NUMA nodes 2,3
+VLLM_CONTAINER_NAME=vllm-batch-0 VLLM_NUMA_NODES="2,3" \
+  ./scripts/bash/run-offline-batch-suite.sh use-cases --cores 32
 ```
 
 ## Testing

--- a/automation/test-execution/ansible/audio-benchmark.yml
+++ b/automation/test-execution/ansible/audio-benchmark.yml
@@ -387,7 +387,7 @@
     effective_vllm_kvcache_space: "{{ hostvars['localhost']['effective_vllm_kvcache_space'] }}"
     effective_omp_num_threads: "{{ hostvars['localhost']['effective_omp_num_threads'] }}"
     effective_requested_tensor_parallel: "{{ hostvars['localhost']['effective_requested_tensor_parallel'] }}"
-    core_configuration: "{{ hostvars['localhost']['core_configuration'] }}"
+    core_configuration: "{{ hostvars['localhost']['core_configuration'] | default({}) }}"
     vllm_control_plane_cores: 2  # Reserve 2 cores for control plane (defined here for vllm-server play)
     # vllm_container_name defaults to 'vllm-server' via group_vars. run-audio-suite.sh
     # forwards VLLM_CONTAINER_NAME as -e vllm_container_name=...; any value other than

--- a/automation/test-execution/ansible/audio-benchmark.yml
+++ b/automation/test-execution/ansible/audio-benchmark.yml
@@ -598,7 +598,7 @@
               - "   Image: {{ vllm_audio_image }} (with audio support)"
               - "   URL: http://{{ ansible_host }}:{{ vllm_server.port }}"
               - "   Model: {{ actual_model }}"
-              - "   Cores: {{ requested_cores }} ({{ '0-' + ((requested_cores | int) - 1) | string }})"
+              - "   Cores: {{ requested_cores }} ({{ core_configuration.cpuset_cpus }})"
               - "   Tensor Parallel: {{ effective_requested_tensor_parallel }}"
               - "   Logs: journalctl -t vllm-audio-{{ actual_model | replace('/', '__') }} -f"
 

--- a/automation/test-execution/ansible/audio-benchmark.yml
+++ b/automation/test-execution/ansible/audio-benchmark.yml
@@ -389,12 +389,12 @@
     effective_requested_tensor_parallel: "{{ hostvars['localhost']['effective_requested_tensor_parallel'] }}"
     core_configuration: "{{ hostvars['localhost']['core_configuration'] }}"
     vllm_control_plane_cores: 2  # Reserve 2 cores for control plane (defined here for vllm-server play)
-    # vllm_container_name_override: set via VLLM_CONTAINER_NAME env var (forwarded by
-    # run-audio-suite.sh) for parallel instances. Not defined by default, so the
-    # is defined + length check cleanly detects an explicit override without a sentinel.
+    # vllm_container_name defaults to 'vllm-server' via group_vars. run-audio-suite.sh
+    # forwards VLLM_CONTAINER_NAME as -e vllm_container_name=...; any value other than
+    # the group_vars default signals an explicit caller override.
     container_name: >-
-      {{ vllm_container_name_override
-         if (vllm_container_name_override is defined and vllm_container_name_override | length > 0)
+      {{ vllm_container_name
+         if (vllm_container_name != 'vllm-server')
          else 'vllm-audio-' + hostvars['localhost']['test_run_id'] }}
 
   tasks:
@@ -880,8 +880,8 @@
     vllm_mode: "{{ vllm_endpoint.mode | default('managed') }}"
     test_run_id: "{{ hostvars['localhost']['test_run_id'] }}"
     container_name: >-
-      {{ vllm_container_name_override
-         if (vllm_container_name_override is defined and vllm_container_name_override | length > 0)
+      {{ vllm_container_name
+         if (vllm_container_name != 'vllm-server')
          else 'vllm-audio-' + hostvars['localhost']['test_run_id'] }}
 
   tasks:

--- a/automation/test-execution/ansible/audio-benchmark.yml
+++ b/automation/test-execution/ansible/audio-benchmark.yml
@@ -339,7 +339,12 @@
     effective_omp_num_threads: "{{ hostvars['localhost']['effective_omp_num_threads'] }}"
     effective_requested_tensor_parallel: "{{ hostvars['localhost']['effective_requested_tensor_parallel'] }}"
     vllm_control_plane_cores: 2  # Reserve 2 cores for control plane (defined here for vllm-server play)
-    container_name: "vllm-audio-{{ hostvars['localhost']['test_run_id'] }}"
+    # Use vllm_container_name when explicitly set (e.g. VLLM_CONTAINER_NAME=vllm-0 for parallel
+    # instances), otherwise generate a unique per-run name so sequential runs don't conflict.
+    container_name: >-
+      {{ vllm_container_name
+         if (vllm_container_name is defined and vllm_container_name != 'vllm-server')
+         else 'vllm-audio-' + hostvars['localhost']['test_run_id'] }}
 
   tasks:
     - name: Detect DUT platform (managed mode)
@@ -827,7 +832,10 @@
   vars:
     vllm_mode: "{{ vllm_endpoint.mode | default('managed') }}"
     test_run_id: "{{ hostvars['localhost']['test_run_id'] }}"
-    container_name: "vllm-audio-{{ hostvars['localhost']['test_run_id'] }}"
+    container_name: >-
+      {{ vllm_container_name
+         if (vllm_container_name is defined and vllm_container_name != 'vllm-server')
+         else 'vllm-audio-' + hostvars['localhost']['test_run_id'] }}
 
   tasks:
     - name: Stop vLLM audio server (managed mode only)

--- a/automation/test-execution/ansible/audio-benchmark.yml
+++ b/automation/test-execution/ansible/audio-benchmark.yml
@@ -218,7 +218,7 @@
               - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
               - "CPU Configuration (Managed Mode)"
               - "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-              - "Container Cores: {{ requested_cores }} (cores 0-{{ (requested_cores | int) - 1 }})"
+              - "Container Cores: {{ requested_cores }} (NUMA allocation runs on DUT before container start)"
               - "Control Plane Reserve: {{ vllm_control_plane_cores }} cores (VLLM_CPU_NUM_OF_RESERVED_CPU={{ vllm_control_plane_cores }})"
               - "Tensor Parallel: {{ requested_tensor_parallel }}"
               - "{% if requested_tensor_parallel | int > 1 %}Worker Threads (OMP): {{ omp_num_threads }}{% else %}Worker Threads: Auto (TP=1, no OMP override){% endif %}"
@@ -320,6 +320,55 @@
           - "╚══════════════════════════════════════════════════════════════╝"
 
 # ============================================================================
+# Detect NUMA Topology and Allocate Cores (Managed Mode Only)
+# ============================================================================
+
+- name: "Audio Benchmark - Detect NUMA Topology"
+  hosts: dut
+  become: true
+  gather_facts: false
+  vars:
+    vllm_mode: "{{ vllm_endpoint.mode | default('managed') }}"
+
+  pre_tasks:
+    - name: Skip NUMA detection in external mode
+      ansible.builtin.meta: end_play
+      when: vllm_mode != 'managed'
+
+  tasks:
+    - name: Detect NUMA topology on DUT
+      ansible.builtin.include_role:
+        name: common
+        tasks_from: detect-numa-topology
+
+- name: "Audio Benchmark - Allocate Cores"
+  hosts: dut
+  become: true
+  gather_facts: false
+  vars:
+    vllm_mode: "{{ vllm_endpoint.mode | default('managed') }}"
+    requested_cores: "{{ hostvars['localhost']['requested_cores'] }}"
+    requested_tensor_parallel: "{{ hostvars['localhost']['requested_tensor_parallel'] | default(omit) }}"
+    vllm_numa_node: "{{ vllm_numa_node | default(None) }}"
+
+  pre_tasks:
+    - name: Skip core allocation in external mode
+      ansible.builtin.meta: end_play
+      when: vllm_mode != 'managed'
+
+  tasks:
+    - name: Allocate cores from NUMA topology
+      ansible.builtin.include_role:
+        name: common
+        tasks_from: allocate-cores-from-count
+
+    - name: Save auto-allocated config to localhost
+      ansible.builtin.set_fact:
+        core_configuration: "{{ auto_core_config }}"
+      delegate_to: localhost
+      delegate_facts: true
+
+# ============================================================================
 # Start vLLM Server (Managed Mode Only)
 # ============================================================================
 
@@ -338,12 +387,14 @@
     effective_vllm_kvcache_space: "{{ hostvars['localhost']['effective_vllm_kvcache_space'] }}"
     effective_omp_num_threads: "{{ hostvars['localhost']['effective_omp_num_threads'] }}"
     effective_requested_tensor_parallel: "{{ hostvars['localhost']['effective_requested_tensor_parallel'] }}"
+    core_configuration: "{{ hostvars['localhost']['core_configuration'] }}"
     vllm_control_plane_cores: 2  # Reserve 2 cores for control plane (defined here for vllm-server play)
-    # Use vllm_container_name when explicitly set (e.g. VLLM_CONTAINER_NAME=vllm-0 for parallel
-    # instances), otherwise generate a unique per-run name so sequential runs don't conflict.
+    # vllm_container_name_override: set via VLLM_CONTAINER_NAME env var (forwarded by
+    # run-audio-suite.sh) for parallel instances. Not defined by default, so the
+    # is defined + length check cleanly detects an explicit override without a sentinel.
     container_name: >-
-      {{ vllm_container_name
-         if (vllm_container_name is defined and vllm_container_name != 'vllm-server')
+      {{ vllm_container_name_override
+         if (vllm_container_name_override is defined and vllm_container_name_override | length > 0)
          else 'vllm-audio-' + hostvars['localhost']['test_run_id'] }}
 
   tasks:
@@ -463,10 +514,6 @@
             state: absent
           ignore_errors: true
 
-        - name: Determine NUMA node from core range
-          ansible.builtin.set_fact:
-            numa_node: "0"  # Default to node 0, can be enhanced with auto-detection
-
         - name: Build vLLM command arguments
           ansible.builtin.set_fact:
             vllm_command: >-
@@ -502,19 +549,19 @@
         # For TP>1: Set OMP variables explicitly for multi-rank configurations
         - name: Add OMP_NUM_THREADS if TP > 1
           ansible.builtin.set_fact:
-            vllm_env_vars: "{{ vllm_env_vars | combine({'OMP_NUM_THREADS': effective_omp_num_threads | string}) }}"
+            vllm_env_vars: "{{ vllm_env_vars | combine({'OMP_NUM_THREADS': (core_configuration.omp_num_threads | default(effective_omp_num_threads)) | string}) }}"
           when:
             - effective_requested_tensor_parallel | int > 1
-            - effective_omp_num_threads is defined
+            - core_configuration.omp_num_threads is defined or effective_omp_num_threads is defined
           no_log: true
 
         - name: Add VLLM_CPU_OMP_THREADS_BIND if TP > 1
           ansible.builtin.set_fact:
-            vllm_env_vars: "{{ vllm_env_vars | combine({'VLLM_CPU_OMP_THREADS_BIND': omp_threads_bind}) }}"
+            vllm_env_vars: "{{ vllm_env_vars | combine({'VLLM_CPU_OMP_THREADS_BIND': core_configuration.omp_threads_bind}) }}"
           when:
             - effective_requested_tensor_parallel | int > 1
-            - omp_threads_bind is defined
-            - omp_threads_bind != ''
+            - core_configuration.omp_threads_bind is defined
+            - core_configuration.omp_threads_bind != ''
           no_log: true
           # NOTE: Setting VLLM_CPU_OMP_THREADS_BIND to explicit CPU list disables
           # VLLM_CPU_NUM_OF_RESERVED_CPU. Only set for TP>1 where we manage binding manually.
@@ -527,8 +574,8 @@
             restart_policy: "no"
             detach: true
             network: "{{ container_runtime.network_mode }}"
-            cpuset_cpus: "{{ '0-' + ((requested_cores | int) - 1) | string }}"
-            cpuset_mems: "{{ numa_node }}"
+            cpuset_cpus: "{{ core_configuration.cpuset_cpus }}"
+            cpuset_mems: "{{ core_configuration.cpuset_mems }}"
             shm_size: "{{ container_runtime.shm_size }}"
             security_opt: "{{ container_runtime.security_opts }}"
             cap_add: "{{ container_runtime.capabilities }}"
@@ -833,8 +880,8 @@
     vllm_mode: "{{ vllm_endpoint.mode | default('managed') }}"
     test_run_id: "{{ hostvars['localhost']['test_run_id'] }}"
     container_name: >-
-      {{ vllm_container_name
-         if (vllm_container_name is defined and vllm_container_name != 'vllm-server')
+      {{ vllm_container_name_override
+         if (vllm_container_name_override is defined and vllm_container_name_override | length > 0)
          else 'vllm-audio-' + hostvars['localhost']['test_run_id'] }}
 
   tasks:

--- a/automation/test-execution/ansible/audio-benchmark.yml
+++ b/automation/test-execution/ansible/audio-benchmark.yml
@@ -277,7 +277,7 @@
 
     - name: Generate test run ID if not provided
       ansible.builtin.set_fact:
-        test_run_id: "{{ lookup('pipe', 'date +%Y%m%d-%H%M%S') }}"
+        test_run_id: "{{ now(utc=true, fmt='%Y%m%d-%H%M%S-%f') }}"
         cacheable: true
       when: test_run_id is not defined
 

--- a/automation/test-execution/ansible/inventory/group_vars/all/endpoints.yml
+++ b/automation/test-execution/ansible/inventory/group_vars/all/endpoints.yml
@@ -5,10 +5,14 @@
 # vLLM server settings and endpoint mode (managed vs external)
 
 # vLLM server configuration
+# vllm_port is the single source of truth for the vLLM listen port.
+# Override with -e vllm_port=8001 (ansible) or VLLM_PORT=8001 (bash scripts)
+# to run multiple parallel instances on the same host.
 vllm_container_name: "vllm-server"
+vllm_port: 8000
 vllm_server:
   host: "0.0.0.0"
-  port: 8000
+  port: "{{ vllm_port }}"
 
 # vLLM Endpoint Mode Configuration
 # Supports testing against external vLLM deployments (cloud, k8s, production)

--- a/automation/test-execution/ansible/inventory/hosts.yml
+++ b/automation/test-execution/ansible/inventory/hosts.yml
@@ -78,7 +78,7 @@ all:
           # Automatically uses the DUT's ansible_host
           # Override here if you need different IPs (e.g., private IP for benchmarking)
           vllm_host: "{{ hostvars['vllm-server']['ansible_host'] }}"
-          vllm_port: 8000
+          vllm_port: "{{ vllm_port | default(8000) }}"
 
           # Results storage location - store in git workspace results/llm for AWX, otherwise use playbook-relative path
           # This ensures all files (guidellm.log, benchmarks.json, vllm logs, etc.) are in one location

--- a/automation/test-execution/ansible/llm-benchmark-auto.yml
+++ b/automation/test-execution/ansible/llm-benchmark-auto.yml
@@ -802,7 +802,7 @@
       ansible.builtin.meta: end_play
       when: >-
         hostvars['localhost']['vllm_mode'] | default('managed') == 'external' or
-        not (cleanup_after_test | default(false) | bool)
+        not (cleanup_after_test | default(true) | bool)
 
   tasks:
     - name: Stop and remove vLLM container

--- a/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
+++ b/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
@@ -223,11 +223,18 @@
       ansible.builtin.debug:
         msg: "LD_PRELOAD={{ vllm_ld_preload | default('(not set - libomp not found in container)') }}"
 
+    - name: Set effective container name for offline batch
+      ansible.builtin.set_fact:
+        _batch_container_name: >-
+          {{ vllm_container_name
+             if (vllm_container_name is defined and vllm_container_name != 'vllm-server')
+             else 'vllm-batch-' + dataset_name + '-' + (requested_cores | string) + 'c' }}
+
     - name: Build benchmark command (sonnet dataset with file)
       ansible.builtin.set_fact:
         benchmark_cmd: |
           podman run --rm --replace \
-            --name vllm-batch-{{ dataset_name }}-{{ requested_cores }}c \
+            --name {{ _batch_container_name }} \
             --cpuset-cpus=0-{{ requested_cores | int - 1 }} \
             -v "{{ hostvars['localhost']['dut_cache_dir'] }}:/root/.cache/huggingface:z" \
             -v "{{ hostvars['localhost']['datasets_dir'] }}:/datasets:z" \
@@ -247,7 +254,7 @@
       ansible.builtin.set_fact:
         benchmark_cmd: |
           podman run --rm --replace \
-            --name vllm-batch-{{ dataset_name }}-{{ requested_cores }}c \
+            --name {{ _batch_container_name }} \
             --cpuset-cpus=0-{{ requested_cores | int - 1 }} \
             -v "{{ hostvars['localhost']['dut_cache_dir'] }}:/root/.cache/huggingface:z" \
             {{ '-e LD_PRELOAD=' + vllm_ld_preload if vllm_ld_preload is defined else '' }} \
@@ -267,7 +274,7 @@
       ansible.builtin.set_fact:
         benchmark_cmd: |
           podman run --rm --replace \
-            --name vllm-batch-random-{{ requested_cores }}c \
+            --name {{ _batch_container_name }} \
             --cpuset-cpus=0-{{ requested_cores | int - 1 }} \
             -v "{{ hostvars['localhost']['dut_cache_dir'] }}:/root/.cache/huggingface:z" \
             {{ '-e LD_PRELOAD=' + vllm_ld_preload if vllm_ld_preload is defined else '' }} \

--- a/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
+++ b/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
@@ -245,7 +245,7 @@
         _batch_container_name: >-
           {{ vllm_container_name
              if (vllm_container_name != 'vllm-server')
-             else 'vllm-batch-' + dataset_name + '-' + (requested_cores | string) + 'c' }}
+             else 'vllm-batch-' + dataset_name + '-' + (requested_cores | string) + 'c-' + hostvars['localhost']['test_run_id'] }}
 
     - name: Build benchmark command (sonnet dataset with file)
       ansible.builtin.set_fact:

--- a/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
+++ b/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
@@ -223,11 +223,28 @@
       ansible.builtin.debug:
         msg: "LD_PRELOAD={{ vllm_ld_preload | default('(not set - libomp not found in container)') }}"
 
+    - name: Detect NUMA topology on DUT
+      become: true
+      ansible.builtin.include_role:
+        name: common
+        tasks_from: detect-numa-topology
+
+    - name: Allocate cores from NUMA topology
+      become: true
+      ansible.builtin.include_role:
+        name: common
+        tasks_from: allocate-cores-from-count
+
+    - name: Set CPU pinning from NUMA allocation
+      ansible.builtin.set_fact:
+        _batch_cpuset_cpus: "{{ auto_core_config.cpuset_cpus }}"
+        _batch_cpuset_mems: "{{ auto_core_config.cpuset_mems }}"
+
     - name: Set effective container name for offline batch
       ansible.builtin.set_fact:
         _batch_container_name: >-
-          {{ vllm_container_name
-             if (vllm_container_name is defined and vllm_container_name != 'vllm-server')
+          {{ vllm_container_name_override
+             if (vllm_container_name_override is defined and vllm_container_name_override | length > 0)
              else 'vllm-batch-' + dataset_name + '-' + (requested_cores | string) + 'c' }}
 
     - name: Build benchmark command (sonnet dataset with file)
@@ -235,7 +252,8 @@
         benchmark_cmd: |
           podman run --rm --replace \
             --name {{ _batch_container_name }} \
-            --cpuset-cpus=0-{{ requested_cores | int - 1 }} \
+            --cpuset-cpus={{ _batch_cpuset_cpus }} \
+            --cpuset-mems={{ _batch_cpuset_mems }} \
             -v "{{ hostvars['localhost']['dut_cache_dir'] }}:/root/.cache/huggingface:z" \
             -v "{{ hostvars['localhost']['datasets_dir'] }}:/datasets:z" \
             {{ '-e LD_PRELOAD=' + vllm_ld_preload if vllm_ld_preload is defined else '' }} \
@@ -255,7 +273,8 @@
         benchmark_cmd: |
           podman run --rm --replace \
             --name {{ _batch_container_name }} \
-            --cpuset-cpus=0-{{ requested_cores | int - 1 }} \
+            --cpuset-cpus={{ _batch_cpuset_cpus }} \
+            --cpuset-mems={{ _batch_cpuset_mems }} \
             -v "{{ hostvars['localhost']['dut_cache_dir'] }}:/root/.cache/huggingface:z" \
             {{ '-e LD_PRELOAD=' + vllm_ld_preload if vllm_ld_preload is defined else '' }} \
             -e HF_TOKEN \
@@ -275,7 +294,8 @@
         benchmark_cmd: |
           podman run --rm --replace \
             --name {{ _batch_container_name }} \
-            --cpuset-cpus=0-{{ requested_cores | int - 1 }} \
+            --cpuset-cpus={{ _batch_cpuset_cpus }} \
+            --cpuset-mems={{ _batch_cpuset_mems }} \
             -v "{{ hostvars['localhost']['dut_cache_dir'] }}:/root/.cache/huggingface:z" \
             {{ '-e LD_PRELOAD=' + vllm_ld_preload if vllm_ld_preload is defined else '' }} \
             -e HF_HUB_OFFLINE=1 \

--- a/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
+++ b/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
@@ -243,8 +243,8 @@
     - name: Set effective container name for offline batch
       ansible.builtin.set_fact:
         _batch_container_name: >-
-          {{ vllm_container_name_override
-             if (vllm_container_name_override is defined and vllm_container_name_override | length > 0)
+          {{ vllm_container_name
+             if (vllm_container_name != 'vllm-server')
              else 'vllm-batch-' + dataset_name + '-' + (requested_cores | string) + 'c' }}
 
     - name: Build benchmark command (sonnet dataset with file)

--- a/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
+++ b/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
@@ -54,8 +54,8 @@
         cache_dir: "{{ lookup('env', 'HOME') }}/.cache/huggingface"
         datasets_dir: "{{ lookup('env', 'HOME') }}/datasets"
         results_base: "{{ playbook_dir }}/../../../results/llm"
-        test_run_id: "{{ lookup('pipe', 'date +%Y%m%d_%H%M%S') }}"
-        test_timestamp: "{{ lookup('pipe', 'date +%Y%m%d-%H%M%S') }}"
+        test_run_id: "{{ now(utc=true, fmt='%Y%m%d_%H%M%S_%f') }}"
+        test_timestamp: "{{ now(utc=true, fmt='%Y%m%d-%H%M%S-%f') }}"
 
     - name: Sanitize model name for filesystem
       ansible.builtin.set_fact:

--- a/automation/test-execution/ansible/roles/common/tasks/allocate-cores-from-count.yml
+++ b/automation/test-execution/ansible/roles/common/tasks/allocate-cores-from-count.yml
@@ -71,7 +71,7 @@
     - vllm_numa_nodes not in [None, ""]
   ansible.builtin.assert:
     that:
-      - vllm_numa_nodes | string | regex_search('^[0-9]+(,[0-9]+)*$') is not none
+      - vllm_numa_nodes | string | trim | regex_search('^[0-9]+(\s*,\s*[0-9]+)*$') is not none
     fail_msg: >-
       vllm_numa_nodes='{{ vllm_numa_nodes }}' is not a valid comma-separated list of
       non-negative integers (e.g. '0' or '0,1'). Negative values and non-integer
@@ -82,7 +82,7 @@
     - vllm_numa_nodes is defined
     - vllm_numa_nodes not in [None, ""]
   ansible.builtin.set_fact:
-    _vllm_node_ids: "{{ vllm_numa_nodes | string | split(',') | map('int') | list }}"
+    _vllm_node_ids: "{{ vllm_numa_nodes | string | split(',') | map('trim') | map('int') | list }}"
 
 - name: Validate vllm_numa_nodes produced non-empty node list
   when:

--- a/automation/test-execution/ansible/roles/common/tasks/allocate-cores-from-count.yml
+++ b/automation/test-execution/ansible/roles/common/tasks/allocate-cores-from-count.yml
@@ -55,9 +55,74 @@
     _vllm_cpu_start_value: "{{ vllm_cpu_start if (vllm_cpu_start is defined and vllm_cpu_start != omit and vllm_cpu_start != None and vllm_cpu_start != '') else None }}"
     _vllm_numa_node_value: "{{ vllm_numa_node if (vllm_numa_node is defined and vllm_numa_node != omit and vllm_numa_node != None and vllm_numa_node != '') else None }}"
 
+# vllm_numa_nodes (comma-separated, e.g. "0,1") allows pinning a single vLLM
+# instance to a specific subset of NUMA nodes for parallel multi-instance runs.
+# Takes precedence over vllm_numa_node (single int) when both are provided.
+
+# Reset on every include so stale facts from a previous include cannot leak
+# into subsequent calls that omit vllm_numa_nodes.
+- name: Reset NUMA filtering facts
+  ansible.builtin.set_fact:
+    _vllm_node_ids: "{{ [] }}"
+
+- name: Parse vllm_numa_nodes into node-id list
+  when:
+    - vllm_numa_nodes is defined
+    - vllm_numa_nodes not in [None, ""]
+  ansible.builtin.set_fact:
+    _vllm_node_ids: "{{ vllm_numa_nodes | string | regex_findall('[0-9]+') | map('int') | list }}"
+
+- name: Validate vllm_numa_nodes produced non-empty node list
+  when:
+    - vllm_numa_nodes is defined
+    - vllm_numa_nodes not in [None, ""]
+  ansible.builtin.assert:
+    that:
+      - _vllm_node_ids | length > 0
+    fail_msg: >-
+      vllm_numa_nodes='{{ vllm_numa_nodes }}' produced no valid node IDs.
+      Expected comma-separated integers, e.g. '0,1'.
+
+- name: Validate all vllm_numa_nodes IDs exist in NUMA topology
+  when:
+    - vllm_numa_nodes is defined
+    - vllm_numa_nodes not in [None, ""]
+    - _vllm_node_ids | length > 0
+  ansible.builtin.assert:
+    that:
+      - (_vllm_node_ids | difference(numa_topology.nodes | map(attribute='id') | list)) | length == 0
+    fail_msg: >-
+      vllm_numa_nodes contains node IDs not present in NUMA topology:
+      {{ _vllm_node_ids | difference(numa_topology.nodes | map(attribute='id') | list) | join(', ') }}.
+      Available NUMA node IDs: {{ numa_topology.nodes | map(attribute='id') | list | join(', ') }}
+
+# When vllm_numa_nodes is active the filtered topology drives NUMA selection;
+# clear _vllm_numa_node_value so socket-pinning mode is not also triggered.
+- name: Clear socket-pinning node override when vllm_numa_nodes takes precedence
+  when:
+    - vllm_numa_nodes is defined
+    - vllm_numa_nodes not in [None, ""]
+    - _vllm_node_ids | length > 0
+  ansible.builtin.set_fact:
+    _vllm_numa_node_value: ~
+
+- name: Build filtered NUMA topology for specified nodes
+  when: _vllm_node_ids | length > 0
+  ansible.builtin.set_fact:
+    _effective_topology: >-
+      {{ numa_topology | combine({
+           'nodes': numa_topology.nodes | selectattr('id', 'in', _vllm_node_ids) | list,
+           'node_count': numa_topology.nodes | selectattr('id', 'in', _vllm_node_ids) | list | length
+         }, recursive=true) }}
+
 - name: Allocate cores using multi-NUMA algorithm
   ansible.builtin.set_fact:
-    core_allocation_result: "{{ numa_topology | allocate_cores_multi_numa(requested_cores | int, _tensor_parallel_value, _vllm_cpu_start_value, _vllm_numa_node_value) }}"
+    core_allocation_result: >-
+      {{ (numa_topology if (_vllm_node_ids | length == 0) else _effective_topology)
+         | allocate_cores_multi_numa(requested_cores | int,
+                                     _tensor_parallel_value,
+                                     _vllm_cpu_start_value,
+                                     _vllm_numa_node_value) }}
 
 - name: Build auto-allocated core configuration
   ansible.builtin.set_fact:

--- a/automation/test-execution/ansible/roles/common/tasks/allocate-cores-from-count.yml
+++ b/automation/test-execution/ansible/roles/common/tasks/allocate-cores-from-count.yml
@@ -65,12 +65,24 @@
   ansible.builtin.set_fact:
     _vllm_node_ids: "{{ [] }}"
 
+- name: Validate vllm_numa_nodes format (comma-separated non-negative integers)
+  when:
+    - vllm_numa_nodes is defined
+    - vllm_numa_nodes not in [None, ""]
+  ansible.builtin.assert:
+    that:
+      - vllm_numa_nodes | string | regex_search('^[0-9]+(,[0-9]+)*$') is not none
+    fail_msg: >-
+      vllm_numa_nodes='{{ vllm_numa_nodes }}' is not a valid comma-separated list of
+      non-negative integers (e.g. '0' or '0,1'). Negative values and non-integer
+      tokens are not allowed.
+
 - name: Parse vllm_numa_nodes into node-id list
   when:
     - vllm_numa_nodes is defined
     - vllm_numa_nodes not in [None, ""]
   ansible.builtin.set_fact:
-    _vllm_node_ids: "{{ vllm_numa_nodes | string | regex_findall('[0-9]+') | map('int') | list }}"
+    _vllm_node_ids: "{{ vllm_numa_nodes | string | split(',') | map('int') | list }}"
 
 - name: Validate vllm_numa_nodes produced non-empty node list
   when:

--- a/automation/test-execution/ansible/tests/unit/test_cpu_utils.py
+++ b/automation/test-execution/ansible/tests/unit/test_cpu_utils.py
@@ -209,7 +209,7 @@ class TestExtractPrimaryCpus:
     def test_empty_input(self):
         """Test empty input returns empty string."""
         with pytest.raises(AnsibleFilterError) as exc_info:
-            extract_primary_cpus("",0)
+            extract_primary_cpus("", 0)
 
         error_msg = str(exc_info.value)
         assert "Invalid lscpu input" in error_msg
@@ -227,10 +227,15 @@ invalid line
 1 0 0
 2 0 1"""
         with pytest.raises(AnsibleFilterError) as exc_info:
-            extract_primary_cpus(lscpu_data,0)
+            extract_primary_cpus(lscpu_data, 0)
 
         error_msg = str(exc_info.value)
-        assert "Failed to parse lscpu data: Line 2: Expected 3 columns (CPU NODE CORE), got 2: 'invalid line'" in error_msg
+        expected = (
+            "Failed to parse lscpu data: Line 2: "
+            "Expected 3 columns (CPU NODE CORE), "
+            "got 2: 'invalid line'"
+        )
+        assert expected in error_msg
 
 
 @pytest.mark.unit
@@ -563,10 +568,12 @@ class TestMultiNumaAllocation:
         assert result['cores_per_node'] == [32, 32]
 
     def test_serialized_tp_ansible_unsafe_text(self):
-        """AnsibleUnsafeText requested_tp should be normalized and behave like auto-TP."""
+        """AnsibleUnsafeText requested_tp should be normalized
+        and behave like auto-TP."""
         topology = create_numa_topology(num_nodes=6, cores_per_node=32)
 
-        # Wrap requested_tp as AnsibleUnsafeText to exercise normalization logic
+        # Wrap requested_tp as AnsibleUnsafeText to exercise
+        # normalization logic
         unsafe_tp = AnsibleUnsafeText('2')
         result = allocate_cores_multi_numa(
             topology, requested_cores=64, requested_tp=unsafe_tp
@@ -626,6 +633,180 @@ class TestValidTpValues:
     def test_valid_tp_values_constant(self):
         """Verify VALID_TP_VALUES is correct."""
         assert VALID_TP_VALUES == [1, 2, 4, 8]
+
+
+@pytest.mark.unit
+class TestVllmNumaNodesFiltering:
+    """Test vllm_numa_nodes parsing and topology-filtering logic.
+
+    These tests simulate the Ansible tasks in allocate-cores-from-count.yml:
+      - Parse vllm_numa_nodes into node-id list  (regex_findall + map('int'))
+      - Validate non-empty and all IDs in topology
+      - Build filtered NUMA topology (selectattr + node_count)
+      - Allocate cores against the filtered topology
+      - Verify socket-pinning override is cleared when
+        vllm_numa_nodes is active
+    """
+
+    # ── helpers that mirror Ansible/Jinja2 expressions ──────────────────────
+
+    @staticmethod
+    def _parse_numa_nodes(value):
+        """Simulate: vllm_numa_nodes | string | regex_findall('[0-9]+')
+        | map('int') | list."""
+        import re
+        return [int(x) for x in re.findall(r'[0-9]+', str(value))]
+
+    @staticmethod
+    def _filter_topology(topology, node_ids):
+        """Simulate: numa_topology | combine(
+        {'nodes': ..., 'node_count': ...})."""
+        filtered = [n for n in topology['nodes'] if n['id'] in node_ids]
+        return {**topology, 'nodes': filtered, 'node_count': len(filtered)}
+
+    @staticmethod
+    def _missing_ids(topology, node_ids):
+        """Simulate: _vllm_node_ids | difference(
+        numa_topology.nodes | map('id') | list)."""
+        available = {n['id'] for n in topology['nodes']}
+        return [i for i in node_ids if i not in available]
+
+    # ── parsing ──────────────────────────────────────────────────────────────
+
+    def test_parse_comma_separated(self):
+        """'0,1' → [0, 1]."""
+        assert self._parse_numa_nodes("0,1") == [0, 1]
+
+    def test_parse_with_spaces(self):
+        """'0, 1' (with space) → [0, 1]; regex_findall handles whitespace."""
+        assert self._parse_numa_nodes("0, 1") == [0, 1]
+
+    def test_parse_single_node(self):
+        """'2' → [2]."""
+        assert self._parse_numa_nodes("2") == [2]
+
+    def test_parse_invalid_all_letters_returns_empty(self):
+        """'abc' produces no digit matches → empty list
+        (fails non-empty assert)."""
+        assert self._parse_numa_nodes("abc") == []
+
+    def test_parse_empty_string_returns_empty(self):
+        """Empty string produces no digit matches → empty list."""
+        assert self._parse_numa_nodes("") == []
+
+    # ── topology-id validation ───────────────────────────────────────────────
+
+    def test_all_ids_valid_no_missing(self):
+        """IDs that exist in topology → empty missing set."""
+        topology = create_numa_topology(num_nodes=6, cores_per_node=32)
+        node_ids = self._parse_numa_nodes("1,3")
+        assert self._missing_ids(topology, node_ids) == []
+
+    def test_unknown_id_detected_as_missing(self):
+        """ID 99 is not in a 6-node topology → appears in missing set."""
+        topology = create_numa_topology(num_nodes=6, cores_per_node=32)
+        node_ids = self._parse_numa_nodes("0,99")
+        assert self._missing_ids(topology, node_ids) == [99]
+
+    def test_all_ids_unknown_all_missing(self):
+        """All IDs outside topology → all appear in missing set."""
+        topology = create_numa_topology(num_nodes=3, cores_per_node=32)
+        node_ids = self._parse_numa_nodes("10,11")
+        assert set(self._missing_ids(topology, node_ids)) == {10, 11}
+
+    # ── stale-fact isolation ─────────────────────────────────────────────────
+
+    def test_reset_clears_stale_node_ids(self):
+        """Simulates 'Reset NUMA filtering facts' task:
+        _vllm_node_ids reset to []. A previous include may have
+        set node_ids = [0, 1]; after reset it must be [] so
+        subsequent includes that omit vllm_numa_nodes don't
+        inherit stale state."""
+        node_ids = [0, 1]    # stale from previous include
+        node_ids = []        # Reset NUMA filtering facts
+        assert node_ids == []
+
+    def test_allocation_without_vllm_numa_nodes_uses_full_topology(self):
+        """When _vllm_node_ids == [], the full topology is
+        passed to the allocator."""
+        topology = create_numa_topology(num_nodes=6, cores_per_node=32)
+        node_ids = []
+        # Simulate: (numa_topology if (_vllm_node_ids | length == 0)
+        #            else _effective_topology)
+        effective = (
+            topology if not node_ids
+            else self._filter_topology(topology, node_ids)
+        )
+        result = allocate_cores_multi_numa(effective, requested_cores=32)
+        # With a 6-node topology (node 0 reserved),
+        # single-node allocation uses node 1
+        assert result['allocated_nodes'] == [1]
+
+    # ── filtered topology construction ───────────────────────────────────────
+
+    def test_filtered_topology_node_count_matches_filter(self):
+        """node_count in the filtered topology equals
+        len(filtered nodes), not len(all ids)."""
+        topology = create_numa_topology(num_nodes=6, cores_per_node=32)
+        node_ids = self._parse_numa_nodes("1,3")
+        filtered = self._filter_topology(topology, node_ids)
+        assert filtered['node_count'] == 2
+        assert len(filtered['nodes']) == 2
+
+    def test_filtered_topology_contains_only_requested_nodes(self):
+        """Filtered topology nodes have IDs exactly
+        matching the requested subset."""
+        topology = create_numa_topology(num_nodes=6, cores_per_node=32)
+        node_ids = self._parse_numa_nodes("2,4")
+        filtered = self._filter_topology(topology, node_ids)
+        assert {n['id'] for n in filtered['nodes']} == {2, 4}
+
+    # ── allocation on filtered topology ─────────────────────────────────────
+
+    def test_allocation_on_two_node_subset(self):
+        """allocate_cores_multi_numa on a 2-node filtered
+        topology allocates to those nodes."""
+        topology = create_numa_topology(num_nodes=6, cores_per_node=32)
+        node_ids = self._parse_numa_nodes("1,3")
+        filtered = self._filter_topology(topology, node_ids)
+        result = allocate_cores_multi_numa(filtered, requested_cores=64)
+        assert set(result['allocated_nodes']) == {1, 3}
+        assert result['tensor_parallel'] == 2
+
+    def test_allocation_on_single_node_subset(self):
+        """Single-node filtered topology → TP=1, allocation on that node."""
+        topology = create_numa_topology(num_nodes=6, cores_per_node=32)
+        node_ids = self._parse_numa_nodes("2")
+        filtered = self._filter_topology(topology, node_ids)
+        result = allocate_cores_multi_numa(filtered, requested_cores=16)
+        assert result['allocated_nodes'] == [2]
+        assert result['tensor_parallel'] == 1
+
+    # ── socket-pinning precedence ────────────────────────────────────────────
+
+    def test_socket_pinning_cleared_when_vllm_numa_nodes_active(self):
+        """When vllm_numa_nodes is set and non-empty,
+        _vllm_numa_node_value is cleared to None. Simulates
+        'Clear socket-pinning node override when vllm_numa_nodes
+        takes precedence'."""
+        vllm_numa_node_value = 2      # previously set socket-pinning node
+        vllm_numa_nodes = "0,1"
+        node_ids = self._parse_numa_nodes(vllm_numa_nodes)
+        # Task runs when vllm_numa_nodes is defined, non-empty,
+        # and _vllm_node_ids | length > 0
+        if node_ids:
+            vllm_numa_node_value = None   # cleared
+        assert vllm_numa_node_value is None
+
+    def test_socket_pinning_not_cleared_when_vllm_numa_nodes_absent(self):
+        """When vllm_numa_nodes is absent (node_ids == []),
+        socket-pinning is not cleared."""
+        vllm_numa_node_value = 2
+        node_ids = []   # reset — vllm_numa_nodes was not provided
+        # Clearing task requires node_ids non-empty; skip if empty
+        if node_ids:
+            vllm_numa_node_value = None
+        assert vllm_numa_node_value == 2
 
 
 if __name__ == "__main__":

--- a/automation/test-execution/scripts/bash/run-audio-suite.sh
+++ b/automation/test-execution/scripts/bash/run-audio-suite.sh
@@ -176,6 +176,19 @@ for model in "${FINAL_MODELS[@]}"; do
                 "-e" '{"vllm_env_vars": {"VLLM_USE_V2_MODEL_RUNNER": "0"}}'
             )
 
+            # Parallel instance overrides — set env vars to run multiple instances
+            # simultaneously on the same host (each with its own container, port, NUMA nodes):
+            #   VLLM_CONTAINER_NAME=vllm-0 VLLM_PORT=8000 VLLM_NUMA_NODES="0,1" ./run-audio-suite.sh
+            if [[ -n "${VLLM_CONTAINER_NAME:-}" ]]; then
+                CMD+=(-e "vllm_container_name=${VLLM_CONTAINER_NAME}")
+            fi
+            if [[ -n "${VLLM_PORT:-}" ]]; then
+                CMD+=(-e "vllm_port=${VLLM_PORT}")
+            fi
+            if [[ -n "${VLLM_NUMA_NODES:-}" ]]; then
+                CMD+=(-e "vllm_numa_nodes=${VLLM_NUMA_NODES}")
+            fi
+
             if [[ "$DRY_RUN" == true ]]; then
                 echo "  DRY-RUN: ${CMD[*]}"
             else

--- a/automation/test-execution/scripts/bash/run-audio-suite.sh
+++ b/automation/test-execution/scripts/bash/run-audio-suite.sh
@@ -180,7 +180,7 @@ for model in "${FINAL_MODELS[@]}"; do
             # simultaneously on the same host (each with its own container, port, NUMA nodes):
             #   VLLM_CONTAINER_NAME=vllm-0 VLLM_PORT=8000 VLLM_NUMA_NODES="0,1" ./run-audio-suite.sh
             if [[ -n "${VLLM_CONTAINER_NAME:-}" ]]; then
-                CMD+=(-e "vllm_container_name=${VLLM_CONTAINER_NAME}")
+                CMD+=(-e "vllm_container_name_override=${VLLM_CONTAINER_NAME}")
             fi
             if [[ -n "${VLLM_PORT:-}" ]]; then
                 CMD+=(-e "vllm_port=${VLLM_PORT}")

--- a/automation/test-execution/scripts/bash/run-audio-suite.sh
+++ b/automation/test-execution/scripts/bash/run-audio-suite.sh
@@ -179,14 +179,18 @@ for model in "${FINAL_MODELS[@]}"; do
             # Parallel instance overrides — set env vars to run multiple instances
             # simultaneously on the same host (each with its own container, port, NUMA nodes):
             #   VLLM_CONTAINER_NAME=vllm-0 VLLM_PORT=8000 VLLM_NUMA_NODES="0,1" ./run-audio-suite.sh
+            # See README "VLLM_NUMA_NODE vs VLLM_NUMA_NODES" for the distinction between the two.
             if [[ -n "${VLLM_CONTAINER_NAME:-}" ]]; then
-                CMD+=(-e "vllm_container_name_override=${VLLM_CONTAINER_NAME}")
+                CMD+=(-e "vllm_container_name=${VLLM_CONTAINER_NAME}")
             fi
             if [[ -n "${VLLM_PORT:-}" ]]; then
                 CMD+=(-e "vllm_port=${VLLM_PORT}")
             fi
             if [[ -n "${VLLM_NUMA_NODES:-}" ]]; then
                 CMD+=(-e "vllm_numa_nodes=${VLLM_NUMA_NODES}")
+            fi
+            if [[ -n "${VLLM_NUMA_NODE:-}" ]]; then
+                CMD+=(-e "vllm_numa_node=${VLLM_NUMA_NODE}")
             fi
 
             if [[ "$DRY_RUN" == true ]]; then

--- a/automation/test-execution/scripts/bash/run-concurrent-load-suite.sh
+++ b/automation/test-execution/scripts/bash/run-concurrent-load-suite.sh
@@ -267,6 +267,19 @@ for model in "${FINAL_MODELS[@]}"; do
                 "-e" "skip_phase_3=$SKIP_PHASE_3"
             )
 
+            # Parallel instance overrides — set env vars to run multiple instances
+            # simultaneously on the same host (each with its own container, port, NUMA nodes):
+            #   VLLM_CONTAINER_NAME=vllm-0 VLLM_PORT=8000 VLLM_NUMA_NODES="0,1" ./run-concurrent-load-suite.sh
+            if [[ -n "${VLLM_CONTAINER_NAME:-}" ]]; then
+                CMD+=(-e "vllm_container_name=${VLLM_CONTAINER_NAME}")
+            fi
+            if [[ -n "${VLLM_PORT:-}" ]]; then
+                CMD+=(-e "vllm_port=${VLLM_PORT}")
+            fi
+            if [[ -n "${VLLM_NUMA_NODES:-}" ]]; then
+                CMD+=(-e "vllm_numa_nodes=${VLLM_NUMA_NODES}")
+            fi
+
             if [[ "$DRY_RUN" == true ]]; then
                 echo "  DRY-RUN: ${CMD[*]}"
             else

--- a/automation/test-execution/scripts/bash/run-embedding-suite.sh
+++ b/automation/test-execution/scripts/bash/run-embedding-suite.sh
@@ -311,6 +311,19 @@ for model in "${MODELS[@]}"; do
             -e "test_name=${TEST_NAME}"
         )
 
+        # Parallel instance overrides — set env vars to run multiple instances
+        # simultaneously on the same host (each with its own container, port, NUMA nodes):
+        #   VLLM_CONTAINER_NAME=vllm-0 VLLM_PORT=8000 VLLM_NUMA_NODES="0,1" ./run-embedding-suite.sh
+        if [[ -n "${VLLM_CONTAINER_NAME:-}" ]]; then
+            cmd+=(-e "vllm_container_name=${VLLM_CONTAINER_NAME}")
+        fi
+        if [[ -n "${VLLM_PORT:-}" ]]; then
+            cmd+=(-e "vllm_port=${VLLM_PORT}")
+        fi
+        if [[ -n "${VLLM_NUMA_NODES:-}" ]]; then
+            cmd+=(-e "vllm_numa_nodes=${VLLM_NUMA_NODES}")
+        fi
+
         if [[ "${DRY_RUN}" == true ]]; then
             log_info "DRY RUN: Would execute:"
             echo "  ${cmd[*]}"

--- a/automation/test-execution/scripts/bash/run-mteb-model-sweep.sh
+++ b/automation/test-execution/scripts/bash/run-mteb-model-sweep.sh
@@ -250,6 +250,19 @@ run_mteb_test() {
         cmd+=(-e "vllm_endpoint_url=${ENDPOINT_URL}")
     fi
 
+    # Parallel instance overrides — set env vars to run multiple instances
+    # simultaneously on the same host (each with its own container, port, NUMA nodes):
+    #   VLLM_CONTAINER_NAME=vllm-0 VLLM_PORT=8000 VLLM_NUMA_NODES="0,1" ./run-mteb-model-sweep.sh
+    if [[ -n "${VLLM_CONTAINER_NAME:-}" ]]; then
+        cmd+=(-e "vllm_container_name=${VLLM_CONTAINER_NAME}")
+    fi
+    if [[ -n "${VLLM_PORT:-}" ]]; then
+        cmd+=(-e "vllm_port=${VLLM_PORT}")
+    fi
+    if [[ -n "${VLLM_NUMA_NODES:-}" ]]; then
+        cmd+=(-e "vllm_numa_nodes=${VLLM_NUMA_NODES}")
+    fi
+
     # Add trust_remote_code only for models that require it
     if [[ "${model}" == *"nomic-embed-text"* ]]; then
         cmd+=(-e "trust_remote_code=true")

--- a/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
+++ b/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
@@ -203,7 +203,7 @@ run_ansible_with_timeout() {
     #   VLLM_CONTAINER_NAME=vllm-0 VLLM_PORT=8000 VLLM_NUMA_NODES="0,1" ./run-offline-batch-suite.sh use-cases
     local parallel_args=()
     if [[ -n "${VLLM_CONTAINER_NAME:-}" ]]; then
-        parallel_args+=(-e "vllm_container_name=${VLLM_CONTAINER_NAME}")
+        parallel_args+=(-e "vllm_container_name_override=${VLLM_CONTAINER_NAME}")
     fi
     if [[ -n "${VLLM_PORT:-}" ]]; then
         parallel_args+=(-e "vllm_port=${VLLM_PORT}")

--- a/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
+++ b/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
@@ -201,15 +201,19 @@ run_ansible_with_timeout() {
     # Parallel instance overrides — set env vars to run multiple instances
     # simultaneously on the same host (each with its own container, port, NUMA nodes):
     #   VLLM_CONTAINER_NAME=vllm-0 VLLM_PORT=8000 VLLM_NUMA_NODES="0,1" ./run-offline-batch-suite.sh use-cases
+    # See README "VLLM_NUMA_NODE vs VLLM_NUMA_NODES" for the distinction between the two.
     local parallel_args=()
     if [[ -n "${VLLM_CONTAINER_NAME:-}" ]]; then
-        parallel_args+=(-e "vllm_container_name_override=${VLLM_CONTAINER_NAME}")
+        parallel_args+=(-e "vllm_container_name=${VLLM_CONTAINER_NAME}")
     fi
     if [[ -n "${VLLM_PORT:-}" ]]; then
         parallel_args+=(-e "vllm_port=${VLLM_PORT}")
     fi
     if [[ -n "${VLLM_NUMA_NODES:-}" ]]; then
         parallel_args+=(-e "vllm_numa_nodes=${VLLM_NUMA_NODES}")
+    fi
+    if [[ -n "${VLLM_NUMA_NODE:-}" ]]; then
+        parallel_args+=(-e "vllm_numa_node=${VLLM_NUMA_NODE}")
     fi
 
     while [ $attempt -le $max_attempts ]; do

--- a/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
+++ b/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
@@ -198,6 +198,20 @@ run_ansible_with_timeout() {
     local attempt=1
     local max_attempts=$((MAX_RETRIES + 1))
 
+    # Parallel instance overrides — set env vars to run multiple instances
+    # simultaneously on the same host (each with its own container, port, NUMA nodes):
+    #   VLLM_CONTAINER_NAME=vllm-0 VLLM_PORT=8000 VLLM_NUMA_NODES="0,1" ./run-offline-batch-suite.sh use-cases
+    local parallel_args=()
+    if [[ -n "${VLLM_CONTAINER_NAME:-}" ]]; then
+        parallel_args+=(-e "vllm_container_name=${VLLM_CONTAINER_NAME}")
+    fi
+    if [[ -n "${VLLM_PORT:-}" ]]; then
+        parallel_args+=(-e "vllm_port=${VLLM_PORT}")
+    fi
+    if [[ -n "${VLLM_NUMA_NODES:-}" ]]; then
+        parallel_args+=(-e "vllm_numa_nodes=${VLLM_NUMA_NODES}")
+    fi
+
     while [ $attempt -le $max_attempts ]; do
         if [ -n "$TIMEOUT_CMD" ]; then
             echo -e "${BLUE}Attempt $attempt/$max_attempts (timeout: ${timeout_seconds}s)${NC}"
@@ -214,6 +228,7 @@ run_ansible_with_timeout() {
                 -e "num_prompts=$num_prompts" \
                 -e "requested_cores=$cores" \
                 -e "vllm_container_image=$VLLM_CONTAINER_IMAGE" \
+                "${parallel_args[@]}" \
                 "$@" || exit_code=$?
         else
             ansible-playbook -i "$INVENTORY" "$PLAYBOOK" \
@@ -222,6 +237,7 @@ run_ansible_with_timeout() {
                 -e "num_prompts=$num_prompts" \
                 -e "requested_cores=$cores" \
                 -e "vllm_container_image=$VLLM_CONTAINER_IMAGE" \
+                "${parallel_args[@]}" \
                 "$@" || exit_code=$?
         fi
 

--- a/automation/test-execution/scripts/bash/run-rhaiis-concurrent-load.sh
+++ b/automation/test-execution/scripts/bash/run-rhaiis-concurrent-load.sh
@@ -502,6 +502,15 @@ for model in "${MODELS[@]}"; do
             # Parallel instance overrides — set env vars to run multiple instances
             # simultaneously on the same host (each with its own container, port, NUMA nodes):
             #   VLLM_CONTAINER_NAME=vllm-0 VLLM_PORT=8000 VLLM_NUMA_NODES="0,1" ./run-rhaiis-concurrent-load.sh
+            #
+            # NOTE: Two separate NUMA variables serve different purposes:
+            #   VLLM_NUMA_NODE  (singular, --vllm-numa-node flag) — single-node socket pinning:
+            #                    start vLLM on the specified NUMA node for socket separation.
+            #   VLLM_NUMA_NODES (plural, this block) — comma-separated subset of NUMA nodes for
+            #                    parallel multi-instance runs, e.g. "0,1" pins one instance to
+            #                    nodes 0 and 1 while a second instance uses "2,3".
+            #   When both are set, VLLM_NUMA_NODES takes precedence (Ansible clears the
+            #   socket-pinning override when vllm_numa_nodes is active).
             if [[ -n "${VLLM_CONTAINER_NAME:-}" ]]; then
                 cmd+=(-e "vllm_container_name=${VLLM_CONTAINER_NAME}")
             fi

--- a/automation/test-execution/scripts/bash/run-rhaiis-concurrent-load.sh
+++ b/automation/test-execution/scripts/bash/run-rhaiis-concurrent-load.sh
@@ -499,6 +499,19 @@ for model in "${MODELS[@]}"; do
                 cmd+=(-e "guidellm_numa_node=${GUIDELLM_NUMA_NODE}")
             fi
 
+            # Parallel instance overrides — set env vars to run multiple instances
+            # simultaneously on the same host (each with its own container, port, NUMA nodes):
+            #   VLLM_CONTAINER_NAME=vllm-0 VLLM_PORT=8000 VLLM_NUMA_NODES="0,1" ./run-rhaiis-concurrent-load.sh
+            if [[ -n "${VLLM_CONTAINER_NAME:-}" ]]; then
+                cmd+=(-e "vllm_container_name=${VLLM_CONTAINER_NAME}")
+            fi
+            if [[ -n "${VLLM_PORT:-}" ]]; then
+                cmd+=(-e "vllm_port=${VLLM_PORT}")
+            fi
+            if [[ -n "${VLLM_NUMA_NODES:-}" ]]; then
+                cmd+=(-e "vllm_numa_nodes=${VLLM_NUMA_NODES}")
+            fi
+
             # Add phase skip flags
             if [[ "${SKIP_PHASE_1}" == true ]]; then
                 cmd+=(-e "skip_phase_1=true")


### PR DESCRIPTION
Allow multiple vLLM benchmark instances to run simultaneously on a single host by pinning each to a distinct subset of NUMA nodes via the new vllm_numa_nodes variable (comma-separated, e.g. "0,1").

Changes:
- allocate-cores-from-count.yml: reset _vllm_node_ids on every include to prevent stale facts leaking across re-includes; parse and validate vllm_numa_nodes; clear _vllm_numa_node_value when multi-node filtering is active; derive node_count from filtered topology length; use Jinja2 if/else short-circuit in the allocation call to avoid evaluating _effective_topology when no filtering is needed
- All bash suite scripts: forward VLLM_CONTAINER_NAME, VLLM_PORT, and VLLM_NUMA_NODES env vars as ansible-playbook -e overrides so callers can run concurrent instances without modifying inventory
- README.md: document parallel instance variables with example