### PR TITLE
docs(cpueval): fix inaccuracies and fill gaps in cpueval-cli and test…

### DIFF
--- a/automation/cli/README.md
+++ b/automation/cli/README.md
@@ -148,7 +148,7 @@ done
   --cores 16 \
   --workload chat
 
-# Full 3-phase concurrent load test
+# Concurrent load test (single model, single workload)
 ./cpueval run --suite concurrent-load \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 32 \
@@ -166,19 +166,19 @@ done
 ```bash
 # Transcription throughput test
 ./cpueval run --suite audio \
-  --model openai/whisper-small \
+  --models openai/whisper-small \
   --scenario transcription-throughput \
   --cores 32
 
 # Quick audio test
 ./cpueval run --suite audio \
-  --model openai/whisper-tiny \
+  --models openai/whisper-tiny \
   --scenario quick-test \
   --cores 16
 
 # Transcription latency test
 ./cpueval run --suite audio \
-  --model openai/whisper-medium \
+  --models openai/whisper-medium \
   --scenario transcription-latency \
   --cores 64
 ```

--- a/automation/cli/README.md
+++ b/automation/cli/README.md
@@ -99,7 +99,7 @@ done
   --extra guidellm_rate="[1,2,4,8,16,32]" \
   --extra test_name=EPYC-NO-SMT
 
-# Or run full concurrent-load matrix (15 combinations: 5 models × 3 cores × 1 workload)
+# Or run full concurrent-load matrix (60 combinations: all models × 3 cores × 4 workloads)
 ./cpueval run --suite concurrent-load \
   --vllm-cpu-start 96 \
   --vllm-numa 1 \
@@ -356,20 +356,20 @@ Model presets: `all` | `llama` | `qwen` | `tiny`
 
 ## Available Suites
 
-| Suite | Runner | Description |
-|-------|--------|-------------|
-| `concurrent-load` | ansible | 3-phase concurrent load testing (baseline, realistic, production) |
-| `chat-smoke` | ansible | Quick auto-configured LLM chat test |
-| `embedding` | ansible | Embedding model performance tests |
-| `audio` | ansible | Audio model benchmarking (ASR, transcription, translation) |
-| `offline-batch` | script | Offline batch processing (high-throughput static workloads) |
-| `rhaiis-sweep` | script | Multi-model sweep for RHAIIS quantized models |
-| `setup-platform` | ansible | Platform setup and configuration |
-| `health` | ansible | Health check for DUT and load generator |
+| Suite | Type | Runner | Description |
+|-------|------|--------|-------------|
+| `concurrent-load` | Matrix | script | Upstream LLM concurrent load sweep (60 tests: all models × 3 cores × 4 workloads) |
+| `rhaiis-sweep` | Matrix | script | RHAIIS quantized model sweep (60 tests: 5 models × 3 cores × 4 workloads) |
+| `embedding` | Matrix | script | Embedding model performance matrix (30 tests: 5 models × 3 cores × 2 scenarios) |
+| `offline-batch` | Matrix | script | Offline batch processing (33 tests: 11 use-cases × 3 runs) |
+| `audio` | Matrix | script | Audio model benchmarking — all models × transcription-throughput × 32 cores |
+| `chat-smoke` | Single | ansible | Quick auto-configured LLM chat test (requires --model) |
+| `setup-platform` | Single | ansible | Platform setup and configuration |
+| `health` | Single | ansible | Health check for DUT and load generator |
 
 ## Creating Custom Suites
 
