### PR TITLE
feat(cpueval): make run implicit — cpueval --suite … executes directly

### DIFF
--- a/.github/workflows/cpueval-tests.yml
+++ b/.github/workflows/cpueval-tests.yml
@@ -57,6 +57,12 @@ jobs:
           python -m cpueval run --help
           python -m cpueval results --help
 
+      - name: Smoke-test implicit run and backward compat
+        run: |
+          cd automation/cli
+          python -m cpueval --suite rhaiis-sweep --dry-run
+          python -m cpueval run --suite rhaiis-sweep --dry-run
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/automation/cli/README.md
+++ b/automation/cli/README.md
@@ -129,15 +129,17 @@ done
 ./cpueval doctor --no-ping
 ```
 
-### run - Execute benchmarks
+### Execute benchmarks
+
+> `cpueval run --suite …` is also accepted for backward compatibility.
 
 **Common options:**
-- `--suite/-s` (required) - Suite name
-- `--model/-m` - Model ID
-- `--cores/-c` - CPU core count
-- `--workload/-w` - Workload type
-- `--dry-run` - Print command without running
-- `--skip-doctor` - Skip health checks
+- `--suite/-s` (required): Suite name
+- `--model/-m`: Model ID
+- `--cores/-c`: CPU core count
+- `--workload/-w`: Workload type
+- `--dry-run`: Print command without running
+- `--skip-doctor`: Skip health checks
 
 **LLM Examples:**
 

--- a/automation/cli/README.md
+++ b/automation/cli/README.md
@@ -12,16 +12,16 @@ Thin CLI wrapper for running full test matrices with easy overrides.
 
 ```bash
 # Matrix suites - run full test matrix (no --model required!)
-./cpueval run --suite rhaiis-sweep           # 60 combinations: 5 models × 3 cores × 4 workloads
-./cpueval run --suite embedding              # 30 combinations: 5 models × 3 cores × 2 scenarios
-./cpueval run --suite offline-batch          # 33 runs: use-cases 3
+./cpueval --suite rhaiis-sweep           # 60 combinations: 5 models × 3 cores × 4 workloads
+./cpueval --suite embedding              # 30 combinations: 5 models × 3 cores × 2 scenarios
+./cpueval --suite offline-batch          # 33 runs: use-cases 3
 
 # Override to narrow scope
-./cpueval run --suite rhaiis-sweep --models tiny --cores 8
-./cpueval run --suite embedding --models quick --cores 4
+./cpueval --suite rhaiis-sweep --models tiny --cores 8
+./cpueval --suite embedding --models quick --cores 4
 
 # Single-shot suites (require --model)
-./cpueval run --suite chat-smoke --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --cores 16
+./cpueval --suite chat-smoke --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --cores 16
 
 # Explore
 ./cpueval list                    # Shows Matrix vs Single type
@@ -88,7 +88,7 @@ done
 **After** (simple cpueval):
 ```bash
 # Clean, simple - matrix runs automatically
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 32 \
   --vllm-cpu-start 96 \
@@ -100,7 +100,7 @@ done
   --extra test_name=EPYC-NO-SMT
 
 # Or run full concurrent-load matrix (60 combinations: all models × 3 cores × 4 workloads)
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --vllm-cpu-start 96 \
   --vllm-numa 1 \
   --guidellm-cpus 0-31 \
@@ -143,19 +143,19 @@ done
 
 ```bash
 # Quick chat smoke test
-./cpueval run --suite chat-smoke \
+./cpueval --suite chat-smoke \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 16 \
   --workload chat
 
-# Concurrent load test (single model, single workload)
-./cpueval run --suite concurrent-load \
+# Concurrent load sweep (narrowed to single model/workload)
+./cpueval --suite concurrent-load \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 32 \
   --workload summarization
 
 # Dry run to see command
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
   --cores 16 \
   --dry-run
@@ -165,19 +165,19 @@ done
 
 ```bash
 # Transcription throughput test
-./cpueval run --suite audio \
+./cpueval --suite audio \
   --models openai/whisper-small \
   --scenario transcription-throughput \
   --cores 32
 
 # Quick audio test
-./cpueval run --suite audio \
+./cpueval --suite audio \
   --models openai/whisper-tiny \
   --scenario quick-test \
   --cores 16
 
 # Transcription latency test
-./cpueval run --suite audio \
+./cpueval --suite audio \
   --models openai/whisper-medium \
   --scenario transcription-latency \
   --cores 64
@@ -195,7 +195,7 @@ Available audio scenarios:
 **Embedding Example:**
 
 ```bash
-./cpueval run --suite embedding \
+./cpueval --suite embedding \
   --model RedHatAI/granite-embedding-english-r2 \
   --cores 16
 ```
@@ -208,19 +208,19 @@ RHAIIS quantized models work with the standard concurrent-load suite:
 # Test RHAIIS model with custom container
 export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
 
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16 \
   --cores 16 \
   --workload chat
 
 # Test tiny quantized model
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model RedHatAI/TinyLlama-1.1B-Chat-v1.0-pruned2.4 \
   --cores 8 \
   --workload chat
 
 # Core sweep with RHAIIS
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model RedHatAI/TinyLlama-1.1B-Chat-v1.0-pruned2.4 \
   --extra core_sweep_counts="[8,16,32]" \
   --workload chat
@@ -230,13 +230,13 @@ export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
 
 ```bash
 # Default: all 11 use cases, 3 runs each
-./cpueval run --suite offline-batch
+./cpueval --suite offline-batch
 
 # All use cases, all RedHatAI models, 5 runs each
-./cpueval run --suite offline-batch --mode use-cases --runs 5 --models all
+./cpueval --suite offline-batch --mode use-cases --runs 5 --models all
 
 # Single use case with core sweep
-./cpueval run --suite offline-batch \
+./cpueval --suite offline-batch \
   --mode use-case-sweep \
   --use-case summarization \
   --models all \
@@ -244,7 +244,7 @@ export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
   --runs 3
 
 # Single test configuration
-./cpueval run --suite offline-batch \
+./cpueval --suite offline-batch \
   --mode run_test \
   --model all \
   --dataset sonnet \
@@ -253,7 +253,7 @@ export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
 
 # RHAIIS container image
 export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
-./cpueval run --suite offline-batch --mode use-cases --runs 3 --models all
+./cpueval --suite offline-batch --mode use-cases --runs 3 --models all
 ```
 
 **Offline-batch flags:** `--mode`, `--runs`, `--use-case`, `--models`/`--model`,
@@ -263,7 +263,7 @@ export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
 
 ```bash
 # Via cpueval (wraps bash script)
-./cpueval run --suite rhaiis-sweep \
+./cpueval --suite rhaiis-sweep \
   --extra models=llama \
   --extra cores="8,16,32" \
   --extra workloads="chat,rag"
@@ -283,7 +283,7 @@ Model presets: `all` | `llama` | `qwen` | `tiny`
 **Simple pinning via CLI flags:**
 
 ```bash
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 32 \
   --vllm-cpu-start 64 \
@@ -295,7 +295,7 @@ Model presets: `all` | `llama` | `qwen` | `tiny`
 **Using a profile:**
 
 ```bash
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 32 \
   --profile dual-socket-split
@@ -306,14 +306,14 @@ Model presets: `all` | `llama` | `qwen` | `tiny`
 **Advanced: extra vars:**
 
 ```bash
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 32 \
   --extra vllm_cpu_start=64 \
   --extra vllm_numa_node=1
 
 # Or from a file
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 32 \
   --extra-vars-file my-config.yaml
@@ -401,7 +401,7 @@ guidellm_numa_node: 0
 
 Use it:
 ```bash
-./cpueval run --suite concurrent-load --model my-model --cores 32 --profile my-profile
+./cpueval --suite concurrent-load --model my-model --cores 32 --profile my-profile
 ```
 
 ## Troubleshooting
@@ -487,7 +487,7 @@ For comprehensive RHAIIS validation with results by end of week:
 **Day 1-2: Online Inference (Concurrent Load)**
 ```bash
 # Tier 1 workloads: chat, code, summarization, rag (60 combinations)
-./cpueval run --suite rhaiis-sweep \
+./cpueval --suite rhaiis-sweep \
   --models all \
   --cores "8,16,32" \
   --workloads "chat,code,summarization,rag" \
@@ -499,7 +499,7 @@ For comprehensive RHAIIS validation with results by end of week:
 **Day 3: Offline Batch Processing**
 ```bash
 # All 11 enterprise use-cases, 3 runs each = 33 tests
-./cpueval run --suite offline-batch
+./cpueval --suite offline-batch
 
 # Enterprise Tier Priorities:
 #   Tier 1 (Must-have): Summarization, Classification, RAG Batch, Entity Extraction
@@ -508,7 +508,7 @@ For comprehensive RHAIIS validation with results by end of week:
 #   Tier 4 (Deprioritize): Shared-Prefix
 
 # Run specific use case:
-./cpueval run --suite offline-batch \
+./cpueval --suite offline-batch \
   --mode use-case-sweep \
   --use-case summarization \
   --models all \
@@ -519,14 +519,14 @@ For comprehensive RHAIIS validation with results by end of week:
 **Day 4: Embedding Models**
 ```bash
 # All 5 embedding models (default: all)
