### PR TITLE
docs: refresh README and add Apache 2.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works, within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,396 +1,121 @@
 # vLLM CPU Performance Evaluation
 
-Comprehensive performance evaluation framework for vLLM on CPU platforms.
+[![Tests](https://github.com/redhat-et/vllm-cpu-perf-eval/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/redhat-et/vllm-cpu-perf-eval/actions/workflows/unit-tests.yml)
+[![cpueval CLI Tests](https://github.com/redhat-et/vllm-cpu-perf-eval/actions/workflows/cpueval-tests.yml/badge.svg)](https://github.com/redhat-et/vllm-cpu-perf-eval/actions/workflows/cpueval-tests.yml)
+[![pre-commit](https://github.com/redhat-et/vllm-cpu-perf-eval/actions/workflows/pre-commit.yaml/badge.svg)](https://github.com/redhat-et/vllm-cpu-perf-eval/actions/workflows/pre-commit.yaml)
+[![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://redhat-et.github.io/vllm-cpu-perf-eval/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-This repository provides a complete testing methodology, automation tools, and
-platform configurations for evaluating vLLM inference performance on CPU-based
-systems.
+Performance evaluation framework for [vLLM](https://github.com/vllm-project/vllm) on CPU
+platforms — methodology, automation, and platform configurations for reproducible
+inference benchmarking.
 
 ## Quick Start
 
-See the [Quick Start Guide](docs/getting-started.md)
+The recommended entry point is the **cpueval CLI** — it wraps Ansible playbooks and
+suite scripts so you can run full test matrices without hand-writing playbook commands.
 
-## Repository Structure
+```bash
+# Set up your test hosts
+export DUT_HOSTNAME=<dut-host>
+export LOADGEN_HOSTNAME=<loadgen-host>
 
-```text
-vllm-cpu-perf-eval/
-├── README.md                           # This file
-│
-├── models/                             # Centralized model definitions
-│   ├── models.md                       # Comprehensive model documentation
-│   ├── llm-models/                     # LLM model configurations
-│   │   ├── model-matrix.yaml          # LLM model test mappings
-│   │   └── llm-models.md              # Redirects to models.md
-│   ├── embedding-models/               # Embedding model configurations
-│   │   └── model-matrix.yaml          # Embedding model test mappings
-│   └── audio-models/                   # Audio model configurations
-│       └── model-matrix.yaml          # Audio model test mappings
-│
-├── tests/                              # Test suites and scenarios
-│   ├── tests.md                        # Test suite overview
-│   ├── concurrent-load/                # Test Suite 1: Concurrent load testing
-│   │   └── concurrent-load.md         # Suite documentation
-│   ├── scalability/                    # Test Suite 2: Scalability testing
-│   │   └── scalability.md             # Suite documentation
-│   ├── resource-contention/            # Test Suite 3: Resource contention (planned)
-│   │   └── resource-contention.md     # Suite documentation
-│   ├── embedding-models/               # Embedding model test scenarios
-│   │   ├── embedding-models.md        # Embedding test documentation
-│   │   ├── baseline-sweep.md          # Baseline performance tests
-│   │   └── latency-concurrent.md      # Latency tests
-│   └── audio-models/                   # Audio model test scenarios
-│       ├── README.md                  # Audio test documentation
-│       ├── transcription-throughput.yaml
-│       ├── transcription-latency.yaml
-│       └── *.yaml                     # Additional audio scenarios
-│
-├── automation/                         # Automation framework
-│   ├── test-execution/                 # Test orchestration
-│   │   ├── ansible/                   # Ansible playbooks (primary)
-│   │   │   ├── ansible.md             # Ansible documentation
-│   │   │   ├── inventory/             # Host configurations
-│   │   │   ├── filter_plugins/        # Custom Ansible filters
-│   │   │   ├── roles/                 # Ansible roles
-│   │   │   ├── tests/                 # Ansible tests
-│   │   │   └── *.yml                  # Playbook files
-│   │   └── bash/                      # Bash automation scripts
-│   │       └── embedding/             # Embedding test scripts
-│   ├── platform-setup/                 # Platform configuration
-│   │   └── bash/                      # Platform setup scripts
-│   │       └── intel/                 # Intel-specific setup
-│   └── utilities/                      # Helper utilities
-│       ├── health-checks/             # Health check scripts
-│       └── log-monitoring/            # Log analysis tools
-│
-├── docs/                               # Documentation
-│   ├── docs.md                         # Documentation index
-│   ├── methodology/                    # Test methodology
-│   │   └── overview.md                # Testing approach and metrics
-│   └── platform-setup/                 # Platform setup guides
-│
-├── results/                            # Test results (gitignored)
-│   ├── llm/                           # LLM test results
-│   ├── audio-models/                  # Audio model test results
-│   └── results.md                     # Results documentation
-│
-├── logs/                               # Test execution logs (gitignored)
-│   ├── playbook-runs/                 # Ansible playbook execution logs
-│   └── progress/                      # Benchmark progress tracking logs
-│
-├── utils/                              # Utility scripts and tools
-│
-└── Configuration Files
-    ├── .pre-commit-config.yaml        # Pre-commit hooks configuration
-    ├── .yamllint.yaml                 # YAML linting rules
-    ├── .markdownlint-cli2.yaml        # Markdown linting rules
-    └── .gitignore                     # Git ignore patterns
+# Verify environment, then run a quick sanity check
+./cpueval doctor
+./cpueval --suite chat-smoke --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --cores 8
+
+# Explore suites and view results
+./cpueval list
+./cpueval results --last
 ```
 
-**Key Directories:**
-
-- **[models/](models/models.md)** - Model definitions reused across all test suites
-- **[tests/](tests/tests.md)** - Test suite definitions organized by testing focus
-- **[automation/test-execution/ansible/](automation/test-execution/ansible/ansible.md)** - Ansible playbooks for test execution
-- **[docs/](docs/docs.md)** - Comprehensive testing methodology and guides
-- **results/** - Local test results (gitignored, see [results.md](results/results.md))
-- **logs/** - Test execution logs (gitignored)
-  - `playbook-runs/` - Ansible playbook execution logs
-  - `progress/` - Benchmark progress tracking logs
-
-See individual directory markdown files for detailed information.
-
-## Key Features
-
-### Flexible Container Runtime Support
-
-- **Docker** or **Podman** - Use either runtime
-- **Auto-detection** - Automatically detects available runtime
-- **Rootless support** - Full Podman rootless compatibility
-
-### Centralized Model Management
-
-- Define models once, use across all test phases
-- Easy to add new models
-- Model matrix for flexible test configuration
-
-### Multi-Platform Support
-
-- Intel Xeon (Ice Lake, Sapphire Rapids)
-- AMD EPYC
-- ARM64 (planned)
-
-### Comprehensive Automation
-
-- **Ansible playbooks** for platform setup and test execution
-- **Bash scripts** for manual operation
-- **Docker/Podman Compose** for containerized testing
-- **Distributed testing** across multiple nodes
-
-### Multiple Test Suites
-
-- **Concurrent Load**: Concurrent load testing (LLM models)
-- **Scalability**: Scalability and sweep testing (LLM models)
-- **Audio Models**: Audio transcription (ASR) benchmarking
-- **Resource Contention**: Resource contention testing (planned)
-
-### Enhanced Concurrent Load Testing
-
-- ⏱️ **Time-based testing** - Consistent 10-minute tests across CPU types
-- 1️⃣ **Single-user baseline** - Concurrency=1 for efficiency calculations
-- 📊 **Variable workloads** - Realistic traffic simulation with statistical variance
-- 🔄 **Prefix caching control** - Baseline vs production comparison
-- 🎯 **3-phase testing** - Baseline → Realistic → Production methodology
-- 🚀 **Large model support** - Added gpt-oss-20b (21B MoE) for scalability testing
-
-See [3-Phase Testing Strategy](docs/methodology/testing-phases.md) for details.
-
-## Documentation
-
-- **[Ansible Testing](automation/test-execution/ansible/ansible.md)** - Complete Ansible usage guide
-- **[Audio Benchmarking](docs/audio-benchmarking.md)** - Audio model benchmarking guide with troubleshooting
-- **[Methodology](docs/methodology/overview.md)** - Testing methodology and metrics
-- **[Platform Setup](docs/platform-setup/x86/intel/deterministic-benchmarking.md)** - Intel platform configuration
-- **[Models](models/models.md)** - Model definitions and selection
-- **[Tests](tests/tests.md)** - Test suite documentation
-
-Full documentation index: [docs/docs.md](docs/docs.md)
+See the [Getting Started Guide](docs/getting-started.md) and
+[cpueval CLI reference](docs/cpueval-cli.md) for full setup instructions.
 
 ## Test Suites
 
-> **⚠️ IMPORTANT: Validation Status and Availability**
->
-> **✅ SUPPORTED (Fully Validated):**
-> - **Concurrent Load Testing (Phase 1 & Phase 2)** - Ready for use
->   - Playbooks: `llm-benchmark-concurrent-load.yml`, `llm-benchmark-auto.yml`
->   - Documentation: [tests/concurrent-load/concurrent-load.md](tests/concurrent-load/concurrent-load.md)
->
-> **🚧 NOT YET SUPPORTED (Blocked from End User Execution):**
->
-> The following test suites are work in progress and are **automatically blocked**
-> to prevent end users from running them until they are fully validated:
->
-> - **Scalability** - Work in progress; blocked by default
->   - Playbook: `llm-core-sweep-auto.yml` (will fail with error message)
->   - Contains: sweep, synchronous, poisson tests
->
-> - **Resource Contention** - Planned; not yet implemented
->   - No test files exist yet
->
-> **Bypass for Development/Testing Only:**
->
-> If you need to run unsupported tests for development or testing purposes:
-> - Ansible: Add `-e "allow_unsupported_tests=true"` to your playbook command
-> - Bash: Export `ALLOW_UNSUPPORTED_TESTS=true` before running scripts
->
-> **Note:** Unsupported tests are provided as-is with no guarantees they will
-> work without modification. Only use them if you understand the risks and are
-> willing to troubleshoot issues independently.
+| Suite | Status | Entry point |
+| --- | --- | --- |
+| [Concurrent Load](tests/concurrent-load/concurrent-load.md) | Validated | `./cpueval --suite concurrent-load` |
+| [RHAIIS Sweep](tests/concurrent-load/rhaiis-testing.md) | Validated | `./cpueval --suite rhaiis-sweep` |
+| [Offline Batch](tests/offline-batch/offline-batch.md) | Validated | `./cpueval --suite offline-batch` |
+| [Embedding](tests/embedding-models/embedding-models.md) | Validated | `./cpueval --suite embedding` |
+| [Audio](tests/audio-models/) | Validated | `./cpueval --suite audio` |
+| [Scalability](tests/scalability/scalability.md) | WIP | Ansible playbooks |
+| [Resource Contention](tests/resource-contention/resource-contention.md) | Planned | — |
 
-### Test Suite: Concurrent Load
+Full suite reference, selection guide, and status details:
+[docs/test-suites.md](docs/test-suites.md)
 
-Tests model performance under various concurrent request loads.
+Unsupported suites (e.g. scalability) are blocked by default. For development only,
+pass `-e "allow_unsupported_tests=true"` to Ansible or set `ALLOW_UNSUPPORTED_TESTS=true`.
 
-- Concurrency levels: 1, 2, 4, 8, 16, 32
-- 7 LLM models + 2 embedding models
-- Focus: P95 latency, TTFT, throughput scaling
+## Key Features
 
-### Test Suite: Scalability
+- **cpueval CLI** — Matrix-first benchmarking across 8 suites
+- **3-phase testing** — Baseline, realistic, and production methodology ([details](docs/methodology/testing-phases.md))
+- **Ansible automation** — Distributed test execution on DUT + load generator
+- **Docker or Podman** — Auto-detected container runtime with rootless Podman support
+- **MTEB integration** — Embedding quality evaluation ([guide](docs/mteb-sweep-guide.md))
+- **Results tooling** — [Streamlit dashboards](docs/dashboards-quickstart.md) and [MLflow](docs/mlflow.md) tracking
 
-> **🚧 NOT YET SUPPORTED** - This test suite is blocked by default.
-> See validation status above for details.
+## Documentation
 
-Characterizes maximum throughput and performance curves.
+| Topic | Link |
+| --- | --- |
+| Documentation index | [docs/index.md](docs/index.md) |
+| Getting started | [docs/getting-started.md](docs/getting-started.md) |
+| cpueval CLI | [docs/cpueval-cli.md](docs/cpueval-cli.md) |
+| Ansible playbooks | [automation/test-execution/ansible/ansible.md](automation/test-execution/ansible/ansible.md) |
+| Model catalog | [models/models.md](models/models.md) |
+| Methodology & metrics | [docs/methodology/overview.md](docs/methodology/overview.md) |
+| Platform setup (Intel) | [docs/platform-setup/x86/intel/deterministic-benchmarking.md](docs/platform-setup/x86/intel/deterministic-benchmarking.md) |
 
-- Sweep tests for capacity discovery
-- Synchronous baseline tests
-- Poisson distribution tests
-- Focus: Maximum capacity, saturation points
+## Repository Layout
 
-### Test Suite: Resource Contention
-
-> **📋 PLANNED** - Not yet implemented.
-
-Multi-tenant and resource sharing scenarios.
-
-### Test Suite: Audio Models
-
-**✅ SUPPORTED** - Fully validated and ready for use.
-
-Tests audio transcription (ASR) models.
-
-**Quick Start:**
-```bash
-cd automation/test-execution/ansible
-
-# Quick test (5 files, ~2 minutes)
-ansible-playbook -i inventory/hosts.yml audio-benchmark.yml \
-  -e "test_model=openai/whisper-tiny" \
-  -e "test_scenario=transcription-throughput" \
-  -e "requested_cores=32" \
-  -e "audio_num_files=5"
-```
-
-**Key Scenarios:**
-- **transcription-throughput** - Batch processing & concurrent user testing
-- **transcription-latency** - SLA validation under load
-- **audio-duration-scaling** - Performance vs audio length
-- **constant-rate-stress** - Production readiness testing
-- **format-comparison** - Audio format optimization
-
-**Models Supported:**
-- Whisper (tiny, small, medium) - ASR transcription
-- Ultravox - Audio chat (planned, no runnable scenarios yet)
-
-**Documentation:**
-- **[Audio Benchmarking Guide](docs/audio-benchmarking.md)** - Comprehensive guide with troubleshooting
-- **[Audio Test Suite README](tests/audio-models/README.md)** - Detailed scenario documentation
-
-**Key Features:**
-- Automatic audio dependency management (librosa, soundfile, ffmpeg-python)
-- Network connectivity pre-flight checks
-- Auto-cleanup of previous containers
-- Dataset sample limiting to avoid full downloads
-- Organized results by timestamp and stage
-
-## Models
-
-Current model coverage:
-
-**LLM Models (7 total):**
-
-- Llama-3.2 (1B, 3B) - Prefill-heavy
-- TinyLlama-1.1B - Balanced small-scale
-- Granite-3.2-2B - Balanced enterprise
-- Qwen3-0.6B, Qwen2.5-3B - High-efficiency balanced
-
-**Embedding Models:** ✅ **SUPPORTED**
-
-Embedding models are fully supported with three execution modes and comprehensive dashboard analysis:
-
-- **RedHatAI/all-MiniLM-L6-v2** (22M) - Fast, lightweight
-- **RedHatAI/nomic-embed-text-v1.5** (137M) - General-purpose
-- **RedHatAI/granite-embedding-english-r2** (109M) - Enterprise
-- **RedHatAI/embeddinggemma-300m** (300M) - Medium-quality
-- **RedHatAI/Qwen3-Embedding-8B** (8B) - High-quality, long context (40K tokens)
-
-**Quick start:**
-```bash
-ansible-playbook -i inventory/hosts.yml embedding-benchmark.yml \
-  -e "test_model=RedHatAI/all-MiniLM-L6-v2" \
-  -e "scenario=all"
-```
-
-See [docs/embedding-models.md](docs/embedding-models.md) for comprehensive guide including:
-- Three execution modes (managed, dut-only, external)
-- Configurable baseline percentages
-- Custom input lengths
-- Dashboard filtering
-
-**Audio Models:**
-
-**✅ SUPPORTED** - Fully validated and ready for use.
-
-- **Whisper (tiny, small, medium)** - Speech-to-text transcription
-- **Ultravox** - Multimodal audio chat (planned, no runnable scenarios yet)
-
-See [models/models.md](models/models.md) for complete model definitions,
-selection rationale, and how to add new models.
+| Path | Purpose |
+| --- | --- |
+| `automation/` | Ansible playbooks, cpueval CLI, dashboards, MLflow |
+| `docs/` | Guides and methodology (source for the published site) |
+| `models/` | Model definitions and test matrices |
+| `tests/` | Per-suite methodology and scenario configs |
+| `results/` | Local benchmark output (gitignored) |
+| `logs/` | Execution logs (gitignored) |
 
 ## Requirements
 
-### System Requirements
+- **Hardware:** Intel Xeon (Ice Lake+) or AMD EPYC; 64 GB+ RAM recommended
+- **OS:** Ubuntu 22.04+, RHEL 9+, or Fedora 38+
+- **Software:** Python 3.10+, Docker 24+ or Podman 4+, Ansible 2.14+, vLLM, GuideLLM
 
-- **CPU**: Intel Xeon (Ice Lake or newer) or AMD EPYC
-- **Memory**: 64GB+ RAM recommended
-- **OS**: Ubuntu 22.04+, RHEL 9+, or Fedora 38+
-- **Storage**: 500GB+ for models and results
-
-### Software Requirements
-
-- Python 3.10+
-- Docker 24.0+ or Podman 4.0+
-- Ansible 2.14+ (for automation)
-- GuideLLM v0.5.0+
-- vLLM
-
-See [Ansible Documentation](automation/test-execution/ansible/ansible.md) for
-setup and configuration instructions.
-
-## Container Runtime Support
-
-This repository supports both Docker and Podman:
-
-- **Docker**: Traditional container runtime
-- **Podman**: Daemonless, rootless-capable alternative
-- **Auto-detection**: Automatically uses available runtime
-
-The Ansible playbooks automatically detect and use the available container runtime.
-For manual configuration, see the [vllm_server role](automation/test-execution/ansible/roles/vllm_server/)
-documentation.
-
-### Using Red Hat AI Inference Server Images
-
-Red Hat AI Inference Server (RHAIIS) provides enterprise-grade vLLM images optimized for Intel Xeon and AMD EPYC processors. These images require authentication:
-
-```bash
-# 1. Login and pull image manually on DUT (Ansible cannot pull authenticated images)
-ssh admin@your-dut
-
-# Login and pull with sudo (credentials stored in /root/.config/containers/auth.json)
-sudo podman login registry.redhat.io  # Enter Red Hat credentials
-sudo podman pull registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
-
-# Note: Both login and pull must use sudo together, or neither should use sudo.
-# Using sudo for only one will fail because root and user have separate auth files.
-
-# 2. Set image environment variable
-export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
-```
-
-**Important**: You must manually pull Red Hat registry images on the DUT before running tests. See [docs/embedding-models.md](docs/embedding-models.md#using-red-hat-ai-inference-server-rhaiis-images) for complete setup instructions.
-
-**Reference**: [Red Hat AI Inference Documentation](https://docs.redhat.com/en/documentation/red_hat_ai_inference/3.4/html/getting_started/about-cpu-inference_getting-started)
+See [Getting Started](docs/getting-started.md) for control-machine and DUT setup.
 
 ## Contributing
 
-Contributions are welcome! Please:
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Run pre-commit checks: `pre-commit run --all-files`
-5. Submit a pull request
-
-### Pre-commit Hooks
-
-This repository uses [pre-commit](https://pre-commit.com/) to ensure code
-quality.
+1. Fork the repository and create a feature branch
+2. Make your changes
+3. Run pre-commit checks: `pre-commit run --all-files`
+4. Open a pull request
 
 ```bash
-# Install pre-commit
 pip install pre-commit
-
-# Install hooks
 pre-commit install
 pre-commit install --hook-type commit-msg
-
-# Run manually
-pre-commit run --all-files
 ```
 
 ## License
 
-[Add license information]
+Licensed under the [Apache License, Version 2.0](LICENSE).
+
+Model weights, container images, and other third-party assets referenced by
+this project remain under their respective licenses.
 
 ## Support
 
-- **Documentation**: See [docs/](docs/)
-- **Issues**: [GitHub Issues](https://github.com/YOUR_ORG/vllm-cpu-perf-eval/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/YOUR_ORG/vllm-cpu-perf-eval/discussions)
+- **Issues:** [github.com/redhat-et/vllm-cpu-perf-eval/issues](https://github.com/redhat-et/vllm-cpu-perf-eval/issues)
+- **Discussions:** [github.com/redhat-et/vllm-cpu-perf-eval/discussions](https://github.com/redhat-et/vllm-cpu-perf-eval/discussions)
 
 ## Acknowledgments
 
-- [vLLM](https://github.com/vllm-project/vllm) - High-performance LLM
-  inference engine
-- [GuideLLM](https://github.com/vllm-project/guidellm) - LLM benchmarking tool
-- Intel and AMD for CPU optimization guidance
+- [vLLM](https://github.com/vllm-project/vllm) — High-performance LLM inference
+- [GuideLLM](https://github.com/vllm-project/guidellm) — LLM benchmarking tool

--- a/automation/cli/pyproject.toml
+++ b/automation/cli/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.10"
 authors = [
     {name = "Red Hat AI Performance Team"}
 ]
+license = "Apache-2.0"
 dependencies = [
     "typer>=0.9.0",
     "pyyaml>=6.0",


### PR DESCRIPTION
Replace the stale directory tree with a concise landing page centred on cpueval, add CI/docs/license badges, and declare Apache-2.0 for the project.