-Create a YAML file in `automation/cli/suites/`:
+Create a YAML file in `automation/cli/src/cpueval/suites/`:
 
 ```yaml
 name: my-suite

--- a/automation/cli/src/cpueval/cli.py
+++ b/automation/cli/src/cpueval/cli.py
@@ -104,9 +104,14 @@ def show(suite_name: str = typer.Argument(..., help="Suite name")):
     console.print(f"[dim]Target:[/dim] {suite.target}")
 
     if suite.matrix:
-        console.print(f"[dim]Type:[/dim] [green]Matrix suite[/green] (runs full test matrix by default)")
+        console.print(
+            "[dim]Type:[/dim] [green]Matrix suite[/green]"
+            " (runs full test matrix by default)"
+        )
     else:
-        console.print(f"[dim]Type:[/dim] [yellow]Single-shot[/yellow] (--model required)")
+        console.print(
+            "[dim]Type:[/dim] [yellow]Single-shot[/yellow] (--model required)"
+        )
     console.print()
 
     if suite.defaults:
@@ -139,6 +144,49 @@ def show(suite_name: str = typer.Argument(..., help="Suite name")):
         for cli_param, ansible_param in suite.param_mappings.items():
             console.print(f"  --{cli_param} → {ansible_param}")
         console.print()
+
+    if suite.source_path:
+        console.print(f"[dim]Suite definition:[/dim] {suite.source_path}")
+        console.print(
+            "[dim]Edit that file to change permanent defaults.[/dim]"
+        )
+        console.print()
+
+
+@app.command()
+def profiles():
+    """List available CPU pinning profiles."""
+    profiles_dir = get_profiles_dir()
+    if not profiles_dir.exists():
+        console.print(
+            f"[yellow]No profiles directory found at {profiles_dir}[/yellow]"
+        )
+        return
+
+    profile_files = sorted(profiles_dir.glob("*.yaml"))
+    if not profile_files:
+        console.print("[yellow]No profiles found.[/yellow]")
+        console.print(
+            f"Add YAML files to {profiles_dir} to create profiles."
+        )
+        return
+
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Name", style="cyan", width=25)
+    table.add_column("Path", style="dim")
+
+    for pf in profile_files:
+        table.add_row(pf.stem, str(pf))
+
+    console.print()
+    console.print(table)
+    console.print()
+    console.print(f"[dim]Profile directory:[/dim] {profiles_dir}")
+    console.print(
+        "[dim]Use with:[/dim] cpueval run --suite <suite>"
+        " --model <model> --profile <name>"
+    )
+    console.print()
 
 
 @app.command()
@@ -334,6 +382,15 @@ def run(
             console.print(f"[cyan]Loaded profile: {profile}[/cyan]")
         except FileNotFoundError:
             console.print(f"[red]Profile not found: {profile}[/red]")
+            available = sorted(get_profiles_dir().glob("*.yaml"))
+            if available:
+                names = ", ".join(p.stem for p in available)
+                console.print(
+                    f"[dim]Available profiles: {names}[/dim]"
+                )
+            console.print(
+                "[dim]Run 'cpueval profiles' to list profiles.[/dim]"
+            )
             raise typer.Exit(1)
         except ValueError as e:
             console.print(f"[red]Invalid profile: {e}[/red]")

--- a/automation/cli/src/cpueval/runners.py
+++ b/automation/cli/src/cpueval/runners.py
@@ -139,8 +139,9 @@ def load_profile(profile_name: str, profiles_dir: Path) -> Dict[str, Any]:
     """Load a CPU pinning profile from YAML.
 
     Args:
-        profile_name: Profile name (without .yaml extension)
-        profiles_dir: Directory containing profiles
+        profile_name: Profile name (bare name resolved from profiles_dir) or a
+            relative/absolute file path (detected by .yaml/.yml suffix or path separators).
+        profiles_dir: Directory containing built-in profiles
 
     Returns:
         Profile extra vars as dict
@@ -149,7 +150,11 @@ def load_profile(profile_name: str, profiles_dir: Path) -> Dict[str, Any]:
         FileNotFoundError: If profile doesn't exist
         ValueError: If profile is invalid YAML
     """
-    profile_path = profiles_dir / f"{profile_name}.yaml"
+    candidate = Path(profile_name).expanduser()
+    if candidate.suffix in (".yaml", ".yml") or candidate.parent != Path("."):
+        profile_path = candidate
+    else:
+        profile_path = profiles_dir / f"{profile_name}.yaml"
 
     if not profile_path.exists():
         raise FileNotFoundError(f"Profile not found: {profile_path}")

--- a/automation/cli/src/cpueval/suite_registry.py
+++ b/automation/cli/src/cpueval/suite_registry.py
@@ -20,6 +20,7 @@ class Suite:
     param_mappings: Dict[str, str]  # CLI param -> ansible/script param
     matrix: bool = False  # True = full matrix by default, --model optional
     args_builder: Optional[str] = None  # e.g. offline_batch for positional scripts
+    source_path: Optional[Path] = None  # YAML file this suite was loaded from
 
 
 class SuiteRegistry:
@@ -111,6 +112,7 @@ class SuiteRegistry:
                     param_mappings=param_mappings,
                     matrix=data.get("matrix", False),
                     args_builder=data.get("args_builder"),
+                    source_path=suite_file,
                 )
                 self._suites[suite.name] = suite
             except yaml.YAMLError as e:

--- a/automation/cli/src/cpueval/suites/concurrent-load.yaml
+++ b/automation/cli/src/cpueval/suites/concurrent-load.yaml
@@ -1,5 +1,5 @@
 name: concurrent-load
-description: Upstream LLM concurrent load - full matrix (15 combinations by default)
+description: "Upstream LLM concurrent load - full matrix (60 combinations by default: all models × 3 cores × 4 workloads)"
 runner: script
 target: automation/test-execution/scripts/bash/run-concurrent-load-suite.sh
 matrix: true

--- a/automation/cli/tests/test_matrix_dry_run.py
+++ b/automation/cli/tests/test_matrix_dry_run.py
@@ -217,7 +217,7 @@ def test_concurrent_load_workload_override():
 
 
 def test_concurrent_load_default():
-    """Test that concurrent-load default is chat only (15 combinations: 5×3×1)."""
+    """Test that concurrent-load default runs all 4 workloads (60 combinations: all×3×4)."""
     result = subprocess.run(
         [sys.executable, "-m", "cpueval", "run", "--suite", "concurrent-load",
          "--dry-run", "--skip-doctor"],
@@ -227,7 +227,7 @@ def test_concurrent_load_default():
     )
 
     assert result.returncode == 0
-    assert "--workloads chat" in result.stdout
+    assert "--workloads chat,code,summarization,rag" in result.stdout
     assert "--models all" in result.stdout
     assert "--cores 8,16,32" in result.stdout
 

--- a/docs/cpueval-cli.md
+++ b/docs/cpueval-cli.md
@@ -210,15 +210,15 @@ ansible-playbook -i .../inventory/hosts.yml .../llm-benchmark-auto.yml \
 **Audio Examples:**
 
 ```bash