-./cpueval run --suite embedding \
+./cpueval --suite embedding \
   --models all \
   --cores "8,16,32"
 
 # 5 models × 3 cores × 2 scenarios (baseline+latency) = 30 tests (~6-8 hours)
 
 # Or just small/fast models:
-./cpueval run --suite embedding \
+./cpueval --suite embedding \
   --models small \
   --cores "8,16,32"
 # 2 models × 3 cores × 2 scenarios = 12 tests (~4-6 hours)
@@ -535,7 +535,7 @@ For comprehensive RHAIIS validation with results by end of week:
 **Day 5: Audio Workloads**
 ```bash
 # Whisper models: tiny, small, medium
-./cpueval run --suite audio \
+./cpueval --suite audio \
   --models all \
   --scenarios transcription-throughput \
   --cores "32"
@@ -549,7 +549,7 @@ Verify everything works before starting week-long runs:
 
 ```bash
 # 3-5 minute smoke test
-./cpueval run --suite chat-smoke \
+./cpueval --suite chat-smoke \
   --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
   --cores 8 \
   --skip-doctor

--- a/automation/cli/profiles/dual-socket-split.yaml
+++ b/automation/cli/profiles/dual-socket-split.yaml
@@ -11,7 +11,7 @@
 # 3. Use with: --profile path/to/my-profile.yaml
 #
 # Usage:
-#   cpueval run --suite concurrent-load \
+#   cpueval --suite concurrent-load \
 #     --model meta-llama/Llama-3.2-1B-Instruct \
 #     --cores 32 \
 #     --profile dual-socket-split

--- a/automation/cli/src/cpueval/cli.py
+++ b/automation/cli/src/cpueval/cli.py
@@ -40,214 +40,34 @@ def version_callback(value: bool):
         raise typer.Exit()
 
 
-@app.callback()
-def main(
-    version: Optional[bool] = typer.Option(
-        None,
-        "--version",
-        "-V",
-        callback=version_callback,
-        is_eager=True,
-        help="Show version and exit",
-    ),
-):
-    """cpueval - Thin CLI wrapper over Ansible CPU automation."""
-    pass
-
-
-@app.command()
-def list():
-    """List available test suites."""
-    registry = SuiteRegistry()
-    suites = registry.list_suites()
-
-    if not suites:
-        console.print("[yellow]No suites found. Check automation/cli/suites/[/yellow]")
-        return
-
-    table = Table(show_header=True, header_style="bold magenta")
-    table.add_column("Name", style="cyan", width=25)
-    table.add_column("Type", width=12)
-    table.add_column("Runner", width=10)
-    table.add_column("Description")
-
-    for suite in suites:
-        suite_type = "[green]Matrix[/green]" if suite.matrix else "[yellow]Single[/yellow]"
-        table.add_row(
-            suite.name,
-            suite_type,
-            suite.runner,
-            suite.description[:60] + "..." if len(suite.description) > 60 else suite.description,
-        )
-
-    console.print()
-    console.print(table)
-    console.print()
-    console.print("[dim]Legend:[/dim] [green]Matrix[/green] = full test matrix by default, [yellow]Single[/yellow] = requires --model")
-    console.print()
-
-
-@app.command()
-def show(suite_name: str = typer.Argument(..., help="Suite name")):
-    """Show detailed information about a suite."""
-    registry = SuiteRegistry()
-    suite = registry.get_suite(suite_name)
-
-    if not suite:
-        console.print(f"[red]Suite not found: {suite_name}[/red]")
-        console.print("\nRun 'cpueval list' to see available suites.")
-        raise typer.Exit(1)
-
-    console.print(f"\n[bold cyan]Suite: {suite.name}[/bold cyan]\n")
-    console.print(f"[dim]Description:[/dim] {suite.description}")
-    console.print(f"[dim]Runner:[/dim] {suite.runner}")
-    console.print(f"[dim]Target:[/dim] {suite.target}")
-
-    if suite.matrix:
-        console.print(
-            "[dim]Type:[/dim] [green]Matrix suite[/green]"
-            " (runs full test matrix by default)"
-        )
-    else:
-        console.print(
-            "[dim]Type:[/dim] [yellow]Single-shot[/yellow] (--model required)"
-        )
-    console.print()
-
-    if suite.defaults:
-        console.print("[bold]Default Parameters:[/bold]")
-        for key, value in suite.defaults.items():
-            console.print(f"  {key}: {value}")
-        console.print()
-
-        if suite.matrix:
-            console.print("[dim]This suite runs the full matrix by default.[/dim]")
-            console.print("[dim]Use CLI flags to narrow the scope:[/dim]")
-            if "models" in suite.defaults:
-                console.print("  --models <preset|list> to select specific models")
-            if "cores" in suite.defaults:
-                console.print("  --cores <list> to select specific core counts")
-            if "workloads" in suite.defaults:
-                console.print("  --workloads <list> to select specific workloads")
-            if suite.args_builder == "offline_batch":
-                console.print("  --mode <mode> to select test mode (default: use-cases)")
-                console.print("  --runs <n> for use-cases / use-case-sweep iteration count")
-                console.print("  --use-case <name> for use-case-sweep mode")
-                console.print("  --models / --model for model selection")
-                console.print("  --cores <list> for core sweep modes")
-                console.print("  --dataset / --num-prompts for run_test mode")
-                console.print("  --input-len / --output-len for dataset token lengths")
-            console.print()
-
-    if suite.param_mappings:
-        console.print("[bold]Parameter Mappings:[/bold]")
-        for cli_param, ansible_param in suite.param_mappings.items():
-            console.print(f"  --{cli_param} → {ansible_param}")
-        console.print()
-
-    if suite.source_path:
-        console.print(f"[dim]Suite definition:[/dim] {suite.source_path}")
-        console.print(
-            "[dim]Edit that file to change permanent defaults.[/dim]"
-        )
-        console.print()
-
-
-@app.command()
-def profiles():
-    """List available CPU pinning profiles."""
-    profiles_dir = get_profiles_dir()
-    if not profiles_dir.exists():
-        console.print(
-            f"[yellow]No profiles directory found at {profiles_dir}[/yellow]"
-        )
-        return
-
-    profile_files = sorted(profiles_dir.glob("*.yaml"))
-    if not profile_files:
-        console.print("[yellow]No profiles found.[/yellow]")
-        console.print(
-            f"Add YAML files to {profiles_dir} to create profiles."
-        )
-        return
-
-    table = Table(show_header=True, header_style="bold magenta")
-    table.add_column("Name", style="cyan", width=25)
-    table.add_column("Path", style="dim")
-
-    for pf in profile_files:
-        table.add_row(pf.stem, str(pf))
-
-    console.print()
-    console.print(table)
-    console.print()
-    console.print(f"[dim]Profile directory:[/dim] {profiles_dir}")
-    console.print(
-        "[dim]Use with:[/dim] cpueval run --suite <suite>"
-        " --model <model> --profile <name>"
-    )
-    console.print()
-
-
-@app.command()
-def doctor(
-    no_ping: bool = typer.Option(False, "--no-ping", help="Skip host connectivity check"),
-):
-    """Run system health checks."""
-    exit_code = run_doctor(no_ping=no_ping)
-    raise typer.Exit(exit_code)
-
-
-@app.command()
-def run(
-    suite: str = typer.Option(..., "--suite", "-s", help="Suite name (required)"),
-    model: Optional[str] = typer.Option(None, "--model", "-m", help="Model ID (single model)"),
-    models: Optional[str] = typer.Option(None, "--models", help="Models preset or comma-list (matrix suites)"),
-    cores: Optional[str] = typer.Option(None, "--cores", "-c", help="Core counts (comma-separated or single)"),
-    workload: Optional[str] = typer.Option(None, "--workload", "-w", help="Workload type"),
-    workloads: Optional[str] = typer.Option(None, "--workloads", help="Workloads (comma-separated, matrix suites)"),
-    scenario: Optional[str] = typer.Option(None, "--scenario", help="Test scenario"),
-    mode: Optional[str] = typer.Option(
-        None,
-        "--mode",
-        help=(
-            "Offline-batch mode: use-cases, use-case-sweep, baseline, batch-scaling, "
-            "input-scaling, output-scaling, core-scaling, quantization, kv-capacity, "
-            "context-scaling, all, run_test"
-        ),
-    ),
-    runs: Optional[int] = typer.Option(
-        None, "--runs", help="Iteration count (offline-batch use-cases / use-case-sweep)"
-    ),
-    use_case: Optional[str] = typer.Option(
-        None, "--use-case", help="Use case name (offline-batch use-case-sweep mode)"
-    ),
-    dataset: Optional[str] = typer.Option(
-        None, "--dataset", help="Dataset name (offline-batch run_test mode)"
-    ),
-    num_prompts: Optional[int] = typer.Option(
-        None, "--num-prompts", help="Prompt count (offline-batch run_test / baseline)"
-    ),
-    input_len: Optional[int] = typer.Option(
-        None, "--input-len", help="Input token length (offline-batch random dataset)"
-    ),
-    output_len: Optional[int] = typer.Option(
-        None, "--output-len", help="Output token length (offline-batch random/sharegpt)"
-    ),
-    preset: Optional[str] = typer.Option(None, "--preset", help="Model preset (deprecated, use --models)"),
-    tensor_parallel: Optional[int] = typer.Option(None, "--tensor-parallel", help="Tensor parallel size"),
-    vllm_cpu_start: Optional[int] = typer.Option(None, "--vllm-cpu-start", help="vLLM CPU start core"),
-    vllm_numa: Optional[int] = typer.Option(None, "--vllm-numa", help="vLLM NUMA node"),
-    guidellm_cpus: Optional[str] = typer.Option(None, "--guidellm-cpus", help="GuideLLM CPU range (e.g., 0-31)"),
-    guidellm_numa: Optional[int] = typer.Option(None, "--guidellm-numa", help="GuideLLM NUMA node"),
-    profile: Optional[str] = typer.Option(None, "--profile", help="Load CPU pinning profile"),
-    extra: Optional[List[str]] = typer.Option(None, "--extra", help="Extra vars (KEY=VAL, repeatable)"),
-    extra_vars_file: Optional[str] = typer.Option(None, "--extra-vars-file", help="Load extra vars from YAML/JSON"),
-    ansible_arg: Optional[List[str]] = typer.Option(None, "--ansible-arg", help="Raw ansible-playbook args (repeatable)"),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Print command without running"),
-    skip_doctor: bool = typer.Option(False, "--skip-doctor", help="Skip pre-run health check"),
-):
-    """Run a test suite."""
+def _execute_suite(
+    suite: str,
+    model: Optional[str],
+    models: Optional[str],
+    cores: Optional[str],
+    workload: Optional[str],
+    workloads: Optional[str],
+    scenario: Optional[str],
+    mode: Optional[str],
+    runs: Optional[int],
+    use_case: Optional[str],
+    dataset: Optional[str],
+    num_prompts: Optional[int],
+    input_len: Optional[int],
+    output_len: Optional[int],
+    preset: Optional[str],
+    tensor_parallel: Optional[int],
+    vllm_cpu_start: Optional[int],
+    vllm_numa: Optional[int],
+    guidellm_cpus: Optional[str],
+    guidellm_numa: Optional[int],
+    profile: Optional[str],
+    extra: Optional[List[str]],
+    extra_vars_file: Optional[str],
+    ansible_arg: Optional[List[str]],
+    dry_run: bool,
+    skip_doctor: bool,
+) -> None:
     registry = SuiteRegistry()
     suite_obj = registry.get_suite(suite)
 
