### PR TITLE
Fix integer type error in health-check.yml retries calculation

### DIFF
--- a/automation/test-execution/ansible/health-check.yml
+++ b/automation/test-execution/ansible/health-check.yml
@@ -21,8 +21,8 @@
         method: GET
         status_code: 200
       register: health_check_result
-      retries: "{{ health_check.timeout // health_check.interval }}"
-      delay: "{{ health_check.interval }}"
+      retries: "{{ health_check.timeout | int // health_check.interval | int }}"
+      delay: "{{ health_check.interval | int }}"
       until: health_check_result.status == 200
 
     - name: Display vLLM server status


### PR DESCRIPTION
health_check.timeout is templated from an env lookup and arrives as AnsibleUnsafeText at evaluation time; the // operator requires both operands to be int. The role equivalent (vllm-health-check.yml) already used | int — apply the same fix to the standalone playbook.