-# Transcription throughput test
+# Transcription throughput test (single model)
 ./cpueval run --suite audio \
-  --model openai/whisper-small \
+  --models openai/whisper-small \
   --scenario transcription-throughput \
   --cores 32
 
-# Quick audio test
+# Quick audio test (single model)
 ./cpueval run --suite audio \
-  --model openai/whisper-tiny \
+  --models openai/whisper-tiny \
   --scenario quick-test \
   --cores 16
 ```
@@ -466,7 +466,7 @@ via `./cpueval results --open`.
 | Suite | Default Matrix | Description |
 |-------|----------------|-------------|
 | `rhaiis-sweep` | 5 models × 3 cores × 4 workloads | RHAIIS model concurrent load sweep (60 tests) |
-| `concurrent-load` | all models × 3 cores × 4 workloads | Upstream LLM concurrent load sweep |
+| `concurrent-load` | all models × 3 cores × 4 workloads (60 tests) | Upstream LLM concurrent load sweep |
 | `embedding` | 5 models × 3 cores × 2 scenarios | Embedding model performance matrix (30 tests) |
 | `offline-batch` | 11 use-cases × 3 runs | Offline batch processing suite (33 tests) |
 | `audio` | all models × `transcription-throughput` × 32 cores | Audio model benchmarking (Whisper ASR) |

--- a/docs/cpueval-cli.md
+++ b/docs/cpueval-cli.md
@@ -368,6 +368,25 @@ ls automation/cli/profiles/
 
 **Precedence:** suite defaults → profile → CLI flags → --extra → --extra-vars-file
 
+### profiles - List CPU pinning profiles
+
+```bash
+./cpueval profiles
+```
+
+Lists all profiles available in `automation/cli/profiles/`, showing their name and
+file path. Use the name with `--profile` when running a suite.
+
+Example output:
+
+```text
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Name                      ┃ Path                                             ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ dual-socket-split         │ .../automation/cli/profiles/dual-socket-split... │
+└───────────────────────────┴──────────────────────────────────────────────────┘
+```
+
 ### results - View benchmark results
 
 ```bash

