### PR TITLE
docs(cpueval): consistent option-list style + expand harness gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,8 @@ results/*.csv
 *.csv
 
 # Local test harnesses (not for commit)
-run-parallel-3inst.sh
+run-parallel-*.sh
+run-embed-*.sh
 
 # Log directories
 logs/

--- a/automation/cli/README.md
+++ b/automation/cli/README.md
@@ -134,12 +134,12 @@ done
 > `cpueval run --suite …` is also accepted for backward compatibility.
 
 **Common options:**
-- `--suite/-s` (required): Suite name
-- `--model/-m`: Model ID
-- `--cores/-c`: CPU core count
-- `--workload/-w`: Workload type
-- `--dry-run`: Print command without running
-- `--skip-doctor`: Skip health checks
+- `--suite`/`-s` (required); Suite name
+- `--model`/`-m`; Model ID
+- `--cores`/`-c`; CPU core count
+- `--workload`/`-w`; Workload type
+- `--dry-run`; Print command without running
+- `--skip-doctor`; Skip health checks
 
 **LLM Examples:**
 

--- a/docs/cpueval-cli.md
+++ b/docs/cpueval-cli.md
@@ -170,13 +170,13 @@ Verifies:
 > `cpueval run --suite …` is also accepted for backward compatibility.
 
 **Common options:**
-- `--suite/-s` (required): Suite name
-- `--model/-m`: Model ID (overrides suite default)
-- `--cores/-c`: CPU core count
-- `--workload/-w`: Workload type
-- `--scenario`: Test scenario (audio suites)
-- `--dry-run`: Print command without running
-- `--skip-doctor`: Skip health checks
+- `--suite`/`-s` (required); Suite name
+- `--model`/`-m`; Model ID (overrides suite default)
+- `--cores`/`-c`; CPU core count
+- `--workload`/`-w`; Workload type
+- `--scenario`; Test scenario (audio suites)
+- `--dry-run`; Print command without running
+- `--skip-doctor`; Skip health checks
 
 **LLM Examples:**
 


### PR DESCRIPTION
Switch CLI flag bullets in both docs from colon to semicolon separator and split backticks around the / between flag and short form (--suite`/`-s). Expand .gitignore harness pattern from run-parallel-3inst.sh to run-parallel-*.sh and add run-embed-*.sh so all local harness scripts are covered.