@@ -469,6 +289,322 @@ def run(
     else:
         console.print(f"[red]Unknown runner type: {suite_obj.runner}[/red]")
         raise typer.Exit(1)
+
+
+@app.callback(invoke_without_command=True)
+def main(
+    ctx: typer.Context,
+    version: Optional[bool] = typer.Option(
+        None,
+        "--version",
+        "-V",
+        callback=version_callback,
+        is_eager=True,
+        help="Show version and exit",
+    ),
+    suite: Optional[str] = typer.Option(None, "--suite", "-s", help="Suite name"),
+    model: Optional[str] = typer.Option(None, "--model", "-m", help="Model ID (single model)"),
+    models: Optional[str] = typer.Option(None, "--models", help="Models preset or comma-list (matrix suites)"),
+    cores: Optional[str] = typer.Option(None, "--cores", "-c", help="Core counts (comma-separated or single)"),
+    workload: Optional[str] = typer.Option(None, "--workload", "-w", help="Workload type"),
+    workloads: Optional[str] = typer.Option(None, "--workloads", help="Workloads (comma-separated, matrix suites)"),
+    scenario: Optional[str] = typer.Option(None, "--scenario", help="Test scenario"),
+    mode: Optional[str] = typer.Option(
+        None,
+        "--mode",
+        help=(
+            "Offline-batch mode: use-cases, use-case-sweep, baseline, batch-scaling, "
+            "input-scaling, output-scaling, core-scaling, quantization, kv-capacity, "
+            "context-scaling, all, run_test"
+        ),
+    ),
+    runs: Optional[int] = typer.Option(
+        None, "--runs", help="Iteration count (offline-batch use-cases / use-case-sweep)"
+    ),
+    use_case: Optional[str] = typer.Option(
+        None, "--use-case", help="Use case name (offline-batch use-case-sweep mode)"
+    ),
+    dataset: Optional[str] = typer.Option(
+        None, "--dataset", help="Dataset name (offline-batch run_test mode)"
+    ),
+    num_prompts: Optional[int] = typer.Option(
+        None, "--num-prompts", help="Prompt count (offline-batch run_test / baseline)"
+    ),
+    input_len: Optional[int] = typer.Option(
+        None, "--input-len", help="Input token length (offline-batch random dataset)"
+    ),
+    output_len: Optional[int] = typer.Option(
+        None, "--output-len", help="Output token length (offline-batch random/sharegpt)"
+    ),
+    preset: Optional[str] = typer.Option(None, "--preset", help="Model preset (deprecated, use --models)"),
+    tensor_parallel: Optional[int] = typer.Option(None, "--tensor-parallel", help="Tensor parallel size"),
+    vllm_cpu_start: Optional[int] = typer.Option(None, "--vllm-cpu-start", help="vLLM CPU start core"),
+    vllm_numa: Optional[int] = typer.Option(None, "--vllm-numa", help="vLLM NUMA node"),
+    guidellm_cpus: Optional[str] = typer.Option(None, "--guidellm-cpus", help="GuideLLM CPU range (e.g., 0-31)"),
+    guidellm_numa: Optional[int] = typer.Option(None, "--guidellm-numa", help="GuideLLM NUMA node"),
+    profile: Optional[str] = typer.Option(None, "--profile", help="Load CPU pinning profile"),
+    extra: Optional[List[str]] = typer.Option(None, "--extra", help="Extra vars (KEY=VAL, repeatable)"),
+    extra_vars_file: Optional[str] = typer.Option(None, "--extra-vars-file", help="Load extra vars from YAML/JSON"),
+    ansible_arg: Optional[List[str]] = typer.Option(None, "--ansible-arg", help="Raw ansible-playbook args (repeatable)"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Print command without running"),
+    skip_doctor: bool = typer.Option(False, "--skip-doctor", help="Skip pre-run health check"),
+):
+    """cpueval - Thin CLI wrapper over Ansible CPU automation."""
+    if ctx.invoked_subcommand is not None:
+        return
+    if suite is None:
+        typer.echo(ctx.get_help())
+        raise typer.Exit()
+    _execute_suite(
+        suite=suite,
+        model=model,
+        models=models,
+        cores=cores,
+        workload=workload,
+        workloads=workloads,
+        scenario=scenario,
+        mode=mode,
+        runs=runs,
+        use_case=use_case,
+        dataset=dataset,
+        num_prompts=num_prompts,
+        input_len=input_len,
+        output_len=output_len,
+        preset=preset,
+        tensor_parallel=tensor_parallel,
+        vllm_cpu_start=vllm_cpu_start,
+        vllm_numa=vllm_numa,
+        guidellm_cpus=guidellm_cpus,
+        guidellm_numa=guidellm_numa,
+        profile=profile,
+        extra=extra,
+        extra_vars_file=extra_vars_file,
+        ansible_arg=ansible_arg,
+        dry_run=dry_run,
+        skip_doctor=skip_doctor,
+    )
+
+
+@app.command()
+def list():
+    """List available test suites."""
+    registry = SuiteRegistry()
+    suites = registry.list_suites()
+
+    if not suites:
+        console.print("[yellow]No suites found. Check automation/cli/suites/[/yellow]")
+        return
+
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Name", style="cyan", width=25)
+    table.add_column("Type", width=12)
+    table.add_column("Runner", width=10)
+    table.add_column("Description")
+
+    for suite in suites:
+        suite_type = "[green]Matrix[/green]" if suite.matrix else "[yellow]Single[/yellow]"
+        table.add_row(
+            suite.name,
+            suite_type,
+            suite.runner,
+            suite.description[:60] + "..." if len(suite.description) > 60 else suite.description,
+        )
+
+    console.print()
+    console.print(table)
+    console.print()
+    console.print("[dim]Legend:[/dim] [green]Matrix[/green] = full test matrix by default, [yellow]Single[/yellow] = requires --model")
+    console.print()
+
+
+@app.command()
+def show(suite_name: str = typer.Argument(..., help="Suite name")):
+    """Show detailed information about a suite."""
+    registry = SuiteRegistry()
+    suite = registry.get_suite(suite_name)
+
+    if not suite:
+        console.print(f"[red]Suite not found: {suite_name}[/red]")
+        console.print("\nRun 'cpueval list' to see available suites.")
+        raise typer.Exit(1)
+
+    console.print(f"\n[bold cyan]Suite: {suite.name}[/bold cyan]\n")
+    console.print(f"[dim]Description:[/dim] {suite.description}")
+    console.print(f"[dim]Runner:[/dim] {suite.runner}")
+    console.print(f"[dim]Target:[/dim] {suite.target}")
+
+    if suite.matrix:
+        console.print(
+            "[dim]Type:[/dim] [green]Matrix suite[/green]"
+            " (runs full test matrix by default)"
+        )
+    else:
+        console.print(
+            "[dim]Type:[/dim] [yellow]Single-shot[/yellow] (--model required)"
+        )
+    console.print()
+
+    if suite.defaults:
+        console.print("[bold]Default Parameters:[/bold]")
+        for key, value in suite.defaults.items():
+            console.print(f"  {key}: {value}")
+        console.print()
+
+        if suite.matrix:
+            console.print("[dim]This suite runs the full matrix by default.[/dim]")
+            console.print("[dim]Use CLI flags to narrow the scope:[/dim]")
+            if "models" in suite.defaults:
+                console.print("  --models <preset|list> to select specific models")
+            if "cores" in suite.defaults:
+                console.print("  --cores <list> to select specific core counts")
+            if "workloads" in suite.defaults:
+                console.print("  --workloads <list> to select specific workloads")
+            if suite.args_builder == "offline_batch":
+                console.print("  --mode <mode> to select test mode (default: use-cases)")
+                console.print("  --runs <n> for use-cases / use-case-sweep iteration count")
+                console.print("  --use-case <name> for use-case-sweep mode")
+                console.print("  --models / --model for model selection")
+                console.print("  --cores <list> for core sweep modes")
+                console.print("  --dataset / --num-prompts for run_test mode")
+                console.print("  --input-len / --output-len for dataset token lengths")
+            console.print()
+
+    if suite.param_mappings:
+        console.print("[bold]Parameter Mappings:[/bold]")
+        for cli_param, ansible_param in suite.param_mappings.items():
+            console.print(f"  --{cli_param} → {ansible_param}")
+        console.print()
+
+    if suite.source_path:
+        console.print(f"[dim]Suite definition:[/dim] {suite.source_path}")
+        console.print(
+            "[dim]Edit that file to change permanent defaults.[/dim]"
+        )
+        console.print()
+
+
+@app.command()
+def profiles():
+    """List available CPU pinning profiles."""
+    profiles_dir = get_profiles_dir()
+    if not profiles_dir.exists():
+        console.print(
+            f"[yellow]No profiles directory found at {profiles_dir}[/yellow]"
+        )
+        return
+
+    profile_files = sorted(profiles_dir.glob("*.yaml"))
+    if not profile_files:
+        console.print("[yellow]No profiles found.[/yellow]")
+        console.print(
+            f"Add YAML files to {profiles_dir} to create profiles."
+        )
+        return
+
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Name", style="cyan", width=25)
+    table.add_column("Path", style="dim")
+
+    for pf in profile_files:
+        table.add_row(pf.stem, str(pf))
+
+    console.print()
+    console.print(table)
+    console.print()
+    console.print(f"[dim]Profile directory:[/dim] {profiles_dir}")
+    console.print(
+        "[dim]Use with:[/dim] cpueval --suite <suite> --profile <name>"
+    )
+    console.print()
+
+
+@app.command()
+def doctor(
+    no_ping: bool = typer.Option(False, "--no-ping", help="Skip host connectivity check"),
+):
+    """Run system health checks."""
+    exit_code = run_doctor(no_ping=no_ping)
+    raise typer.Exit(exit_code)
+
+
+@app.command()
+def run(
+    suite: str = typer.Option(..., "--suite", "-s", help="Suite name (required)"),
+    model: Optional[str] = typer.Option(None, "--model", "-m", help="Model ID (single model)"),
+    models: Optional[str] = typer.Option(None, "--models", help="Models preset or comma-list (matrix suites)"),
+    cores: Optional[str] = typer.Option(None, "--cores", "-c", help="Core counts (comma-separated or single)"),
+    workload: Optional[str] = typer.Option(None, "--workload", "-w", help="Workload type"),
+    workloads: Optional[str] = typer.Option(None, "--workloads", help="Workloads (comma-separated, matrix suites)"),
+    scenario: Optional[str] = typer.Option(None, "--scenario", help="Test scenario"),
+    mode: Optional[str] = typer.Option(
+        None,
+        "--mode",
+        help=(
+            "Offline-batch mode: use-cases, use-case-sweep, baseline, batch-scaling, "
+            "input-scaling, output-scaling, core-scaling, quantization, kv-capacity, "
+            "context-scaling, all, run_test"
+        ),
+    ),
+    runs: Optional[int] = typer.Option(
+        None, "--runs", help="Iteration count (offline-batch use-cases / use-case-sweep)"
+    ),
+    use_case: Optional[str] = typer.Option(
+        None, "--use-case", help="Use case name (offline-batch use-case-sweep mode)"
+    ),
+    dataset: Optional[str] = typer.Option(
+        None, "--dataset", help="Dataset name (offline-batch run_test mode)"
+    ),
+    num_prompts: Optional[int] = typer.Option(
+        None, "--num-prompts", help="Prompt count (offline-batch run_test / baseline)"
+    ),
+    input_len: Optional[int] = typer.Option(
+        None, "--input-len", help="Input token length (offline-batch random dataset)"
+    ),
+    output_len: Optional[int] = typer.Option(
+        None, "--output-len", help="Output token length (offline-batch random/sharegpt)"
+    ),
+    preset: Optional[str] = typer.Option(None, "--preset", help="Model preset (deprecated, use --models)"),
+    tensor_parallel: Optional[int] = typer.Option(None, "--tensor-parallel", help="Tensor parallel size"),
+    vllm_cpu_start: Optional[int] = typer.Option(None, "--vllm-cpu-start", help="vLLM CPU start core"),
+    vllm_numa: Optional[int] = typer.Option(None, "--vllm-numa", help="vLLM NUMA node"),
+    guidellm_cpus: Optional[str] = typer.Option(None, "--guidellm-cpus", help="GuideLLM CPU range (e.g., 0-31)"),
+    guidellm_numa: Optional[int] = typer.Option(None, "--guidellm-numa", help="GuideLLM NUMA node"),
+    profile: Optional[str] = typer.Option(None, "--profile", help="Load CPU pinning profile"),
+    extra: Optional[List[str]] = typer.Option(None, "--extra", help="Extra vars (KEY=VAL, repeatable)"),
+    extra_vars_file: Optional[str] = typer.Option(None, "--extra-vars-file", help="Load extra vars from YAML/JSON"),
+    ansible_arg: Optional[List[str]] = typer.Option(None, "--ansible-arg", help="Raw ansible-playbook args (repeatable)"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Print command without running"),
+    skip_doctor: bool = typer.Option(False, "--skip-doctor", help="Skip pre-run health check"),
+):
+    """Run a test suite (alias; prefer: cpueval --suite …)."""
+    _execute_suite(
+        suite=suite,
+        model=model,
+        models=models,
+        cores=cores,
+        workload=workload,
+        workloads=workloads,
+        scenario=scenario,
+        mode=mode,
+        runs=runs,
+        use_case=use_case,
+        dataset=dataset,
+        num_prompts=num_prompts,
+        input_len=input_len,
+        output_len=output_len,
+        preset=preset,
+        tensor_parallel=tensor_parallel,
+        vllm_cpu_start=vllm_cpu_start,
+        vllm_numa=vllm_numa,
+        guidellm_cpus=guidellm_cpus,
+        guidellm_numa=guidellm_numa,
+        profile=profile,
+        extra=extra,
+        extra_vars_file=extra_vars_file,
+        ansible_arg=ansible_arg,
+        dry_run=dry_run,
+        skip_doctor=skip_doctor,
+    )
 
 
 @app.command()

--- a/automation/cli/src/cpueval/cli.py
+++ b/automation/cli/src/cpueval/cli.py
@@ -349,7 +349,11 @@ def main(
     dry_run: bool = typer.Option(False, "--dry-run", help="Print command without running"),
     skip_doctor: bool = typer.Option(False, "--skip-doctor", help="Skip pre-run health check"),
 ):
-    """cpueval - Thin CLI wrapper over Ansible CPU automation."""
+    """cpueval - Thin CLI wrapper over Ansible CPU automation.
+
+    Run options below apply when no subcommand is given (e.g. cpueval --suite …).
+    Subcommands (list, doctor, run) take precedence when specified.
+    """
     if ctx.invoked_subcommand is not None:
         return
     if suite is None:
@@ -527,6 +531,7 @@ def doctor(
     raise typer.Exit(exit_code)
 
 
+# Keep in sync with main() callback options.
 @app.command()
 def run(
     suite: str = typer.Option(..., "--suite", "-s", help="Suite name (required)"),

--- a/automation/cli/src/cpueval/suites/offline-batch.yaml
+++ b/automation/cli/src/cpueval/suites/offline-batch.yaml
@@ -10,11 +10,11 @@ args_builder: offline_batch
 #        context-scaling | all | run_test
 #
 # Examples:
-#   ./cpueval run --suite offline-batch
-#   ./cpueval run --suite offline-batch --mode use-cases --runs 5 --models all
-#   ./cpueval run --suite offline-batch --mode use-case-sweep \
+#   ./cpueval --suite offline-batch
+#   ./cpueval --suite offline-batch --mode use-cases --runs 5 --models all
+#   ./cpueval --suite offline-batch --mode use-case-sweep \
 #     --use-case summarization --models all --cores 8,16,32 --runs 3
-#   ./cpueval run --suite offline-batch --mode run_test \
+#   ./cpueval --suite offline-batch --mode run_test \
 #     --model all --dataset random --num-prompts 3 --cores 8 \
 #     --input-len 32 --output-len 16
 #

--- a/automation/cli/tests/test_matrix_dry_run.py
+++ b/automation/cli/tests/test_matrix_dry_run.py
@@ -344,10 +344,10 @@ def test_implicit_matches_explicit_run():
 # ---------------------------------------------------------------------------
 
 def test_offline_batch_use_case_summarization():
-    """Summarization: sharegpt, 1000 prompts, core sweep."""
+    """Summarization via implicit run (no subcommand): sharegpt, 1000 prompts, core sweep."""
     result = subprocess.run(
         [
-            sys.executable, "-m", "cpueval", "run",
+            sys.executable, "-m", "cpueval",
             "--suite", "offline-batch",
             "--mode", "use-case-sweep",
             "--use-case", "summarization",

--- a/automation/cli/tests/test_matrix_dry_run.py
+++ b/automation/cli/tests/test_matrix_dry_run.py
@@ -8,7 +8,10 @@ from .conftest import repo_root
 def test_rhaiis_sweep_dry_run_without_model():
     """Test that rhaiis-sweep runs without --model."""
     result = subprocess.run(
-        [sys.executable, "-m", "cpueval", "run", "--suite", "rhaiis-sweep", "--dry-run"],
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "rhaiis-sweep", "--dry-run",
+        ],
         capture_output=True,
         text=True,
         cwd=str(repo_root()),
@@ -23,7 +26,10 @@ def test_rhaiis_sweep_dry_run_without_model():
 def test_embedding_dry_run_without_model():
     """Test that embedding runs without --model."""
     result = subprocess.run(
-        [sys.executable, "-m", "cpueval", "run", "--suite", "embedding", "--dry-run"],
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "embedding", "--dry-run",
+        ],
         capture_output=True,
         text=True,
         cwd=str(repo_root()),
@@ -38,7 +44,10 @@ def test_embedding_dry_run_without_model():
 def test_offline_batch_dry_run_without_model():
     """Test that offline-batch runs without --model."""
     result = subprocess.run(
-        [sys.executable, "-m", "cpueval", "run", "--suite", "offline-batch", "--dry-run"],
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "offline-batch", "--dry-run",
+        ],
         capture_output=True,
         text=True,
         cwd=str(repo_root()),
@@ -144,7 +153,10 @@ def test_offline_batch_input_output_len_flags():
     )
 
     assert result.returncode == 0, f"STDERR: {result.stderr}"
-    assert "run_test RedHatAI/TinyLlama-1.1B-Chat-v1.0-pruned2.4 random 3 8" in result.stdout
+    assert (
+        "run_test RedHatAI/TinyLlama-1.1B-Chat-v1.0-pruned2.4 random 3 8"
+        in result.stdout
+    )
     assert "-e input_len=32" in result.stdout
     assert "-e output_len=16" in result.stdout
 
@@ -175,7 +187,10 @@ def test_offline_batch_extra_args_override():
 def test_chat_smoke_requires_model():
     """Test that chat-smoke requires --model."""
     result = subprocess.run(
-        [sys.executable, "-m", "cpueval", "run", "--suite", "chat-smoke", "--dry-run"],
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "chat-smoke", "--dry-run",
+        ],
         capture_output=True,
         text=True,
         cwd=str(repo_root()),
@@ -217,7 +232,7 @@ def test_concurrent_load_workload_override():
 
 
 def test_concurrent_load_default():
-    """Test that concurrent-load default runs all 4 workloads (60 combinations: all×3×4)."""
+    """concurrent-load default: all 4 workloads, 60 combinations (all×3×4)."""
     result = subprocess.run(
         [sys.executable, "-m", "cpueval", "run", "--suite", "concurrent-load",
          "--dry-run", "--skip-doctor"],
@@ -233,7 +248,7 @@ def test_concurrent_load_default():
 
 
 def test_audio_scenario_override():
-    """Test that --scenario on audio overrides default and appears only once."""
+    """--scenario on audio overrides the default and appears exactly once."""
     result = subprocess.run(
         [sys.executable, "-m", "cpueval", "run", "--suite", "audio",
          "--scenario", "transcription-latency", "--dry-run", "--skip-doctor"],
@@ -253,7 +268,10 @@ def test_audio_scenario_override():
 def test_dry_run_no_results_message():
     """Test that dry-run doesn't show 'Results saved' message."""
     result = subprocess.run(
-        [sys.executable, "-m", "cpueval", "run", "--suite", "rhaiis-sweep", "--dry-run"],
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "rhaiis-sweep", "--dry-run",
+        ],
         capture_output=True,
         text=True,
         cwd=str(repo_root()),
@@ -261,3 +279,219 @@ def test_dry_run_no_results_message():
 
     assert "Results saved" not in result.stdout
     assert "✓" not in result.stdout or "Results" not in result.stdout
+
+
+def test_implicit_rhaiis_sweep_dry_run():
+    """rhaiis-sweep --dry-run works without the 'run' subcommand."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval",
+            "--suite", "rhaiis-sweep", "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert "run-rhaiis-concurrent-load.sh" in result.stdout
+    assert "--models all" in result.stdout
+    assert "--cores 8,16,32" in result.stdout
+
+
+def test_implicit_concurrent_load_dry_run():
+    """concurrent-load --dry-run --skip-doctor works without 'run'."""
+    result = subprocess.run(
+        [sys.executable, "-m", "cpueval", "--suite", "concurrent-load",
+         "--dry-run", "--skip-doctor"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert "run-concurrent-load-suite.sh" in result.stdout
+    assert "--models all" in result.stdout
+
+
+def test_implicit_matches_explicit_run():
+    """Implicit and explicit 'run' invocation produce identical output."""
+    implicit = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval",
+            "--suite", "rhaiis-sweep", "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+    explicit = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "rhaiis-sweep", "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+
+    assert implicit.returncode == 0, f"STDERR: {implicit.stderr}"
+    assert implicit.stdout == explicit.stdout
+
+
+# ---------------------------------------------------------------------------
+# Offline batch — Tier 1 use cases (highest enterprise ROI)
+# ---------------------------------------------------------------------------
+
+def test_offline_batch_use_case_summarization():
+    """Summarization: sharegpt, 1000 prompts, core sweep."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "offline-batch",
+            "--mode", "use-case-sweep",
+            "--use-case", "summarization",
+            "--models", "all",
+            "--cores", "8,16,24,32",
+            "--runs", "3",
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert "use-case-sweep summarization all 8,16,24,32 3" in result.stdout
+
+
+def test_offline_batch_use_case_classification():
+    """Classification: sharegpt, 1000 prompts, output=64, core sweep."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "offline-batch",
+            "--mode", "use-case-sweep",
+            "--use-case", "classification",
+            "--models", "all",
+            "--cores", "8,16,24,32",
+            "--runs", "3",
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert "use-case-sweep classification all 8,16,24,32 3" in result.stdout
+
+
+def test_offline_batch_use_case_rag():
+    """RAG Batch: random, 500 prompts, input=2048, output=128, core sweep."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "offline-batch",
+            "--mode", "use-case-sweep",
+            "--use-case", "rag",
+            "--models", "all",
+            "--cores", "8,16,24,32",
+            "--runs", "3",
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert "use-case-sweep rag all 8,16,24,32 3" in result.stdout
+
+
+def test_offline_batch_use_case_entity_extraction():
+    """Entity Extraction: sharegpt, 1000 prompts, output=128, core sweep."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "offline-batch",
+            "--mode", "use-case-sweep",
+            "--use-case", "entity-extraction",
+            "--models", "all",
+            "--cores", "8,16,24,32",
+            "--runs", "3",
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert "use-case-sweep entity-extraction all 8,16,24,32 3" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Offline batch — Tier 2 use cases (high value, narrower audience)
+# ---------------------------------------------------------------------------
+
+def test_offline_batch_use_case_long_summarization():
+    """Long-Doc Summary: random, 500 prompts, 4096→256 tokens, core sweep."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "offline-batch",
+            "--mode", "use-case-sweep",
+            "--use-case", "long-summarization",
+            "--models", "all",
+            "--cores", "8,16,24,32",
+            "--runs", "3",
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert (
+        "use-case-sweep long-summarization all 8,16,24,32 3"
+        in result.stdout
+    )
+
+
+def test_offline_batch_use_case_etl():
+    """ETL: sonnet, 500 prompts, core-scaling sweep (8/16/24/32)."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "offline-batch",
+            "--mode", "use-case-sweep",
+            "--use-case", "etl",
+            "--models", "all",
+            "--cores", "8,16,24,32",
+            "--runs", "3",
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert "use-case-sweep etl all 8,16,24,32 3" in result.stdout
+
+
+def test_offline_batch_use_case_short_labeling():
+    """Short Labeling: sharegpt, 2000 prompts, output=16, core sweep."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "offline-batch",
+            "--mode", "use-case-sweep",
+            "--use-case", "short-labeling",
+            "--models", "all",
+            "--cores", "8,16,24,32",
+            "--runs", "3",
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert "use-case-sweep short-labeling all 8,16,24,32 3" in result.stdout

--- a/automation/cli/tests/test_offline_batch.py
+++ b/automation/cli/tests/test_offline_batch.py
@@ -141,3 +141,90 @@ def test_baseline():
     assert build_offline_batch_args(
         {"mode": "baseline", "cores": "32", "num_prompts": 100}
     ) == ["baseline", "32", "100"]
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — use-case-sweep arg builder (highest enterprise ROI)
+# ---------------------------------------------------------------------------
+
+def test_use_case_sweep_classification():
+    assert build_offline_batch_args(
+        {
+            "mode": "use-case-sweep",
+            "use_case": "classification",
+            "models": "all",
+            "cores": "8,16,24,32",
+            "runs": 3,
+        }
+    ) == ["use-case-sweep", "classification", "all", "8,16,24,32", "3"]
+
+
+def test_use_case_sweep_rag():
+    assert build_offline_batch_args(
+        {
+            "mode": "use-case-sweep",
+            "use_case": "rag",
+            "models": "all",
+            "cores": "8,16,24,32",
+            "runs": 3,
+        }
+    ) == ["use-case-sweep", "rag", "all", "8,16,24,32", "3"]
+
+
+def test_use_case_sweep_entity_extraction():
+    assert build_offline_batch_args(
+        {
+            "mode": "use-case-sweep",
+            "use_case": "entity-extraction",
+            "models": "all",
+            "cores": "8,16,24,32",
+            "runs": 3,
+        }
+    ) == [
+        "use-case-sweep", "entity-extraction", "all", "8,16,24,32", "3",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — use-case-sweep arg builder (high value, narrower audience)
+# ---------------------------------------------------------------------------
+
+def test_use_case_sweep_long_summarization():
+    assert build_offline_batch_args(
+        {
+            "mode": "use-case-sweep",
+            "use_case": "long-summarization",
+            "models": "all",
+            "cores": "8,16,24,32",
+            "runs": 3,
+        }
+    ) == [
+        "use-case-sweep", "long-summarization", "all", "8,16,24,32", "3",
+    ]
+
+
+def test_use_case_sweep_etl():
+    """ETL: core-scaling sweep directly answers capacity-planning questions."""
+    assert build_offline_batch_args(
+        {
+            "mode": "use-case-sweep",
+            "use_case": "etl",
+            "models": "all",
+            "cores": "8,16,24,32",
+            "runs": 3,
+        }
+    ) == ["use-case-sweep", "etl", "all", "8,16,24,32", "3"]
+
+
+def test_use_case_sweep_short_labeling():
+    assert build_offline_batch_args(
+        {
+            "mode": "use-case-sweep",
+            "use_case": "short-labeling",
+            "models": "all",
+            "cores": "8,16,24,32",
+            "runs": 3,
+        }
+    ) == [
+        "use-case-sweep", "short-labeling", "all", "8,16,24,32", "3",
+    ]

--- a/automation/test-execution/README.md
+++ b/automation/test-execution/README.md
@@ -33,7 +33,7 @@ Tests vLLM in online serving mode with concurrent requests.
 Tests vLLM in offline batch mode (vllm bench throughput).
 
 **CLI (recommended):**
-- `../../cpueval run --suite offline-batch` — see [cpueval CLI Guide](../../docs/cpueval-cli.md)
+- `../../cpueval --suite offline-batch` — see [cpueval CLI Guide](../../docs/cpueval-cli.md)
 
 **Playbook:**
 - `ansible/llm-benchmark-offline-batch.yml` - Offline batch benchmark
@@ -103,13 +103,13 @@ ansible-playbook -i ansible/inventory/hosts.yml ansible/llm-benchmark-concurrent
 
 ```bash
 # Default: all 11 use cases, 3 runs each
-./cpueval run --suite offline-batch
+./cpueval --suite offline-batch
 
 # All use cases, all RedHatAI models, 5 runs each
-./cpueval run --suite offline-batch --mode use-cases --runs 5 --models all
+./cpueval --suite offline-batch --mode use-cases --runs 5 --models all
 
 # Single use case with core sweep
-./cpueval run --suite offline-batch \
+./cpueval --suite offline-batch \
   --mode use-case-sweep \
   --use-case summarization \
   --models all \
@@ -118,7 +118,7 @@ ansible-playbook -i ansible/inventory/hosts.yml ansible/llm-benchmark-concurrent
 
 # RHAIIS container image
 export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
-./cpueval run --suite offline-batch --mode use-cases --runs 3 --models all
+./cpueval --suite offline-batch --mode use-cases --runs 3 --models all
 ```
 
 **Via bash script (advanced):**

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/Home.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/Home.py
@@ -230,8 +230,8 @@ with tab1:
     **Offline Batch Tests:**
     ```bash
     # Recommended: from repository root
-    ./cpueval run --suite offline-batch
-    ./cpueval run --suite offline-batch --mode use-cases --runs 5 --models all
+    ./cpueval --suite offline-batch
+    ./cpueval --suite offline-batch --mode use-cases --runs 5 --models all
 
     # Advanced: bash script directly
     cd automation/test-execution/scripts/bash
@@ -240,7 +240,7 @@ with tab1:
 
     # RHAIIS container
     export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
-    ./cpueval run --suite offline-batch --mode use-cases --runs 3 --models all
+    ./cpueval --suite offline-batch --mode use-cases --runs 3 --models all
     ```
 
     **Offline batch results are saved to:** `results/llm/`

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/4_📦_Offline_Batch.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/4_📦_Offline_Batch.py
@@ -525,8 +525,8 @@ def main():
         st.warning("No benchmark results found. Run some benchmarks first!")
         st.code(
             "# Run a benchmark (from repository root):\n"
-            "./cpueval run --suite offline-batch\n"
-            "./cpueval run --suite offline-batch --mode use-cases --runs 5 --models all\n"
+            "./cpueval --suite offline-batch\n"
+            "./cpueval --suite offline-batch --mode use-cases --runs 5 --models all\n"
             "\n"
             "# Or via bash script:\n"
             "cd automation/test-execution/scripts/bash\n"

--- a/docs/cpueval-cli.md
+++ b/docs/cpueval-cli.md
@@ -13,17 +13,17 @@ Matrix-first CLI for running comprehensive CPU benchmarks. Most suites run full 
 
 ```bash
 # Matrix suites - run full matrices (no --model required!)
-./cpueval run --suite rhaiis-sweep           # 60 combinations: 5 models × 3 cores × 4 workloads
-./cpueval run --suite embedding              # 30 combinations: 5 models × 3 cores × 2 scenarios
-./cpueval run --suite offline-batch          # 33 runs: use-cases 3
-./cpueval run --suite audio                  # Default: all models, transcription-throughput scenario, 32 cores
+./cpueval --suite rhaiis-sweep           # 60 combinations: 5 models × 3 cores × 4 workloads
+./cpueval --suite embedding              # 30 combinations: 5 models × 3 cores × 2 scenarios
+./cpueval --suite offline-batch          # 33 runs: use-cases 3
+./cpueval --suite audio                  # Default: all models, transcription-throughput scenario, 32 cores
 
 # Override to narrow
-./cpueval run --suite rhaiis-sweep --models tiny --cores 8
-./cpueval run --suite embedding --models quick --cores 4
+./cpueval --suite rhaiis-sweep --models tiny --cores 8
+./cpueval --suite embedding --models quick --cores 4
 
 # Single-shot suites (--model required)
-./cpueval run --suite chat-smoke --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --cores 8
+./cpueval --suite chat-smoke --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --cores 8
 
 # Explore
 ./cpueval list                    # Shows Matrix vs Single type
@@ -165,40 +165,42 @@ Verifies:
 - Required environment variables set
 - Host connectivity (unless --no-ping)
 
-### run - Execute benchmarks
+### Execute benchmarks
+
+> `cpueval run --suite …` is also accepted for backward compatibility.
 
 **Common options:**
-- `--suite/-s` (required) - Suite name
-- `--model/-m` - Model ID (overrides suite default)
-- `--cores/-c` - CPU core count
-- `--workload/-w` - Workload type
-- `--scenario` - Test scenario (audio suites)
-- `--dry-run` - Print command without running
-- `--skip-doctor` - Skip health checks
+- `--suite/-s` (required): Suite name
+- `--model/-m`: Model ID (overrides suite default)
+- `--cores/-c`: CPU core count
+- `--workload/-w`: Workload type
+- `--scenario`: Test scenario (audio suites)
+- `--dry-run`: Print command without running
+- `--skip-doctor`: Skip health checks
 
 **LLM Examples:**
 
 ```bash
 # Quick chat smoke test
-./cpueval run --suite chat-smoke \
+./cpueval --suite chat-smoke \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 16 \
   --workload chat
 
-# Concurrent load test (single model, single workload)
-./cpueval run --suite concurrent-load \
+# Concurrent load sweep (narrowed to single model/workload)
+./cpueval --suite concurrent-load \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 32 \
   --workload summarization
 
 # Dry run to see command
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
   --cores 16 \
   --dry-run
 ```
 
-`--dry-run` prints the underlying Ansible command without executing:
+`--dry-run` prints the underlying command without executing (ansible-playbook for ansible suites, bash script for script suites):
 
 ```text
 ansible-playbook -i .../inventory/hosts.yml .../llm-benchmark-auto.yml \
@@ -211,13 +213,13 @@ ansible-playbook -i .../inventory/hosts.yml .../llm-benchmark-auto.yml \
 
 ```bash
 # Transcription throughput test (single model)
-./cpueval run --suite audio \
+./cpueval --suite audio \
   --models openai/whisper-small \
   --scenario transcription-throughput \
   --cores 32
 
 # Quick audio test (single model)
-./cpueval run --suite audio \
+./cpueval --suite audio \
   --models openai/whisper-tiny \
   --scenario quick-test \
   --cores 16
@@ -226,7 +228,7 @@ ansible-playbook -i .../inventory/hosts.yml .../llm-benchmark-auto.yml \
 **Embedding Example:**
 
 ```bash
-./cpueval run --suite embedding \
+./cpueval --suite embedding \
   --model RedHatAI/granite-embedding-english-r2 \
   --cores 16
 ```
@@ -235,13 +237,13 @@ ansible-playbook -i .../inventory/hosts.yml .../llm-benchmark-auto.yml \
 
 ```bash
 # Default: all 11 use cases, 3 runs each
-./cpueval run --suite offline-batch
+./cpueval --suite offline-batch
 
 # All use cases, all RedHatAI models, 5 runs each
-./cpueval run --suite offline-batch --mode use-cases --runs 5 --models all
+./cpueval --suite offline-batch --mode use-cases --runs 5 --models all
 
 # Single use case with core sweep
-./cpueval run --suite offline-batch \
+./cpueval --suite offline-batch \
   --mode use-case-sweep \
   --use-case summarization \
   --models all \
@@ -249,7 +251,7 @@ ansible-playbook -i .../inventory/hosts.yml .../llm-benchmark-auto.yml \
   --runs 3
 
 # Fast smoke test (minimal tokens)
-./cpueval run --suite offline-batch \
+./cpueval --suite offline-batch \
   --mode run_test \
   --model RedHatAI/TinyLlama-1.1B-Chat-v1.0-pruned2.4 \
   --dataset random \
@@ -259,11 +261,11 @@ ansible-playbook -i .../inventory/hosts.yml .../llm-benchmark-auto.yml \
   --output-len 16
 
 # Technical benchmarks
-./cpueval run --suite offline-batch --mode batch-scaling --model <model> --cores 16
+./cpueval --suite offline-batch --mode batch-scaling --model <model> --cores 16
 
 # RHAIIS container image
 export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
-./cpueval run --suite offline-batch --mode use-cases --runs 3 --models all
+./cpueval --suite offline-batch --mode use-cases --runs 3 --models all
 ```
 
 **Offline-batch flags:** `--mode`, `--runs`, `--use-case`, `--models`/`--model`,
@@ -274,13 +276,13 @@ Escape hatch: `--extra args="..."`.
 
 ```bash
 # Test with multiple core counts in one run
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
   --extra core_sweep_counts="[8,16,32,64]" \
   --workload chat
 
 # Single core count (use --cores for clarity)
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
   --cores 16 \
   --workload chat
@@ -292,13 +294,13 @@ Escape hatch: `--extra args="..."`.
 # RHAIIS models work with standard concurrent-load suite
 export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
 
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16 \
   --cores 16 \
   --workload chat
 
 # Core sweep with RHAIIS
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16 \
   --extra core_sweep_counts="[8,16,32]" \
   --workload chat
@@ -309,7 +311,7 @@ export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
 **Simple pinning via CLI flags:**
 
 ```bash
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 32 \
   --vllm-cpu-start 64 \
@@ -326,13 +328,13 @@ file anywhere on disk.
 
 ```bash
 # Built-in profile (resolved from automation/cli/profiles/)
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 32 \
   --profile dual-socket-split
 
 # Custom profile by path
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 32 \
   --profile ~/my-profiles/my-server.yaml
@@ -344,7 +346,7 @@ file anywhere on disk.
 |---------|----------|
 | `dual-socket-split` | Dual-socket system — vLLM pinned to socket 1 (cores 64–95, NUMA 1), GuideLLM pinned to socket 0 (cores 0–31, NUMA 0) |
 
-To list profiles available on disk:
+To list profiles available:
 
 ```bash
 ./cpueval profiles
@@ -353,14 +355,14 @@ To list profiles available on disk:
 **Advanced: extra vars:**
 
 ```bash
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 32 \
   --extra vllm_cpu_start=64 \
   --extra vllm_numa_node=1
 
 # Or from a file (path relative to your current working directory, or absolute)
-./cpueval run --suite concurrent-load \
+./cpueval --suite concurrent-load \
   --model meta-llama/Llama-3.2-1B-Instruct \
   --cores 32 \
   --extra-vars-file my-config.yaml        # relative to CWD
@@ -529,22 +531,22 @@ guidellm_numa_node: 0
 
 Use it:
 ```bash
-./cpueval run --suite concurrent-load --model my-model --cores 32 --profile my-profile
+./cpueval --suite concurrent-load --model my-model --cores 32 --profile my-profile
 ```
 
 ## Architecture
 
 cpueval is a **thin wrapper** that:
-- Generates `ansible-playbook` commands from suite definitions
-- Streams stdout/stderr (no log hiding)
-- Does **NOT** reimplement deploy/GuideLLM/vLLM logic
-- Provides progressive disclosure for CPU pinning
+- Generates `ansible-playbook` commands from suite definitions;
+- Streams stdout/stderr (no log hiding);
+- Does **NOT** reimplement deploy/GuideLLM/vLLM logic;
+- Provides progressive disclosure for CPU pinning.
 
 **Design principles:**
-- Thin wrapper only (subprocess invocation, not Python reimplementation)
-- Suites are YAML data, not hard-coded
-- Env-based inventory
-- Progressive disclosure (simple `--cores`, advanced pinning optional)
+- Thin wrapper only (subprocess invocation, not Python reimplementation);
+- Suites are YAML data, not hard-coded;
+- Env-based inventory;
+- Progressive disclosure (simple `--cores`, advanced pinning optional).
 
 ## Troubleshooting
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -177,7 +177,7 @@ Use `./cpueval doctor --no-ping` to skip host connectivity checks.
 #### 4. Run Platform Setup (Optional)
 
 ```bash
-./cpueval run --suite setup-platform
+./cpueval --suite setup-platform
 ```
 
 This configures CPU isolation, performance governor, NUMA optimizations, etc.
@@ -192,26 +192,26 @@ This configures CPU isolation, performance governor, NUMA optimizations, etc.
 ./cpueval show rhaiis-sweep
 
 # Preview the command before running
-./cpueval run --suite chat-smoke \
+./cpueval --suite chat-smoke \
   --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
   --cores 16 --dry-run
 
 # Quick chat test
-./cpueval run --suite chat-smoke \
+./cpueval --suite chat-smoke \
   --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
   --cores 16
 
 # Matrix sweep (narrowed scope)
-./cpueval run --suite rhaiis-sweep --models tiny --cores 8 --workloads chat
+./cpueval --suite rhaiis-sweep --models tiny --cores 8 --workloads chat
 
 # Audio benchmarking
-./cpueval run --suite audio \
+./cpueval --suite audio \
   --model openai/whisper-small \
   --scenario quick-test \
   --cores 32
 
 # Embedding models (full matrix)
-./cpueval run --suite embedding
+./cpueval --suite embedding
 ```
 
 `--dry-run` prints the underlying Ansible command without executing — useful

--- a/docs/methodology/offline-batch.md
+++ b/docs/methodology/offline-batch.md
@@ -9,7 +9,7 @@ raw inference performance.
 
 > **Tool:** `vllm bench throughput` (direct Python API via Podman container)
 >
-> **CLI:** `./cpueval run --suite offline-batch` (recommended)
+> **CLI:** `./cpueval --suite offline-batch` (recommended)
 >
 > **Playbook:** `llm-benchmark-offline-batch.yml`
 >
@@ -177,13 +177,13 @@ From the repository root:
 
 ```bash
 # Default: all 11 use cases, 3 runs each
-./cpueval run --suite offline-batch
+./cpueval --suite offline-batch
 
 # All use cases, all RedHatAI models, 5 runs each
-./cpueval run --suite offline-batch --mode use-cases --runs 5 --models all
+./cpueval --suite offline-batch --mode use-cases --runs 5 --models all
 
 # Single use case with core sweep
-./cpueval run --suite offline-batch \
+./cpueval --suite offline-batch \
   --mode use-case-sweep \
   --use-case summarization \
   --models all \
@@ -191,8 +191,8 @@ From the repository root:
   --runs 3
 
 # Technical benchmarks
-./cpueval run --suite offline-batch --mode core-scaling --model <model>
-./cpueval run --suite offline-batch --mode batch-scaling --model <model> --cores 16
+./cpueval --suite offline-batch --mode core-scaling --model <model>
+./cpueval --suite offline-batch --mode batch-scaling --model <model> --cores 16
 ```
 
 cpueval maps `--mode`, `--runs`, `--use-case`, `--models`, `--cores`, `--dataset`,

--- a/docs/test-suites.md
+++ b/docs/test-suites.md
@@ -9,13 +9,13 @@ run, how to run it, and where to read the detailed methodology.
 
 | Suite | Type | Status | cpueval command | Detailed docs |
 | --- | --- | --- | --- | --- |
-| Concurrent Load | Matrix | Validated | `cpueval run --suite concurrent-load` | [Concurrent Load](../tests/concurrent-load/concurrent-load.md) |
-| RHAIIS Sweep | Matrix | Validated | `cpueval run --suite rhaiis-sweep` | [RHAIIS Testing](../tests/concurrent-load/rhaiis-testing.md) |
+| Concurrent Load | Matrix | Validated | `cpueval --suite concurrent-load` | [Concurrent Load](../tests/concurrent-load/concurrent-load.md) |
+| RHAIIS Sweep | Matrix | Validated | `cpueval --suite rhaiis-sweep` | [RHAIIS Testing](../tests/concurrent-load/rhaiis-testing.md) |
 | Scalability | Manual/Ansible | WIP | Ansible playbooks | [Scalability](../tests/scalability/scalability.md) |
-| Offline Batch | Matrix | Validated | `cpueval run --suite offline-batch` | [Offline Batch](../tests/offline-batch/offline-batch.md) |
-| Embedding | Matrix | Validated | `cpueval run --suite embedding` | [Embedding Models](../tests/embedding-models/embedding-models.md) |
-| Audio | Matrix | Validated | `cpueval run --suite audio` | [Audio Models](../tests/audio-models/) |
-| Chat Smoke | Single-shot | Validated | `cpueval run --suite chat-smoke --model <model>` | [cpueval CLI](cpueval-cli.md) |
+| Offline Batch | Matrix | Validated | `cpueval --suite offline-batch` | [Offline Batch](../tests/offline-batch/offline-batch.md) |
+| Embedding | Matrix | Validated | `cpueval --suite embedding` | [Embedding Models](../tests/embedding-models/embedding-models.md) |
+| Audio | Matrix | Validated | `cpueval --suite audio` | [Audio Models](../tests/audio-models/) |
+| Chat Smoke | Single-shot | Validated | `cpueval --suite chat-smoke --model <model>` | [cpueval CLI](cpueval-cli.md) |
 | Resource Contention | Planned | Planned | — | [Resource Contention](../tests/resource-contention/resource-contention.md) |
 
 **Status legend:** Validated = production-ready, WIP = in progress, Planned = not yet implemented.
@@ -24,13 +24,13 @@ run, how to run it, and where to read the detailed methodology.
 
 | Your goal | Recommended suite | Example command |
 | --- | --- | --- |
-| LLM serving under concurrency | `concurrent-load` | `./cpueval run --suite concurrent-load` |
-| RHAIIS model matrix sweep | `rhaiis-sweep` | `./cpueval run --suite rhaiis-sweep` |
-| Bulk/offline document processing | `offline-batch` | `./cpueval run --suite offline-batch` |
-| Embedding throughput and latency | `embedding` | `./cpueval run --suite embedding` |
-| Audio transcription (Whisper) | `audio` | `./cpueval run --suite audio --scenario quick-test` |
+| LLM serving under concurrency | `concurrent-load` | `./cpueval --suite concurrent-load` |
+| RHAIIS model matrix sweep | `rhaiis-sweep` | `./cpueval --suite rhaiis-sweep` |
+| Bulk/offline document processing | `offline-batch` | `./cpueval --suite offline-batch` |
+| Embedding throughput and latency | `embedding` | `./cpueval --suite embedding` |
+| Audio transcription (Whisper) | `audio` | `./cpueval --suite audio --scenario quick-test` |
 | Maximum throughput curves | `scalability` | Ansible playbooks (see [Scalability](../tests/scalability/scalability.md)) |
-| Quick sanity check | `chat-smoke` or `health` | `./cpueval run --suite chat-smoke --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --cores 8` |
+| Quick sanity check | `chat-smoke` or `health` | `./cpueval --suite chat-smoke --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --cores 8` |
 
 ## cpueval Workflow
 
@@ -47,11 +47,11 @@ A typical session looks like this:
 ./cpueval doctor
 
 # 4. Preview the underlying command (no execution)
-./cpueval run --suite chat-smoke \
+./cpueval --suite chat-smoke \
   --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --cores 8 --dry-run
 
 # 5. Run the benchmark
-./cpueval run --suite chat-smoke \
+./cpueval --suite chat-smoke \
   --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --cores 8
 
 # 6. View results
@@ -125,9 +125,9 @@ Tip: Set required environment variables:
   export LOADGEN_HOSTNAME=<loadgen-host>
 ```
 
-### `./cpueval run --dry-run` output
+### `./cpueval --dry-run` output
 
-Shows the underlying Ansible command without executing:
+Shows the underlying command without executing:
 
 ```text
 ansible-playbook -i .../inventory/hosts.yml .../llm-benchmark-auto.yml \
@@ -177,16 +177,16 @@ without requiring `--model`.
 
 ```bash
 # Run full matrices
-./cpueval run --suite rhaiis-sweep
-./cpueval run --suite concurrent-load
-./cpueval run --suite embedding
-./cpueval run --suite offline-batch
-./cpueval run --suite audio
+./cpueval --suite rhaiis-sweep
+./cpueval --suite concurrent-load
+./cpueval --suite embedding
+./cpueval --suite offline-batch
+./cpueval --suite audio
 
 # Narrow scope with overrides
-./cpueval run --suite rhaiis-sweep --models tiny --cores 8
-./cpueval run --suite concurrent-load --models tiny --workload chat --cores 32
-./cpueval run --suite embedding --models quick --cores 4
+./cpueval --suite rhaiis-sweep --models tiny --cores 8
+./cpueval --suite concurrent-load --models tiny --workload chat --cores 32
+./cpueval --suite embedding --models quick --cores 4
 ```
 
 ### Single-Shot Suites (require `--model`)
@@ -198,7 +198,7 @@ without requiring `--model`.
 | `health` | Health check for DUT and load generator |
 
 ```bash
-./cpueval run --suite chat-smoke \
+./cpueval --suite chat-smoke \
   --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --cores 8
 ```
 
@@ -275,7 +275,7 @@ See individual suite docs for complete test case listings.
 ### Recommended: cpueval CLI
 
 ```bash
-./cpueval run --suite <suite-name> [options]
+./cpueval --suite <suite-name> [options]
 ```
 
 See [cpueval CLI Guide](cpueval-cli.md) for full options, CPU pinning, and

--- a/tests/offline-batch/offline-batch.md
+++ b/tests/offline-batch/offline-batch.md
@@ -103,7 +103,7 @@ Performance characterization tests:
 The test scenarios are implemented in:
 
 **cpueval CLI (recommended entry point):**
-- `./cpueval run --suite offline-batch` — wraps the bash suite below
+- `./cpueval --suite offline-batch` — wraps the bash suite below
 - See [cpueval CLI Guide](../../docs/cpueval-cli.md) for suite options and overrides
 
 **Bash Test Suite:**
@@ -130,13 +130,13 @@ From the repository root:
 
 ```bash
 # Default: all 11 use cases, 3 runs each (TinyLlama pruned)
-./cpueval run --suite offline-batch
+./cpueval --suite offline-batch
 
 # All use cases, 5 runs, all 4 RedHatAI models
-./cpueval run --suite offline-batch --mode use-cases --runs 5 --models all
+./cpueval --suite offline-batch --mode use-cases --runs 5 --models all
 
 # Single use case with core sweep
-./cpueval run --suite offline-batch \
+./cpueval --suite offline-batch \
   --mode use-case-sweep \
   --use-case summarization \
   --models all \
@@ -144,7 +144,7 @@ From the repository root:
   --runs 3
 
 # Single test configuration
-./cpueval run --suite offline-batch \
+./cpueval --suite offline-batch \
   --mode run_test \
   --model all \
   --dataset sonnet \
@@ -153,7 +153,7 @@ From the repository root:
 
 # RHAIIS container image
 export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
-./cpueval run --suite offline-batch --mode use-cases --runs 3 --models all
+./cpueval --suite offline-batch --mode use-cases --runs 3 --models all
 ```
 
 Modes: `use-cases`, `use-case-sweep`, `baseline`, `batch-scaling`, `input-scaling`,

--- a/tests/tests.md
+++ b/tests/tests.md
@@ -36,7 +36,7 @@ for examples and the full prefix table.
 
 ```bash
 # Recommended: cpueval CLI
-./cpueval run --suite <suite-name> [options]
+./cpueval --suite <suite-name> [options]
 
 # Ansible
 cd automation/test-execution/ansible


### PR DESCRIPTION
Execution is now the default action: passing --suite at the top level
runs the suite without requiring the run subcommand. cpueval run --suite
is kept as a backward-compatible alias.

**CLI:** extract `_execute_suite()`, hoist all options into
`@app.callback(invoke_without_command=True)`, slim `run()` to a thin wrapper.
Update profiles footer to drop redundant `--model`.

**Tests:** add `test_implicit_rhaiis_sweep_dry_run`,
`test_implicit_concurrent_load_dry_run`, `test_implicit_matches_explicit_run`
(55/55 pass). Also expands offline-batch use-case coverage (Tier 1/2 use-case-sweep).
CI: add smoke-test step for both implicit and explicit forms.

**Docs:** replace `./cpueval run --suite` with `./cpueval --suite` across all
example invocations (cpueval-cli.md, test-suites.md, getting-started.md,
offline-batch.md, README files, YAML comments, dashboard examples).
Rename section header, add backward-compat alias note, fix misleading
concurrent-load comment, generalize dry-run output description.