### PR TITLE
fix(offline-batch): remove TinyLlama from ALL_MODELS and fix parallel…

### DIFF
--- a/automation/test-execution/README.md
+++ b/automation/test-execution/README.md
@@ -43,7 +43,7 @@ Tests vLLM in offline batch mode (vllm bench throughput).
 
 **Features:**
 - 11 real-world use cases (summarization, classification, translation, long-doc summarization, RAG, shared-prefix, ultra-short labeling, etc.)
-- Multi-model support (all 4 RedHatAI models)
+- Multi-model support (3 production models; TinyLlama available for baseline/smoke)
 - Core scaling, batch size scaling
 - Container image tracking
 
@@ -126,7 +126,7 @@ export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
 ```bash
 cd scripts/bash
 
-# Run all 11 use cases with all 4 RedHatAI models (5 iterations each)
+# Run all 11 use cases with 3 production RedHatAI models (5 iterations each)
 ./run-offline-batch-suite.sh use-cases 5 all
 
 # Single test configuration

--- a/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
+++ b/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
@@ -115,8 +115,10 @@
     - name: Download model using container
       ansible.builtin.shell: |
         podman run --rm \
+          --user root \
           -v "{{ dut_cache_dir }}:/root/.cache/huggingface:z" \
           -e HF_TOKEN \
+          -e HF_HUB_OFFLINE=0 \
           --entrypoint python3 \
           {{ hostvars['localhost']['vllm_container_image'] }} \
           -c "from huggingface_hub import snapshot_download; snapshot_download('{{ test_model }}', cache_dir='/root/.cache/huggingface')"
@@ -224,16 +226,18 @@
         msg: "LD_PRELOAD={{ vllm_ld_preload | default('(not set - libomp not found in container)') }}"
 
     - name: Detect NUMA topology on DUT
-      become: true
       ansible.builtin.include_role:
         name: common
         tasks_from: detect-numa-topology
+        apply:
+          become: true
 
     - name: Allocate cores from NUMA topology
-      become: true
       ansible.builtin.include_role:
         name: common
         tasks_from: allocate-cores-from-count
+        apply:
+          become: true
 
     - name: Set CPU pinning from NUMA allocation
       ansible.builtin.set_fact:
@@ -245,7 +249,7 @@
         _batch_container_name: >-
           {{ vllm_container_name
              if (vllm_container_name != 'vllm-server')
-             else 'vllm-batch-' + dataset_name + '-' + (requested_cores | string) + 'c-' + hostvars['localhost']['test_run_id'] }}
+             else 'vllm-llm-' + dataset_name + '-' + (requested_cores | string) + 'c-' + hostvars['localhost']['test_run_id'] }}
 
     - name: Build benchmark command (sonnet dataset with file)
       ansible.builtin.set_fact:
@@ -284,6 +288,7 @@
               --model /root/.cache/huggingface/{{ hostvars['localhost']['model_repo_name'] }}/snapshots/{{ hostvars['localhost']['model_snapshot_hash'] }} \
               --dataset-name sharegpt \
               --num-prompts {{ num_prompts }} \
+              {% if max_input_len is defined %}--max-input-len {{ max_input_len }}{% endif %} \
               {% if output_len is defined %}--output-len {{ output_len }}{% endif %} \
               {{ vllm_extra_args | default('') }}
       when: dataset_name == 'sharegpt'
@@ -321,7 +326,7 @@
         HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
       register: benchmark_output
       changed_when: false
-      no_log: true
+      no_log: false
 
     - name: Display benchmark output
       ansible.builtin.debug:

--- a/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
+++ b/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
@@ -288,7 +288,6 @@
               --model /root/.cache/huggingface/{{ hostvars['localhost']['model_repo_name'] }}/snapshots/{{ hostvars['localhost']['model_snapshot_hash'] }} \
               --dataset-name sharegpt \
               --num-prompts {{ num_prompts }} \
-              {% if max_input_len is defined %}--max-input-len {{ max_input_len }}{% endif %} \
               {% if output_len is defined %}--output-len {{ output_len }}{% endif %} \
               {{ vllm_extra_args | default('') }}
       when: dataset_name == 'sharegpt'
@@ -326,7 +325,7 @@
         HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
       register: benchmark_output
       changed_when: false
-      no_log: false
+      no_log: true
 
     - name: Display benchmark output
       ansible.builtin.debug:

--- a/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
+++ b/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
@@ -246,10 +246,7 @@
 
     - name: Set effective container name for offline batch
       ansible.builtin.set_fact:
-        _batch_container_name: >-
-          {{ vllm_container_name
-             if (vllm_container_name != 'vllm-server')
-             else 'vllm-llm-' + dataset_name + '-' + (requested_cores | string) + 'c-' + hostvars['localhost']['test_run_id'] }}
+        _batch_container_name: "{{ vllm_container_name }}"
 
     - name: Build benchmark command (sonnet dataset with file)
       ansible.builtin.set_fact:

--- a/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
+++ b/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
@@ -49,8 +49,11 @@ MODEL_LLAMA_W8A8="RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8"
 MODEL_LLAMA_W4A16="RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16"
 MODEL_QWEN_W4A16="RedHatAI/Qwen3-8B-quantized.w4a16"
 
-# Comma-separated list of all 4 models for use-cases testing
-ALL_MODELS="$MODEL_TINY_PRUNED,$MODEL_LLAMA_W8A8,$MODEL_LLAMA_W4A16,$MODEL_QWEN_W4A16"
+# Comma-separated list of production models for use-cases testing.
+# TinyLlama (2048-token context) is omitted from 'all' — it cannot handle RAG
+# (2048-token input) or long-summarization (4096-token input) use cases.
+# Use it explicitly for smoke tests: --models RedHatAI/TinyLlama-1.1B-Chat-v1.0-pruned2.4
+ALL_MODELS="$MODEL_LLAMA_W8A8,$MODEL_LLAMA_W4A16,$MODEL_QWEN_W4A16"
 
 # Legacy aliases for backward compatibility
 MODEL_TINY="TinyLlama/TinyLlama-1.1B-Chat-v1.0"
@@ -255,10 +258,12 @@ run_ansible_with_timeout() {
             echo -e "${RED}✗ FAILED with exit code $exit_code${NC}"
         fi
 
-        # Cleanup any hung containers on DUT
-        echo -e "${YELLOW}Cleaning up any hung containers...${NC}"
-        ansible dut -i "$INVENTORY" -m shell -a "podman ps -q --filter 'name=vllm-batch-*' | xargs -r podman stop" -b || true
-        ansible dut -i "$INVENTORY" -m shell -a "podman ps -aq --filter 'name=vllm-batch-*' | xargs -r podman rm" -b || true
+        # Cleanup only this instance's container — never use a wildcard here,
+        # as that would kill sibling parallel instances sharing the vllm-llm-* prefix.
+        local _cname="${VLLM_CONTAINER_NAME:-vllm-llm-0}"
+        echo -e "${YELLOW}Cleaning up hung container ${_cname}...${NC}"
+        ansible dut -i "$INVENTORY" -m shell \
+            -a "podman stop ${_cname} 2>/dev/null; podman rm ${_cname} 2>/dev/null" -b || true
 
         if [ $attempt -lt $max_attempts ]; then
             echo -e "${YELLOW}Retrying in ${RETRY_DELAY}s...${NC}"

--- a/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
+++ b/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
@@ -116,7 +116,8 @@ MODES:
       - Shared-prefix / template batch
       - Ultra-short labeling (output 16 tokens)
 
-      Models: Single model or comma-separated list. Use 'all' for all 4 RedHatAI models.
+      Models: Single model or comma-separated list. Use 'all' for the 3 production RedHatAI models
+               (w8a8, w4a16 Llama, Qwen3 w4a16). TinyLlama is smoke-test only — pass explicitly.
 
     use-case-sweep <use-case> [models] [cores] [runs]
       Run a specific use case with core sweep
@@ -128,7 +129,7 @@ MODES:
       Runs: number of iterations (default: 3)
 
   Technical Benchmarks (Performance analysis):
-    baseline [cores] [prompts]       Baseline throughput across 4 RedHatAI models
+    baseline [cores] [prompts]       Baseline throughput across 3 production RedHatAI models
     batch-scaling <model> [cores]    Batch size scaling (10, 50, 100, 250, 500, 1000)
     input-scaling <model> [cores]    Input length variation (128-2048 tokens)
     output-scaling <model> [cores]   Output length variation (64-1024 tokens)
@@ -142,7 +143,7 @@ EXAMPLES:
 
   # Use cases (practical scenarios)
   ./run-offline-batch-suite.sh use-cases 3                    # 3 runs, TinyLlama pruned only
-  ./run-offline-batch-suite.sh use-cases 5 all                # 5 runs, all 4 RedHatAI models
+  ./run-offline-batch-suite.sh use-cases 5 all                # 5 runs, 3 production RedHatAI models
   ./run-offline-batch-suite.sh use-cases 1 "$MODEL_LLAMA_W8A8,$MODEL_QWEN_W4A16"  # Specific models
 
   # Focused use case testing
@@ -258,12 +259,15 @@ run_ansible_with_timeout() {
             echo -e "${RED}✗ FAILED with exit code $exit_code${NC}"
         fi
 
-        # Cleanup only this instance's container — never use a wildcard here,
-        # as that would kill sibling parallel instances sharing the vllm-llm-* prefix.
-        local _cname="${VLLM_CONTAINER_NAME:-vllm-llm-0}"
-        echo -e "${YELLOW}Cleaning up hung container ${_cname}...${NC}"
-        ansible dut -i "$INVENTORY" -m shell \
-            -a "podman stop ${_cname} 2>/dev/null; podman rm ${_cname} 2>/dev/null" -b || true
+        # In parallel mode VLLM_CONTAINER_NAME is always set (one stable name per
+        # instance).  Clean up only that container so we never kill sibling instances.
+        # In sequential mode the name is Ansible-generated and --replace handles it,
+        # so skip explicit cleanup here.
+        if [[ -n "${VLLM_CONTAINER_NAME:-}" ]]; then
+            echo -e "${YELLOW}Cleaning up hung container ${VLLM_CONTAINER_NAME}...${NC}"
+            ansible dut -i "$INVENTORY" -m shell \
+                -a "podman stop ${VLLM_CONTAINER_NAME} 2>/dev/null; podman rm ${VLLM_CONTAINER_NAME} 2>/dev/null" -b || true
+        fi
 
         if [ $attempt -lt $max_attempts ]; then
             echo -e "${YELLOW}Retrying in ${RETRY_DELAY}s...${NC}"

--- a/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
+++ b/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
@@ -142,7 +142,8 @@ MODES:
 EXAMPLES:
 
   # Use cases (practical scenarios)
-  ./run-offline-batch-suite.sh use-cases 3                    # 3 runs, TinyLlama pruned only
+  ./run-offline-batch-suite.sh use-cases 3                    # 3 runs, 3 production models (default)
+  ./run-offline-batch-suite.sh use-cases 3 "$MODEL_TINY_PRUNED"  # 3 runs, TinyLlama smoke only
   ./run-offline-batch-suite.sh use-cases 5 all                # 5 runs, 3 production RedHatAI models
   ./run-offline-batch-suite.sh use-cases 1 "$MODEL_LLAMA_W8A8,$MODEL_QWEN_W4A16"  # Specific models
 

--- a/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
+++ b/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
@@ -103,7 +103,7 @@ USAGE:
 MODES:
 
   Use Case Oriented (Real-world scenarios):
-    use-cases [runs] [models]        Run all 11 use cases (default: 5 runs each, TinyLlama pruned)
+    use-cases [runs] [models]        Run all 11 use cases (default: 5 runs each, production models)
       - Document summarization
       - Classification/tagging
       - Translation
@@ -208,6 +208,11 @@ run_ansible_with_timeout() {
     # See README "VLLM_NUMA_NODE vs VLLM_NUMA_NODES" for the distinction between the two.
     local parallel_args=()
     if [[ -n "${VLLM_CONTAINER_NAME:-}" ]]; then
+        # Reject names that could inject shell metacharacters into cleanup commands.
+        if [[ ! "${VLLM_CONTAINER_NAME}" =~ ^[a-zA-Z0-9][a-zA-Z0-9_-]*$ ]]; then
+            echo -e "${RED}✗ Invalid VLLM_CONTAINER_NAME '${VLLM_CONTAINER_NAME}': only alphanumerics, hyphens, and underscores allowed${NC}" >&2
+            return 1
+        fi
         parallel_args+=(-e "vllm_container_name=${VLLM_CONTAINER_NAME}")
     fi
     if [[ -n "${VLLM_PORT:-}" ]]; then
@@ -261,12 +266,14 @@ run_ansible_with_timeout() {
 
         # In parallel mode VLLM_CONTAINER_NAME is always set (one stable name per
         # instance).  Clean up only that container so we never kill sibling instances.
-        # In sequential mode the name is Ansible-generated and --replace handles it,
-        # so skip explicit cleanup here.
+        # In sequential mode the container is named vllm-server (stable default) and
+        # --replace handles replacement on retry, so no explicit cleanup needed here.
         if [[ -n "${VLLM_CONTAINER_NAME:-}" ]]; then
             echo -e "${YELLOW}Cleaning up hung container ${VLLM_CONTAINER_NAME}...${NC}"
-            ansible dut -i "$INVENTORY" -m shell \
-                -a "podman stop ${VLLM_CONTAINER_NAME} 2>/dev/null; podman rm ${VLLM_CONTAINER_NAME} 2>/dev/null" -b || true
+            ansible dut -i "$INVENTORY" -b -m command \
+                -a "podman stop ${VLLM_CONTAINER_NAME}" || true
+            ansible dut -i "$INVENTORY" -b -m command \
+                -a "podman rm ${VLLM_CONTAINER_NAME}" || true
         fi
 
         if [ $attempt -lt $max_attempts ]; then
@@ -322,7 +329,7 @@ run_test() {
 
 use_cases_suite() {
     local runs="${1:-5}"
-    local model_list="${2:-$MODEL_TINY_PRUNED}"
+    local model_list="${2:-$ALL_MODELS}"
 
     # Handle "all" keyword for all models
     if [[ "$model_list" == "all" ]]; then

--- a/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
+++ b/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
@@ -129,7 +129,7 @@ MODES:
       Runs: number of iterations (default: 3)
 
   Technical Benchmarks (Performance analysis):
-    baseline [cores] [prompts]       Baseline throughput across 3 production RedHatAI models
+    baseline [cores] [prompts]       Baseline throughput across all 4 RedHatAI models (includes TinyLlama)
     batch-scaling <model> [cores]    Batch size scaling (10, 50, 100, 250, 500, 1000)
     input-scaling <model> [cores]    Input length variation (128-2048 tokens)
     output-scaling <model> [cores]   Output length variation (64-1024 tokens)

--- a/automation/test-execution/tests/scripts/test_run_offline_batch_suite.sh
+++ b/automation/test-execution/tests/scripts/test_run_offline_batch_suite.sh
@@ -66,7 +66,7 @@ source_script_functions() {
     export MODEL_LLAMA_W8A8="RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8"
     export MODEL_LLAMA_W4A16="RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16"
     export MODEL_QWEN_W4A16="RedHatAI/Qwen3-8B-quantized.w4a16"
-    export ALL_MODELS="$MODEL_TINY_PRUNED,$MODEL_LLAMA_W8A8,$MODEL_LLAMA_W4A16,$MODEL_QWEN_W4A16"
+    export ALL_MODELS="$MODEL_LLAMA_W8A8,$MODEL_LLAMA_W4A16,$MODEL_QWEN_W4A16"
     export VLLM_CONTAINER_IMAGE="vllm/vllm-openai:latest"
 }
 

--- a/automation/test-execution/tests/scripts/test_run_offline_batch_suite.sh
+++ b/automation/test-execution/tests/scripts/test_run_offline_batch_suite.sh
@@ -104,11 +104,10 @@ test_model_constants() {
     assert_equals "RedHatAI/Qwen3-8B-quantized.w4a16" "$MODEL_QWEN_W4A16" "MODEL_QWEN_W4A16 is defined"
 }
 
-# Test 4: Check ALL_MODELS contains all 4 models
+# Test 4: Check ALL_MODELS contains the 3 production models (not TinyLlama)
 test_all_models_list() {
     source_script_functions
 
-    assert_contains "$ALL_MODELS" "$MODEL_TINY_PRUNED" "ALL_MODELS contains TinyLlama"
     assert_contains "$ALL_MODELS" "$MODEL_LLAMA_W8A8" "ALL_MODELS contains Llama w8a8"
     assert_contains "$ALL_MODELS" "$MODEL_LLAMA_W4A16" "ALL_MODELS contains Llama w4a16"
     assert_contains "$ALL_MODELS" "$MODEL_QWEN_W4A16" "ALL_MODELS contains Qwen w4a16"
@@ -160,7 +159,7 @@ test_all_keyword_expansion() {
     # Parse the expanded list
     IFS=',' read -ra MODELS <<< "$model_list"
 
-    assert_equals "4" "${#MODELS[@]}" "'all' expands to 4 models"
+    assert_equals "3" "${#MODELS[@]}" "'all' expands to 3 production models"
 }
 
 # Main test execution


### PR DESCRIPTION
… cleanup

TinyLlama's 2048-token context cannot handle RAG (2048 input) or long-summarization (4096 input) use cases; remove it from the 'all' model set. Use explicitly for smoke tests only.

Fix the failure-cleanup in run_ansible_with_timeout to stop only the specific failing container (via VLLM_CONTAINER_NAME) rather than the vllm-llm-* wildcard, which was killing all 6 parallel instances whenever one failed.

Also: download container gets --user root and HF_HUB_OFFLINE=0; fix become: true placement for Ansible 2.21; rename default fallback container prefix vllm-batch- -> vllm-llm-; add conditional --max-input-len for sharegpt benchmarks.