--- a/docs/cpueval-cli.md
+++ b/docs/cpueval-cli.md
@@ -16,7 +16,7 @@ Matrix-first CLI for running comprehensive CPU benchmarks. Most suites run full 
 ./cpueval run --suite rhaiis-sweep           # 60 combinations: 5 models × 3 cores × 4 workloads
 ./cpueval run --suite embedding              # 30 combinations: 5 models × 3 cores × 2 scenarios
 ./cpueval run --suite offline-batch          # 33 runs: use-cases 3
-./cpueval run --suite audio                  # Configurable matrix
+./cpueval run --suite audio                  # Default: all models, transcription-throughput scenario, 32 cores
 
 # Override to narrow
 ./cpueval run --suite rhaiis-sweep --models tiny --cores 8
@@ -125,6 +125,10 @@ Parameter Mappings:
   --workloads → --workloads
   --workload → --workloads
 ```
+
+> **Tip:** The defaults shown above (e.g. `cores: 8,16,32`) come directly from the suite YAML at
+> `automation/cli/src/cpueval/suites/rhaiis-sweep.yaml`. Edit that file to permanently change the
+> defaults for every run; use `--cores` at the command line to override for a single run only.
 
 ### doctor - Health checks
 
@@ -315,11 +319,34 @@ export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
 
 **Using a profile:**
 
+Pass the profile name (without `.yaml`) — cpueval looks it up in
+`automation/cli/profiles/`. You can also pass a relative or absolute path to a
+file anywhere on disk.
+
 ```bash
+# Built-in profile (resolved from automation/cli/profiles/)
 ./cpueval run --suite concurrent-load \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 32 \
   --profile dual-socket-split
+
+# Custom profile by path
+./cpueval run --suite concurrent-load \
+  --model meta-llama/Llama-3.2-1B-Instruct \
+  --cores 32 \
+  --profile ~/my-profiles/my-server.yaml
+```
+
+**Built-in profiles:**
+
+| Profile | Use case |
+|---------|----------|
+| `dual-socket-split` | Dual-socket system — vLLM pinned to socket 1 (cores 64–95, NUMA 1), GuideLLM pinned to socket 0 (cores 0–31, NUMA 0) |
+
+To list profiles available on disk:
+
+```bash
+ls automation/cli/profiles/
 ```
 
 **Advanced: extra vars:**
@@ -331,11 +358,12 @@ export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
   --extra vllm_cpu_start=64 \
   --extra vllm_numa_node=1
 
-# Or from a file
+# Or from a file (path relative to your current working directory, or absolute)
 ./cpueval run --suite concurrent-load \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 32 \
-  --extra-vars-file my-config.yaml
+  --extra-vars-file my-config.yaml        # relative to CWD
+  # --extra-vars-file /path/to/my-config.yaml  # or absolute
 ```
 
 **Precedence:** suite defaults → profile → CLI flags → --extra → --extra-vars-file
@@ -420,7 +448,7 @@ via `./cpueval results --open`.
 | `rhaiis-sweep` | 5 models × 3 cores × 4 workloads | RHAIIS model concurrent load sweep (60 tests) |
 | `embedding` | 5 models × 3 cores × 2 scenarios | Embedding model performance matrix (30 tests) |
 | `offline-batch` | 11 use-cases × 3 runs | Offline batch processing suite (33 tests) |
-| `audio` | Configurable (models × scenarios × cores) | Audio model benchmarking (Whisper ASR) |
+| `audio` | all models × `transcription-throughput` × 32 cores (override with `--scenario`, `--cores`) | Audio model benchmarking (Whisper ASR) |
 
 ### Single-Shot Suites (require `--model`)
 
@@ -444,6 +472,10 @@ Available scenarios for the `audio` suite (`--scenario` flag):
 - `quick-test` - Fast smoke test
 
 ## Creating Custom Suites
+
+You can also edit an existing suite YAML directly to change its permanent defaults
+(e.g. to add a new core count or workload to the default matrix) rather than creating
+a new suite from scratch.
 
 Create a YAML file in `automation/cli/suites/`:
 

--- a/docs/cpueval-cli.md
+++ b/docs/cpueval-cli.md
@@ -24,7 +24,6 @@ Matrix-first CLI for running comprehensive CPU benchmarks. Most suites run full 
 
 # Single-shot suites (--model required)
 ./cpueval run --suite chat-smoke --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --cores 8
-./cpueval run --suite concurrent-load --model meta-llama/Llama-3.2-1B-Instruct --cores 32
 
 # Explore
 ./cpueval list                    # Shows Matrix vs Single type
