### PR TITLE
Hotfix embedding

### DIFF
--- a/automation/test-execution/ansible/roles/benchmark_embedding/tasks/baseline.yml
+++ b/automation/test-execution/ansible/roles/benchmark_embedding/tasks/baseline.yml
@@ -14,6 +14,7 @@
     num_prompts: "{{ benchmark_tool.vllm_bench.num_prompts | default(250) }}"
     vllm_bench_cpuset_cpus: "{{ vllm_bench_cpus | default(benchmark_tool.vllm_bench.cpuset_cpus | default('')) }}"
     vllm_bench_cpuset_mems: "{{ vllm_bench_numa_node | default(benchmark_tool.vllm_bench.cpuset_mems | default('')) }}"
+    vllm_bench_max_seconds: "{{ guidellm_max_seconds | default(300) | int }}"
 
 - name: Validate NUMA pinning configuration
   ansible.builtin.assert:
@@ -167,10 +168,12 @@
       - "Maximum RPS achieved: {{ max_rps }}"
       - "Planned load tests: {{ baseline_load_percentages | join('%, ') }}%"
       - "{{ planned_rates | map(attribute='percent') | zip(planned_rates | map(attribute='rate')) | map('join', '% = ') | map('regex_replace', '^(.*)$', '  \\1 req/s') | list }}"
+      - "Time limit per test: {{ vllm_bench_max_seconds }}s (num_prompts capped to rate × time_limit, min 20)"
 
 - name: "Baseline Test - Run at each load percentage"
   ansible.builtin.command:
     cmd: >
+      timeout {{ (vllm_bench_max_seconds | int) * 2 }}
       {{ vllm_bench_prefix }}
       --host {{ bench_config.vllm_host }}
       --port {{ bench_config.vllm_port }}
@@ -178,7 +181,7 @@
       --model "{{ model_name }}"
       --dataset-name random
       --random-input-len {{ embedding_random_input_len | default(512) }}
-      --num-prompts {{ num_prompts }}
+      --num-prompts {{ [[((vllm_bench_max_seconds | int) * ((max_rps | float) * (item | float / 100))) | round | int, 20] | max, num_prompts | int] | min }}
       --request-rate {{ ((max_rps | float) * (item | float / 100)) | round(2) }}
       --endpoint /v1/embeddings
       --save-result

--- a/automation/test-execution/ansible/roles/benchmark_embedding/tasks/baseline.yml
+++ b/automation/test-execution/ansible/roles/benchmark_embedding/tasks/baseline.yml
@@ -64,6 +64,7 @@
 - name: "Baseline Test - Find Maximum Throughput (inf rate)"
   ansible.builtin.command:
     cmd: >
+      timeout {{ (vllm_bench_max_seconds | int) * 2 }}
       {{ vllm_bench_prefix }}
       --host {{ bench_config.vllm_host }}
       --port {{ bench_config.vllm_port }}

--- a/automation/test-execution/ansible/roles/benchmark_embedding/tasks/latency.yml
+++ b/automation/test-execution/ansible/roles/benchmark_embedding/tasks/latency.yml
@@ -14,6 +14,7 @@
     num_prompts: "{{ benchmark_tool.vllm_bench.num_prompts | default(250) }}"
     vllm_bench_cpuset_cpus: "{{ vllm_bench_cpus | default(benchmark_tool.vllm_bench.cpuset_cpus | default('')) }}"
     vllm_bench_cpuset_mems: "{{ vllm_bench_numa_node | default(benchmark_tool.vllm_bench.cpuset_mems | default('')) }}"
+    vllm_bench_max_seconds: "{{ guidellm_max_seconds | default(300) | int }}"
 
 - name: Validate NUMA pinning configuration
   ansible.builtin.assert:
@@ -67,6 +68,7 @@
 - name: "Latency Test - Run at each concurrency level"
   ansible.builtin.command:
     cmd: >
+      timeout {{ (vllm_bench_max_seconds | int) * 2 }}
       {{ vllm_bench_prefix }}
       --host {{ bench_config.vllm_host }}
       --port {{ bench_config.vllm_port }}