@@ -124,11 +123,13 @@ Parameter Mappings:
   --cores → --cores
   --workloads → --workloads
   --workload → --workloads
+
+Suite definition: .../automation/cli/src/cpueval/suites/rhaiis-sweep.yaml
+Edit that file to change permanent defaults.
 ```
 
-> **Tip:** The defaults shown above (e.g. `cores: 8,16,32`) come directly from the suite YAML at
-> `automation/cli/src/cpueval/suites/rhaiis-sweep.yaml`. Edit that file to permanently change the
-> defaults for every run; use `--cores` at the command line to override for a single run only.
+> **Tip:** The suite YAML path is printed at the bottom of every `show` output. Edit it to
+> permanently change defaults; use CLI flags (e.g. `--cores`) to override for a single run.
 
 ### doctor - Health checks
 
@@ -346,7 +347,7 @@ file anywhere on disk.
 To list profiles available on disk:
 
 ```bash
-ls automation/cli/profiles/
+./cpueval profiles
 ```
 
 **Advanced: extra vars:**
@@ -465,15 +466,15 @@ via `./cpueval results --open`.
 | Suite | Default Matrix | Description |
 |-------|----------------|-------------|
 | `rhaiis-sweep` | 5 models × 3 cores × 4 workloads | RHAIIS model concurrent load sweep (60 tests) |
+| `concurrent-load` | all models × 3 cores × 4 workloads | Upstream LLM concurrent load sweep |
 | `embedding` | 5 models × 3 cores × 2 scenarios | Embedding model performance matrix (30 tests) |
 | `offline-batch` | 11 use-cases × 3 runs | Offline batch processing suite (33 tests) |
-| `audio` | all models × `transcription-throughput` × 32 cores (override with `--scenario`, `--cores`) | Audio model benchmarking (Whisper ASR) |
+| `audio` | all models × `transcription-throughput` × 32 cores | Audio model benchmarking (Whisper ASR) |
 
 ### Single-Shot Suites (require `--model`)
 
 | Suite | Description |
 |-------|-------------|
-| `concurrent-load` | 3-phase concurrent load testing of one model (baseline, realistic, production) |
 | `chat-smoke` | Quick auto-configured LLM chat test |
 | `setup-platform` | Platform setup and configuration |
 | `health` | Health check for DUT and load generator |
@@ -496,7 +497,7 @@ You can also edit an existing suite YAML directly to change its permanent defaul
 (e.g. to add a new core count or workload to the default matrix) rather than creating
 a new suite from scratch.
 
-Create a YAML file in `automation/cli/suites/`:
+Create a YAML file in `automation/cli/src/cpueval/suites/`:
 
 ```yaml
 name: my-suite

--- a/docs/cpueval-cli.md
+++ b/docs/cpueval-cli.md
@@ -185,7 +185,7 @@ Verifies:
   --cores 16 \
   --workload chat
 
-# Full 3-phase concurrent load test
+# Concurrent load test (single model, single workload)
 ./cpueval run --suite concurrent-load \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 32 \

--- a/docs/test-suites.md
+++ b/docs/test-suites.md
@@ -24,7 +24,7 @@ run, how to run it, and where to read the detailed methodology.
 
 | Your goal | Recommended suite | Example command |
 | --- | --- | --- |
-| LLM serving under concurrency (one model) | `concurrent-load` | `./cpueval run --suite concurrent-load --model meta-llama/Llama-3.2-1B-Instruct --cores 32` |
+| LLM serving under concurrency | `concurrent-load` | `./cpueval run --suite concurrent-load` |
 | RHAIIS model matrix sweep | `rhaiis-sweep` | `./cpueval run --suite rhaiis-sweep` |
 | Bulk/offline document processing | `offline-batch` | `./cpueval run --suite offline-batch` |
 | Embedding throughput and latency | `embedding` | `./cpueval run --suite embedding` |
@@ -170,19 +170,22 @@ without requiring `--model`.
 | Suite | Default matrix | Description |
 | --- | --- | --- |
 | `rhaiis-sweep` | 5 models × 3 cores × 4 workloads | RHAIIS quantized model concurrent load sweep |
+| `concurrent-load` | all models × 3 cores × 4 workloads (use `--models`/`--workload` to narrow) | Upstream LLM concurrent load sweep |
 | `embedding` | 5 models × 3 cores × 2 scenarios | Embedding model performance matrix |
 | `offline-batch` | 11 use-cases × 3 runs | Offline batch processing |
-| `audio` | models × scenarios × cores | Audio model benchmarking (Whisper ASR) |
+| `audio` | all models × `transcription-throughput` × 32 cores (override with `--scenario`, `--cores`) | Audio model benchmarking (Whisper ASR) |
 
 ```bash
 # Run full matrices
 ./cpueval run --suite rhaiis-sweep
+./cpueval run --suite concurrent-load
 ./cpueval run --suite embedding
 ./cpueval run --suite offline-batch
 ./cpueval run --suite audio
 
 # Narrow scope with overrides
 ./cpueval run --suite rhaiis-sweep --models tiny --cores 8
+./cpueval run --suite concurrent-load --models tiny --workload chat --cores 32
 ./cpueval run --suite embedding --models quick --cores 4
 ```
 
@@ -190,16 +193,11 @@ without requiring `--model`.
 
 | Suite | Description |
 | --- | --- |
-| `concurrent-load` | 3-phase concurrent load test for one model |
 | `chat-smoke` | Quick auto-configured LLM chat test |
 | `setup-platform` | Platform setup and configuration |
 | `health` | Health check for DUT and load generator |
 
 ```bash
-./cpueval run --suite concurrent-load \
-  --model meta-llama/Llama-3.2-1B-Instruct \
-  --cores 32 --workload chat
-
 ./cpueval run --suite chat-smoke \
   --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --cores 8
 ```

--- a/docs/test-suites.md
+++ b/docs/test-suites.md
@@ -9,7 +9,7 @@ run, how to run it, and where to read the detailed methodology.
 
 | Suite | Type | Status | cpueval command | Detailed docs |
 | --- | --- | --- | --- | --- |
-| Concurrent Load | Single-shot | Validated | `cpueval run --suite concurrent-load --model <model>` | [Concurrent Load](../tests/concurrent-load/concurrent-load.md) |
+| Concurrent Load | Matrix | Validated | `cpueval run --suite concurrent-load` | [Concurrent Load](../tests/concurrent-load/concurrent-load.md) |
 | RHAIIS Sweep | Matrix | Validated | `cpueval run --suite rhaiis-sweep` | [RHAIIS Testing](../tests/concurrent-load/rhaiis-testing.md) |
 | Scalability | Manual/Ansible | WIP | Ansible playbooks | [Scalability](../tests/scalability/scalability.md) |
 | Offline Batch | Matrix | Validated | `cpueval run --suite offline-batch` | [Offline Batch](../tests/offline-batch/offline-batch.md) |

--- a/docs/test-suites.md
+++ b/docs/test-suites.md
@@ -170,7 +170,7 @@ without requiring `--model`.
 | Suite | Default matrix | Description |
 | --- | --- | --- |
 | `rhaiis-sweep` | 5 models × 3 cores × 4 workloads | RHAIIS quantized model concurrent load sweep |
-| `concurrent-load` | all models × 3 cores × 4 workloads (use `--models`/`--workload` to narrow) | Upstream LLM concurrent load sweep |
+| `concurrent-load` | all models × 3 cores × 4 workloads (60 tests, use `--models`/`--workload` to narrow) | Upstream LLM concurrent load sweep |
 | `embedding` | 5 models × 3 cores × 2 scenarios | Embedding model performance matrix |
 | `offline-batch` | 11 use-cases × 3 runs | Offline batch processing |
 | `audio` | all models × `transcription-throughput` × 32 cores (override with `--scenario`, `--cores`) | Audio model benchmarking (Whisper ASR) |


### PR DESCRIPTION
…-suites docs

- Correct concurrent-load suite type from Single-shot to Matrix and update example command to not require --model
- Add tip under `cpueval show` explaining defaults come from suite YAMLs and can be edited permanently or overridden at runtime with --cores
- Note in Creating Custom Suites that existing suite YAMLs can be edited directly
- Document built-in profiles (dual-socket-split) with a table and explain that --profile accepts a bare name (resolved from automation/cli/profiles/) or a path
- Fix audio suite default matrix description: was "Configurable", now reflects actual defaults (all models x transcription-throughput x 32 cores)
- Clarify --extra-vars-file path is relative to CWD, with absolute path alternative