--- a/automation/test-execution/scripts/bash/run-embedding-suite.sh
+++ b/automation/test-execution/scripts/bash/run-embedding-suite.sh
@@ -231,6 +231,13 @@ if [[ ${#SKIP_MODELS[@]} -gt 0 ]]; then
     MODELS=("${FILTERED_MODELS[@]}")
 fi
 
+# Validate max-seconds
+if [[ -n "${MAX_SECONDS}" && ! "${MAX_SECONDS}" =~ ^[0-9]+$ ]]; then
+    log_error "Invalid --max-seconds value: ${MAX_SECONDS}"
+    log_error "Must be a positive integer (seconds)"
+    exit 1
+fi
+
 # Validate scenario
 if [[ ! "${SCENARIO}" =~ ^(baseline|latency|all)$ ]]; then
     log_error "Invalid scenario: ${SCENARIO}"

--- a/automation/test-execution/scripts/bash/run-embedding-suite.sh
+++ b/automation/test-execution/scripts/bash/run-embedding-suite.sh
@@ -16,6 +16,8 @@
 #                           Default: all
 #   --num-prompts NUM       Number of prompts per test
 #                           Default: 250
+#   --max-seconds SEC       Per-test time limit in seconds; sets guidellm_max_seconds
+#                           Default: Ansible default (300s); env var GUIDELLM_MAX_SECONDS also accepted
 #   --skip-models LIST      Comma-separated models to skip
 #   --continue-on-error     Continue testing if a model fails
 #   --dry-run               Show what would run without executing
@@ -47,6 +49,10 @@
 #
 #   # Baseline tests only on 16 cores
 #   ./run-embedding-suite.sh --scenario baseline --cores 16
+#
+#   # Increase per-test time limit for slow models (e.g. Qwen3-Embedding-8B)
+#   ./run-embedding-suite.sh --models large --max-seconds 600
+#   GUIDELLM_MAX_SECONDS=600 ./run-embedding-suite.sh --models large
 #
 # ==============================================================================
 
@@ -107,6 +113,7 @@ MODELS_INPUT="all"
 CORES_INPUT="4,8,16,32"
 SCENARIO="all"
 NUM_PROMPTS=250
+MAX_SECONDS="${GUIDELLM_MAX_SECONDS:-}"
 CONTINUE_ON_ERROR=false
 DRY_RUN=false
 SKIP_MODELS_INPUT=""
@@ -144,6 +151,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --num-prompts)
             NUM_PROMPTS="$2"
+            shift 2
+            ;;
+        --max-seconds)
+            MAX_SECONDS="$2"
             shift 2
             ;;
         --skip-models)
@@ -251,6 +262,7 @@ echo ""
 echo "Core counts: ${CORE_COUNTS[*]}"
 echo "Scenario: ${SCENARIO}"
 echo "Prompts per test: ${NUM_PROMPTS}"
+echo "Time limit: ${MAX_SECONDS:-300 (Ansible default)}s"
 echo "Continue on error: ${CONTINUE_ON_ERROR}"
 echo "Dry run: ${DRY_RUN}"
 echo "=========================================="
@@ -310,6 +322,8 @@ for model in "${MODELS[@]}"; do
             -e "num_prompts=${NUM_PROMPTS}"
             -e "test_name=${TEST_NAME}"
         )
+
+        [[ -n "${MAX_SECONDS}" ]] && cmd+=(-e "guidellm_max_seconds=${MAX_SECONDS}")
 
         # Parallel instance overrides — set env vars to run multiple instances
         # simultaneously on the same host (each with its own container, port, NUMA nodes):

--- a/docs/embedding-models.md
+++ b/docs/embedding-models.md
@@ -288,6 +288,33 @@ Files are generated as `sweep-{percentage}pct.json` (e.g., `sweep-10pct.json`, `
 
 ## Benchmark Parameters
 
+### Per-Test Time Limit (`guidellm_max_seconds`)
+
+Embedding benchmarks resolve `guidellm_max_seconds` as `vllm_bench_max_seconds` inside the
+`benchmark_embedding` Ansible role. It controls two things:
+
+| What it affects | How |
+|---|---|
+| Hang guard | `timeout 2 × guidellm_max_seconds` wraps every `vllm-bench` command |
+| Load-% `--num-prompts` cap | `min(num_prompts, max(20, rate × guidellm_max_seconds))` — prevents low-throughput models from running far longer than the time limit |
+
+**Default: 300 seconds** (GuideLLM LLM tests default to 600 s; embedding uses 300 s intentionally for shorter runs).
+
+```bash
+# One-off override via ansible-playbook
+ansible-playbook -i inventory/hosts.yml embedding-benchmark.yml \
+  -e "test_model=RedHatAI/Qwen3-Embedding-8B" \
+  -e "guidellm_max_seconds=600"
+
+# Via run-embedding-suite.sh flag
+./run-embedding-suite.sh --max-seconds 600
+
+# Via environment variable (picked up by run-embedding-suite.sh)
+GUIDELLM_MAX_SECONDS=600 ./run-embedding-suite.sh --models large
+```
+
+### Other Parameters
+
 Override default benchmark settings:
 
 ```bash


### PR DESCRIPTION
## Summary
- Cap embedding baseline load-% \`num_prompts\` to \`rate × max_seconds\` so low-throughput models don't hang (e.g. 0.68 RPS at 25% load: ~24 min → ~5 min per point)
- Add \`timeout 2× max_seconds\` on all embedding \`vllm-bench\` steps (inf-rate, load sweeps, latency)
- Document \`guidellm_max_seconds\`; wire via \`run-embedding-suite.sh --max-seconds\` / \`GUIDELLM_MAX_SECONDS\`

## Configuration
- Per-test time limit: \`guidellm_max_seconds\` (default **300s** for embedding)
- Override: \`-e guidellm_max_seconds=600\`, \`--max-seconds 600\`, or \`GUIDELLM_MAX_SECONDS=600\`

## Test plan
- [ ] Embedding baseline on slow model — load-% points finish within ~max_seconds
- [ ] \`./run-embedding-suite.sh --max-seconds 60 --dry-run\` shows \`-e guidellm_max_seconds=60\`
- [ ] CI passes