### PR TITLE
Fix/cpueval pinning and results

### DIFF
--- a/automation/cli/profiles/dual-socket-split.yaml
+++ b/automation/cli/profiles/dual-socket-split.yaml
@@ -17,7 +17,7 @@
 #     --profile dual-socket-split
 
 # Pin vLLM to socket 1 (cores 64-95)
-vllm_cpu_start: 64
+vllm_cpus: "64-95"
 vllm_numa_node: 1
 
 # Pin GuideLLM to socket 0 (cores 0-31)

--- a/automation/cli/profiles/dual-socket-split.yaml
+++ b/automation/cli/profiles/dual-socket-split.yaml
@@ -16,7 +16,10 @@
 #     --cores 32 \
 #     --profile dual-socket-split
 
-# Pin vLLM to socket 1 (cores 64-95)
+# Pin vLLM to socket 1 (cores 64-95).
+# NOTE: vllm_cpus is a *fixed range* — it overrides count-based cpuset allocation.
+# --cores only controls the auto-allocation count when vllm_cpus is NOT set.
+# With this profile, vLLM always uses all 32 cores in 64-95 regardless of --cores.
 vllm_cpus: "64-95"
 vllm_numa_node: 1
 

--- a/automation/cli/src/cpueval/cli.py
+++ b/automation/cli/src/cpueval/cli.py
@@ -102,6 +102,7 @@ def _execute_suite(
     output_len: Optional[int],
     preset: Optional[str],
     tensor_parallel: Optional[int],
+    vllm_cpus: Optional[str],
     vllm_cpu_start: Optional[int],
     vllm_numa: Optional[int],
     guidellm_cpus: Optional[str],
@@ -232,7 +233,14 @@ def _execute_suite(
         cli_vars["requested_tensor_parallel"] = tensor_parallel
 
     # CPU pinning vars
+    if vllm_cpus:
+        cli_vars["vllm_cpus"] = vllm_cpus
     if vllm_cpu_start is not None:
+        if not vllm_cpus:
+            console.print(
+                "[yellow]Warning: --vllm-cpu-start is deprecated; "
+                "use --vllm-cpus (e.g., --vllm-cpus 64-95)[/yellow]"
+            )
         cli_vars["vllm_cpu_start"] = vllm_cpu_start
 
     if vllm_numa is not None:
@@ -410,7 +418,8 @@ def main(
     ),
     preset: Optional[str] = typer.Option(None, "--preset", help="Model preset (deprecated, use --models)"),
     tensor_parallel: Optional[int] = typer.Option(None, "--tensor-parallel", help="Tensor parallel size"),
-    vllm_cpu_start: Optional[int] = typer.Option(None, "--vllm-cpu-start", help="vLLM CPU start core"),
+    vllm_cpus: Optional[str] = typer.Option(None, "--vllm-cpus", help="vLLM CPU range (e.g., 64-95 or 64,65,66)"),
+    vllm_cpu_start: Optional[int] = typer.Option(None, "--vllm-cpu-start", help="vLLM CPU start core (deprecated: use --vllm-cpus)"),
     vllm_numa: Optional[int] = typer.Option(None, "--vllm-numa", help="vLLM NUMA node"),
     guidellm_cpus: Optional[str] = typer.Option(None, "--guidellm-cpus", help="GuideLLM CPU range (e.g., 0-31)"),
     guidellm_numa: Optional[int] = typer.Option(None, "--guidellm-numa", help="GuideLLM NUMA node"),
@@ -465,6 +474,7 @@ def main(
         output_len=output_len,
         preset=preset,
         tensor_parallel=tensor_parallel,
+        vllm_cpus=vllm_cpus,
         vllm_cpu_start=vllm_cpu_start,
         vllm_numa=vllm_numa,
         guidellm_cpus=guidellm_cpus,
@@ -664,7 +674,8 @@ def run(
     ),
     preset: Optional[str] = typer.Option(None, "--preset", help="Model preset (deprecated, use --models)"),
     tensor_parallel: Optional[int] = typer.Option(None, "--tensor-parallel", help="Tensor parallel size"),
-    vllm_cpu_start: Optional[int] = typer.Option(None, "--vllm-cpu-start", help="vLLM CPU start core"),
+    vllm_cpus: Optional[str] = typer.Option(None, "--vllm-cpus", help="vLLM CPU range (e.g., 64-95 or 64,65,66)"),
+    vllm_cpu_start: Optional[int] = typer.Option(None, "--vllm-cpu-start", help="vLLM CPU start core (deprecated: use --vllm-cpus)"),
     vllm_numa: Optional[int] = typer.Option(None, "--vllm-numa", help="vLLM NUMA node"),
     guidellm_cpus: Optional[str] = typer.Option(None, "--guidellm-cpus", help="GuideLLM CPU range (e.g., 0-31)"),
     guidellm_numa: Optional[int] = typer.Option(None, "--guidellm-numa", help="GuideLLM NUMA node"),
@@ -710,6 +721,7 @@ def run(
         output_len=output_len,
         preset=preset,
         tensor_parallel=tensor_parallel,
+        vllm_cpus=vllm_cpus,
         vllm_cpu_start=vllm_cpu_start,
         vllm_numa=vllm_numa,
         guidellm_cpus=guidellm_cpus,

--- a/automation/cli/src/cpueval/cli.py
+++ b/automation/cli/src/cpueval/cli.py
@@ -1,5 +1,6 @@
 """Main CLI for cpueval."""
 
+import os
 from typing import List, Optional
 
 import typer
@@ -33,6 +34,50 @@ app = typer.Typer(
 console = Console()
 
 
+def _apply_endpoint_env(endpoint_url: Optional[str]) -> None:
+    """Configure external endpoint mode when --endpoint-url is set."""
+    if endpoint_url:
+        os.environ["VLLM_ENDPOINT_MODE"] = "external"
+        os.environ["VLLM_ENDPOINT_URL"] = endpoint_url
+
+
+def _build_script_args(suite_obj, final_vars: dict) -> List[str]:
+    """Build script CLI args from merged vars and suite param_mappings."""
+    script_args: List[str] = []
+    for key, value in final_vars.items():
+        if value is None or value == "":
+            continue
+
+        flag = suite_obj.param_mappings.get(key)
+        if not flag:
+            continue
+
+        if not flag.startswith("--"):
+            flag = f"--{flag}"
+
+        if isinstance(value, bool):
+            if value:
+                script_args.append(flag)
+            continue
+
+        script_args.extend([flag, str(value)])
+
+    return script_args
+
+
+def _result_model_hint(
+    model: Optional[str],
+    models: Optional[str],
+    final_vars: dict,
+    suite: str,
+) -> Optional[str]:
+    """Pick a model filter for find_latest_result after a script suite run."""
+    for candidate in (model, models, final_vars.get("test_model"), final_vars.get("models")):
+        if candidate and candidate not in ("all", "quick", "small", "large", "medium"):
+            return candidate
+    return None
+
+
 def version_callback(value: bool):
     """Print version and exit."""
     if value:
@@ -62,6 +107,11 @@ def _execute_suite(
     guidellm_cpus: Optional[str],
     guidellm_numa: Optional[int],
     profile: Optional[str],
+    endpoint_url: Optional[str],
+    vllm_bench_cpus: Optional[str],
+    vllm_bench_numa: Optional[int],
+    continue_on_error: bool,
+    max_seconds: Optional[int],
     extra: Optional[List[str]],
     extra_vars_file: Optional[str],
     ansible_arg: Optional[List[str]],
@@ -194,6 +244,20 @@ def _execute_suite(
     if guidellm_numa is not None:
         cli_vars["guidellm_numa_node"] = guidellm_numa
 
+    if vllm_bench_cpus:
+        cli_vars["vllm_bench_cpus"] = vllm_bench_cpus
+
+    if vllm_bench_numa is not None:
+        cli_vars["vllm_bench_numa_node"] = vllm_bench_numa
+
+    if continue_on_error:
+        cli_vars["continue_on_error"] = True
+
+    if max_seconds is not None:
+        cli_vars["guidellm_max_seconds"] = max_seconds
+
+    _apply_endpoint_env(endpoint_url)
+
     # Load profile if specified
     profile_vars = {}
     if profile:
@@ -266,23 +330,31 @@ def _execute_suite(
                 raise typer.Exit(1)
         else:
             # Flag-based script suites (e.g. rhaiis-sweep)
-            for key, value in final_vars.items():
-                if value is None or value == "":
-                    continue
-
-                flag = suite_obj.param_mappings.get(key)
-                if flag:
-                    if not flag.startswith("--"):
-                        flag = f"--{flag}"
-                    script_args.extend([flag, str(value)])
+            script_args = _build_script_args(suite_obj, final_vars)
 
         exit_code = run_script(suite_obj.target, script_args, dry_run=dry_run)
 
         # Save last run hint on success (skip for dry-run)
         if exit_code == 0 and not dry_run:
-            # For matrix sweeps, use models or mode as hint
-            model_hint = final_vars.get("models") or final_vars.get("mode") or suite
-            save_last_run_hint(suite, model_hint, None)
+            model_hint = (
+                model
+                or models
+                or final_vars.get("models")
+                or final_vars.get("mode")
+                or suite
+            )
+            result_model = _result_model_hint(model, models, final_vars, suite)
+            result_dir = find_latest_result(
+                model=result_model,
+                audio="audio" in suite,
+            )
+            save_last_run_hint(suite, model_hint, result_dir)
+
+            if result_dir:
+                console.print(f"\n[green]✓ Results saved to: {result_dir}[/green]")
+                console.print("\nView results:")
+                console.print("  cpueval results --last")
+                console.print("  cpueval dashboard start\n")
 
         raise typer.Exit(exit_code)
 
@@ -343,6 +415,23 @@ def main(
     guidellm_cpus: Optional[str] = typer.Option(None, "--guidellm-cpus", help="GuideLLM CPU range (e.g., 0-31)"),
     guidellm_numa: Optional[int] = typer.Option(None, "--guidellm-numa", help="GuideLLM NUMA node"),
     profile: Optional[str] = typer.Option(None, "--profile", help="Load CPU pinning profile"),
+    endpoint_url: Optional[str] = typer.Option(
+        None,
+        "--endpoint-url",
+        help="External vLLM endpoint URL (sets VLLM_ENDPOINT_MODE=external)",
+    ),
+    vllm_bench_cpus: Optional[str] = typer.Option(
+        None, "--vllm-bench-cpus", help="CPU range for embedding vllm-bench container"
+    ),
+    vllm_bench_numa: Optional[int] = typer.Option(
+        None, "--vllm-bench-numa-node", help="NUMA node for embedding vllm-bench container"
+    ),
+    max_seconds: Optional[int] = typer.Option(
+        None, "--max-seconds", help="Per-test time limit in seconds (embedding suite)"
+    ),
+    continue_on_error: bool = typer.Option(
+        False, "--continue-on-error", help="Continue matrix run after a failure"
+    ),
     extra: Optional[List[str]] = typer.Option(None, "--extra", help="Extra vars (KEY=VAL, repeatable)"),
     extra_vars_file: Optional[str] = typer.Option(None, "--extra-vars-file", help="Load extra vars from YAML/JSON"),
     ansible_arg: Optional[List[str]] = typer.Option(None, "--ansible-arg", help="Raw ansible-playbook args (repeatable)"),
@@ -381,6 +470,11 @@ def main(
         guidellm_cpus=guidellm_cpus,
         guidellm_numa=guidellm_numa,
         profile=profile,
+        endpoint_url=endpoint_url,
+        vllm_bench_cpus=vllm_bench_cpus,
+        vllm_bench_numa=vllm_bench_numa,
+        continue_on_error=continue_on_error,
+        max_seconds=max_seconds,
         extra=extra,
         extra_vars_file=extra_vars_file,
         ansible_arg=ansible_arg,
@@ -575,6 +669,23 @@ def run(
     guidellm_cpus: Optional[str] = typer.Option(None, "--guidellm-cpus", help="GuideLLM CPU range (e.g., 0-31)"),
     guidellm_numa: Optional[int] = typer.Option(None, "--guidellm-numa", help="GuideLLM NUMA node"),
     profile: Optional[str] = typer.Option(None, "--profile", help="Load CPU pinning profile"),
+    endpoint_url: Optional[str] = typer.Option(
+        None,
+        "--endpoint-url",
+        help="External vLLM endpoint URL (sets VLLM_ENDPOINT_MODE=external)",
+    ),
+    vllm_bench_cpus: Optional[str] = typer.Option(
+        None, "--vllm-bench-cpus", help="CPU range for embedding vllm-bench container"
+    ),
+    vllm_bench_numa: Optional[int] = typer.Option(
+        None, "--vllm-bench-numa-node", help="NUMA node for embedding vllm-bench container"
+    ),
+    max_seconds: Optional[int] = typer.Option(
+        None, "--max-seconds", help="Per-test time limit in seconds (embedding suite)"
+    ),
+    continue_on_error: bool = typer.Option(
+        False, "--continue-on-error", help="Continue matrix run after a failure"
+    ),
     extra: Optional[List[str]] = typer.Option(None, "--extra", help="Extra vars (KEY=VAL, repeatable)"),
     extra_vars_file: Optional[str] = typer.Option(None, "--extra-vars-file", help="Load extra vars from YAML/JSON"),
     ansible_arg: Optional[List[str]] = typer.Option(None, "--ansible-arg", help="Raw ansible-playbook args (repeatable)"),
@@ -604,6 +715,11 @@ def run(
         guidellm_cpus=guidellm_cpus,
         guidellm_numa=guidellm_numa,
         profile=profile,
+        endpoint_url=endpoint_url,
+        vllm_bench_cpus=vllm_bench_cpus,
+        vllm_bench_numa=vllm_bench_numa,
+        continue_on_error=continue_on_error,
+        max_seconds=max_seconds,
         extra=extra,
         extra_vars_file=extra_vars_file,
         ansible_arg=ansible_arg,

--- a/automation/cli/src/cpueval/cli.py
+++ b/automation/cli/src/cpueval/cli.py
@@ -16,6 +16,7 @@ from cpueval.results import (
     run_dashboard_stop_command,
     save_last_run_hint,
     find_latest_result,
+    find_latest_embedding_result,
 )
 from cpueval.offline_batch import build_offline_batch_args
 from cpueval.runners import (
@@ -65,15 +66,25 @@ def _build_script_args(suite_obj, final_vars: dict) -> List[str]:
     return script_args
 
 
+_PRESET_NAMES = (
+    "all", "quick", "small", "large", "medium",
+    "tiny", "llama", "qwen", "granite",
+)
+
+
 def _result_model_hint(
     model: Optional[str],
     models: Optional[str],
     final_vars: dict,
-    suite: str,
 ) -> Optional[str]:
     """Pick a model filter for find_latest_result after a script suite run."""
-    for candidate in (model, models, final_vars.get("test_model"), final_vars.get("models")):
-        if candidate and candidate not in ("all", "quick", "small", "large", "medium"):
+    for candidate in (
+        model,
+        models,
+        final_vars.get("test_model"),
+        final_vars.get("models"),
+    ):
+        if candidate and candidate not in _PRESET_NAMES:
             return candidate
     return None
 
@@ -304,6 +315,11 @@ def _execute_suite(
         console.print(f"[red]{e}[/red]")
         raise typer.Exit(1)
 
+    # vllm_cpus (fixed range) takes precedence over vllm_cpu_start (offset).
+    # Drop vllm_cpu_start so it is never forwarded alongside vllm_cpus.
+    if final_vars.get("vllm_cpus"):
+        final_vars.pop("vllm_cpu_start", None)
+
     # Execute based on runner type
     if suite_obj.runner == "ansible":
         exit_code = run_ansible(suite_obj.target, final_vars, ansible_arg or [], dry_run=dry_run)
@@ -351,11 +367,14 @@ def _execute_suite(
                 or final_vars.get("mode")
                 or suite
             )
-            result_model = _result_model_hint(model, models, final_vars, suite)
-            result_dir = find_latest_result(
-                model=result_model,
-                audio="audio" in suite,
-            )
+            result_model = _result_model_hint(model, models, final_vars)
+            if "embedding" in suite:
+                result_dir = find_latest_embedding_result(model=result_model)
+            else:
+                result_dir = find_latest_result(
+                    model=result_model,
+                    audio="audio" in suite,
+                )
             save_last_run_hint(suite, model_hint, result_dir)
 
             if result_dir:

--- a/automation/cli/src/cpueval/paths.py
+++ b/automation/cli/src/cpueval/paths.py
@@ -40,6 +40,11 @@ def get_audio_results_dir() -> Path:
     return get_results_dir() / "audio-models"
 
 
+def get_embedding_results_dir() -> Path:
+    """Get the embedding results directory."""
+    return get_results_dir() / "embedding"
+
+
 def get_dashboard_script() -> Path:
     """Get the dashboard launch script."""
     return (
@@ -132,6 +137,42 @@ def find_latest_result(
         ]
 
     # Sort by modification time and return the latest
+    if result_dirs:
+        return max(result_dirs, key=lambda p: p.stat().st_mtime)
+
+    return None
+
+
+def find_latest_embedding_result(model: Optional[str] = None) -> Optional[Path]:
+    """Find the latest embedding result directory.
+
+    Embedding results use test-metadata.json (not benchmarks.json) under
+    results/embedding/<model_dir>/<run_dir>/.
+
+    Args:
+        model: Model name to filter by (optional)
+
+    Returns:
+        Path to the latest matching result directory, or None if not found
+    """
+    base_dir = get_embedding_results_dir()
+
+    if not base_dir.exists():
+        return None
+
+    metadata_files = list(base_dir.rglob("test-metadata.json"))
+    if not metadata_files:
+        return None
+
+    result_dirs = [m.parent for m in metadata_files]
+
+    if model:
+        model_safe = model.replace("/", "__")
+        result_dirs = [
+            d for d in result_dirs
+            if any(part == model_safe for part in d.parts)
+        ]
+
     if result_dirs:
         return max(result_dirs, key=lambda p: p.stat().st_mtime)
 

--- a/automation/cli/src/cpueval/results.py
+++ b/automation/cli/src/cpueval/results.py
@@ -362,8 +362,14 @@ def run_results_command(
         if hint and hint.get("results_hint"):
             result_dir = Path(hint["results_hint"])
         else:
-            # Fall back to finding latest
-            result_dir = find_latest_result()
+            # Fall back to finding latest; respect suite type from hint
+            suite_hint = hint.get("suite", "") if hint else ""
+            if "embedding" in suite_hint:
+                result_dir = find_latest_embedding_result()
+            else:
+                result_dir = find_latest_result(
+                    audio="audio" in suite_hint
+                )
 
         if not result_dir:
             console.print("[yellow]No last run found. Try --list to see available results.[/yellow]")

--- a/automation/cli/src/cpueval/results.py
+++ b/automation/cli/src/cpueval/results.py
@@ -18,6 +18,7 @@ from cpueval.paths import (
     get_conversion_script,
     get_repo_root,
     find_latest_result,
+    find_latest_embedding_result,
 )
 
 

--- a/automation/cli/src/cpueval/suites/audio.yaml
+++ b/automation/cli/src/cpueval/suites/audio.yaml
@@ -16,3 +16,5 @@ param_mappings:
   scenario: --scenarios
   cores: --cores
   skip_models: --skip-models
+  dtype: --dtype
+  max_model_len: --max-model-len

--- a/automation/cli/src/cpueval/suites/concurrent-load.yaml
+++ b/automation/cli/src/cpueval/suites/concurrent-load.yaml
@@ -18,3 +18,9 @@ param_mappings:
   workload: --workloads
   phase: --phase
   skip_models: --skip-models
+  vllm_cpu_start: vllm-cpu-start
+  vllm_numa_node: vllm-numa-node
+  guidellm_cpus: guidellm-cpus
+  guidellm_numa_node: guidellm-numa-node
+  requested_tensor_parallel: tensor-parallel
+  continue_on_error: continue-on-error

--- a/automation/cli/src/cpueval/suites/concurrent-load.yaml
+++ b/automation/cli/src/cpueval/suites/concurrent-load.yaml
@@ -18,6 +18,7 @@ param_mappings:
   workload: --workloads
   phase: --phase
   skip_models: --skip-models
+  vllm_cpus: vllm-cpus
   vllm_cpu_start: vllm-cpu-start
   vllm_numa_node: vllm-numa-node
   guidellm_cpus: guidellm-cpus

--- a/automation/cli/src/cpueval/suites/embedding.yaml
+++ b/automation/cli/src/cpueval/suites/embedding.yaml
@@ -17,3 +17,7 @@ param_mappings:
   scenario: --scenario
   num_prompts: --num-prompts
   skip_models: --skip-models
+  vllm_bench_cpus: vllm-bench-cpus
+  vllm_bench_numa_node: vllm-bench-numa-node
+  guidellm_max_seconds: max-seconds
+  continue_on_error: continue-on-error

--- a/automation/cli/src/cpueval/suites/rhaiis-sweep.yaml
+++ b/automation/cli/src/cpueval/suites/rhaiis-sweep.yaml
@@ -18,3 +18,9 @@ param_mappings:
   workload: --workloads
   phase: --phase
   skip_models: --skip-models
+  vllm_cpu_start: vllm-cpu-start
+  vllm_numa_node: vllm-numa-node
+  guidellm_cpus: guidellm-cpus
+  guidellm_numa_node: guidellm-numa-node
+  requested_tensor_parallel: tensor-parallel
+  continue_on_error: continue-on-error

--- a/automation/cli/src/cpueval/suites/rhaiis-sweep.yaml
+++ b/automation/cli/src/cpueval/suites/rhaiis-sweep.yaml
@@ -18,6 +18,7 @@ param_mappings:
   workload: --workloads
   phase: --phase
   skip_models: --skip-models
+  vllm_cpus: vllm-cpus
   vllm_cpu_start: vllm-cpu-start
   vllm_numa_node: vllm-numa-node
   guidellm_cpus: guidellm-cpus

--- a/automation/cli/tests/test_cli_helpers.py
+++ b/automation/cli/tests/test_cli_helpers.py
@@ -1,0 +1,61 @@
+"""Unit tests for cpueval CLI helper functions."""
+
+import os
+
+from cpueval.cli import _apply_endpoint_env, _build_script_args
+from cpueval.suite_registry import SuiteRegistry
+
+
+def test_apply_endpoint_env_sets_external_mode(monkeypatch):
+    """--endpoint-url sets VLLM_ENDPOINT_MODE and VLLM_ENDPOINT_URL."""
+    monkeypatch.delenv("VLLM_ENDPOINT_MODE", raising=False)
+    monkeypatch.delenv("VLLM_ENDPOINT_URL", raising=False)
+
+    _apply_endpoint_env("http://lb.example:8080")
+
+    assert os.environ["VLLM_ENDPOINT_MODE"] == "external"
+    assert os.environ["VLLM_ENDPOINT_URL"] == "http://lb.example:8080"
+
+
+def test_apply_endpoint_env_noop_when_unset(monkeypatch):
+    """Omitting --endpoint-url leaves existing env vars unchanged."""
+    monkeypatch.setenv("VLLM_ENDPOINT_MODE", "managed")
+    monkeypatch.setenv("VLLM_ENDPOINT_URL", "http://existing:8000")
+
+    _apply_endpoint_env(None)
+
+    assert os.environ["VLLM_ENDPOINT_MODE"] == "managed"
+    assert os.environ["VLLM_ENDPOINT_URL"] == "http://existing:8000"
+
+
+def test_build_script_args_prefixes_mapping_values_without_dashes():
+    """Mappings may omit --; _build_script_args normalizes before invoking scripts."""
+    suite = SuiteRegistry().get_suite("concurrent-load")
+    assert suite is not None
+
+    args = _build_script_args(
+        suite,
+        {
+            "vllm_cpu_start": 64,
+            "guidellm_cpus": "0-31",
+            "continue_on_error": True,
+        },
+    )
+
+    assert args == [
+        "--vllm-cpu-start",
+        "64",
+        "--guidellm-cpus",
+        "0-31",
+        "--continue-on-error",
+    ]
+
+
+def test_build_script_args_preserves_existing_dash_prefix():
+    """Mappings that already include -- are left unchanged."""
+    suite = SuiteRegistry().get_suite("concurrent-load")
+    assert suite is not None
+
+    args = _build_script_args(suite, {"cores": "8"})
+
+    assert args == ["--cores", "8"]

--- a/automation/cli/tests/test_cli_helpers.py
+++ b/automation/cli/tests/test_cli_helpers.py
@@ -51,6 +51,16 @@ def test_build_script_args_prefixes_mapping_values_without_dashes():
     ]
 
 
+def test_build_script_args_vllm_cpus_mapping():
+    """--vllm-cpus range is forwarded via the suite param_mapping."""
+    suite = SuiteRegistry().get_suite("concurrent-load")
+    assert suite is not None
+
+    args = _build_script_args(suite, {"vllm_cpus": "64-95"})
+
+    assert args == ["--vllm-cpus", "64-95"]
+
+
 def test_build_script_args_preserves_existing_dash_prefix():
     """Mappings that already include -- are left unchanged."""
     suite = SuiteRegistry().get_suite("concurrent-load")

--- a/automation/cli/tests/test_cli_helpers.py
+++ b/automation/cli/tests/test_cli_helpers.py
@@ -2,7 +2,7 @@
 
 import os
 
-from cpueval.cli import _apply_endpoint_env, _build_script_args
+from cpueval.cli import _apply_endpoint_env, _build_script_args, _result_model_hint
 from cpueval.suite_registry import SuiteRegistry
 
 
@@ -69,3 +69,42 @@ def test_build_script_args_preserves_existing_dash_prefix():
     args = _build_script_args(suite, {"cores": "8"})
 
     assert args == ["--cores", "8"]
+
+
+# ---------------------------------------------------------------------------
+# _result_model_hint — preset blocklist
+# ---------------------------------------------------------------------------
+
+def test_result_model_hint_preset_tiny_returns_none():
+    """'tiny' is a preset name and must not be used as a model directory filter."""
+    assert _result_model_hint(None, "tiny", {}) is None
+
+
+def test_result_model_hint_preset_llama_returns_none():
+    """'llama' is a preset name and must not be used as a model directory filter."""
+    assert _result_model_hint(None, "llama", {}) is None
+
+
+def test_result_model_hint_preset_qwen_returns_none():
+    """'qwen' is a preset name and must not be used as a model directory filter."""
+    assert _result_model_hint(None, "qwen", {}) is None
+
+
+def test_result_model_hint_preset_in_final_vars_returns_none():
+    """Preset stored in final_vars.models must also be blocked."""
+    assert _result_model_hint(None, None, {"models": "tiny"}) is None
+
+
+def test_result_model_hint_real_model_returned():
+    """An actual model ID passes through the blocklist unchanged."""
+    model = "RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8"
+    assert _result_model_hint(model, None, {}) == model
+
+
+def test_result_model_hint_prefers_explicit_model():
+    """--model takes precedence over --models even when both are present."""
+    assert (
+        _result_model_hint(
+            "RedHatAI/model-a", "tiny", {}
+        ) == "RedHatAI/model-a"
+    )

--- a/automation/cli/tests/test_matrix_dry_run.py
+++ b/automation/cli/tests/test_matrix_dry_run.py
@@ -265,6 +265,26 @@ def test_audio_scenario_override():
     assert "transcription-throughput" not in result.stdout
 
 
+def test_audio_custom_model_dtype_and_max_model_len():
+    """dtype and max_model_len extras are forwarded as bash flags for non-Whisper models."""
+    result = subprocess.run(
+        [sys.executable, "-m", "cpueval", "run", "--suite", "audio",
+         "--models", "fixie-ai/ultravox-v0_5-llama-3_2-1b",
+         "--extra", "dtype=bfloat16",
+         "--extra", "max_model_len=2048",
+         "--scenario", "transcription-throughput",
+         "--dry-run", "--skip-doctor"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert "--models fixie-ai/ultravox-v0_5-llama-3_2-1b" in result.stdout
+    assert "--dtype bfloat16" in result.stdout
+    assert "--max-model-len 2048" in result.stdout
+
+
 def test_dry_run_no_results_message():
     """Test that dry-run doesn't show 'Results saved' message."""
     result = subprocess.run(
@@ -344,7 +364,7 @@ def test_implicit_matches_explicit_run():
 # ---------------------------------------------------------------------------
 
 def test_offline_batch_use_case_summarization():
-    """Summarization via implicit run (no subcommand): sharegpt, 1000 prompts, core sweep."""
+    """Summarization via implicit run (no subcommand): sharegpt, 1000 prompts."""
     result = subprocess.run(
         [
             sys.executable, "-m", "cpueval",

--- a/automation/cli/tests/test_matrix_dry_run.py
+++ b/automation/cli/tests/test_matrix_dry_run.py
@@ -460,6 +460,34 @@ def test_endpoint_url_sets_external_mode():
     """--endpoint-url enables external endpoint mode for ansible-backed runs."""
     result = subprocess.run(
         [
+            sys.executable, "-c",
+            "import os, sys; "
+            "sys.path.insert(0, 'automation/cli/src'); "
+            "from cpueval.cli import _apply_endpoint_env; "
+            "_apply_endpoint_env('http://lb.example:8080'); "
+            "print(os.environ.get('VLLM_ENDPOINT_MODE', '')); "
+            "print(os.environ.get('VLLM_ENDPOINT_URL', ''))",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+        env={
+            **dict(os.environ),
+            "VLLM_ENDPOINT_MODE": "",
+            "VLLM_ENDPOINT_URL": "",
+        },
+    )
+
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    lines = result.stdout.strip().splitlines()
+    assert lines[0] == "external"
+    assert lines[1] == "http://lb.example:8080"
+
+
+def test_endpoint_url_dry_run_invokes_ansible():
+    """Integration: --endpoint-url still produces an ansible dry-run command."""
+    result = subprocess.run(
+        [
             sys.executable, "-m", "cpueval", "run",
             "--suite", "chat-smoke",
             "--model", "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
@@ -471,11 +499,6 @@ def test_endpoint_url_sets_external_mode():
         capture_output=True,
         text=True,
         cwd=str(repo_root()),
-        env={
-            **dict(os.environ),
-            "VLLM_ENDPOINT_MODE": "",
-            "VLLM_ENDPOINT_URL": "",
-        },
     )
 
     assert result.returncode == 0, f"STDERR: {result.stderr}"

--- a/automation/cli/tests/test_matrix_dry_run.py
+++ b/automation/cli/tests/test_matrix_dry_run.py
@@ -379,7 +379,7 @@ def test_concurrent_load_profile_pinning_passthrough():
     )
 
     assert result.returncode == 0, f"STDERR: {result.stderr}"
-    assert "--vllm-cpu-start 64" in result.stdout
+    assert "--vllm-cpus 64-95" in result.stdout
     assert "--vllm-numa-node 1" in result.stdout
     assert "--guidellm-cpus 0-31" in result.stdout
     assert "--guidellm-numa-node 0" in result.stdout
@@ -408,6 +408,31 @@ def test_rhaiis_sweep_pinning_flags():
     assert "--vllm-numa-node 1" in result.stdout
     assert "--guidellm-cpus 0-31" in result.stdout
     assert "--guidellm-numa-node 0" in result.stdout
+
+
+def test_vllm_cpus_flag_passthrough():
+    """--vllm-cpus explicit range is forwarded and --vllm-cpu-start is not present."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "rhaiis-sweep",
+            "--vllm-cpus", "64-95",
+            "--vllm-numa", "1",
+            "--guidellm-cpus", "0-31",
+            "--guidellm-numa", "0",
+            "--dry-run",
+            "--skip-doctor",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert "--vllm-cpus 64-95" in result.stdout
+    assert "--vllm-numa-node 1" in result.stdout
+    assert "--guidellm-cpus 0-31" in result.stdout
+    assert "--vllm-cpu-start" not in result.stdout
 
 
 def test_embedding_bench_pinning_flags():

--- a/automation/cli/tests/test_matrix_dry_run.py
+++ b/automation/cli/tests/test_matrix_dry_run.py
@@ -686,3 +686,48 @@ def test_offline_batch_use_case_short_labeling():
     )
     assert result.returncode == 0, f"STDERR: {result.stderr}"
     assert "use-case-sweep short-labeling all 8,16,24,32 3" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# vllm_cpus / vllm_cpu_start conflict and deprecation
+# ---------------------------------------------------------------------------
+
+def test_vllm_cpu_start_deprecation_warning():
+    """--vllm-cpu-start alone emits a deprecation warning."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "rhaiis-sweep",
+            "--vllm-cpu-start", "64",
+            "--dry-run",
+            "--skip-doctor",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert "deprecated" in result.stdout.lower()
+    assert "--vllm-cpu-start 64" in result.stdout
+
+
+def test_vllm_cpus_suppresses_vllm_cpu_start():
+    """When --vllm-cpus and --vllm-cpu-start are both given, only --vllm-cpus is forwarded."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "rhaiis-sweep",
+            "--vllm-cpus", "64-95",
+            "--vllm-cpu-start", "96",
+            "--dry-run",
+            "--skip-doctor",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert "--vllm-cpus 64-95" in result.stdout
+    assert "--vllm-cpu-start" not in result.stdout

--- a/automation/cli/tests/test_matrix_dry_run.py
+++ b/automation/cli/tests/test_matrix_dry_run.py
@@ -1,5 +1,6 @@
 """Test matrix suite dry-run behavior."""
 
+import os
 import subprocess
 import sys
 from .conftest import repo_root
@@ -357,6 +358,128 @@ def test_implicit_matches_explicit_run():
 
     assert implicit.returncode == 0, f"STDERR: {implicit.stderr}"
     assert implicit.stdout == explicit.stdout
+
+
+def test_concurrent_load_profile_pinning_passthrough():
+    """CPU pinning profile vars are forwarded to the suite script."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "concurrent-load",
+            "--profile", "dual-socket-split",
+            "--models", "tiny",
+            "--cores", "8",
+            "--workloads", "chat",
+            "--dry-run",
+            "--skip-doctor",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert "--vllm-cpu-start 64" in result.stdout
+    assert "--vllm-numa-node 1" in result.stdout
+    assert "--guidellm-cpus 0-31" in result.stdout
+    assert "--guidellm-numa-node 0" in result.stdout
+
+
+def test_rhaiis_sweep_pinning_flags():
+    """Explicit pinning flags are forwarded to the rhaiis sweep script."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "rhaiis-sweep",
+            "--vllm-cpu-start", "96",
+            "--vllm-numa", "1",
+            "--guidellm-cpus", "0-31",
+            "--guidellm-numa", "0",
+            "--dry-run",
+            "--skip-doctor",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert "--vllm-cpu-start 96" in result.stdout
+    assert "--vllm-numa-node 1" in result.stdout
+    assert "--guidellm-cpus 0-31" in result.stdout
+    assert "--guidellm-numa-node 0" in result.stdout
+
+
+def test_embedding_bench_pinning_flags():
+    """Embedding bench CPU pinning flags are forwarded to the suite script."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "embedding",
+            "--models", "quick",
+            "--cores", "8",
+            "--vllm-bench-cpus", "8-15",
+            "--vllm-bench-numa-node", "0",
+            "--max-seconds", "300",
+            "--dry-run",
+            "--skip-doctor",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert "--vllm-bench-cpus 8-15" in result.stdout
+    assert "--vllm-bench-numa-node 0" in result.stdout
+    assert "--max-seconds 300" in result.stdout
+
+
+def test_continue_on_error_flag_only():
+    """Boolean suite flags are passed without a value."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "concurrent-load",
+            "--models", "tiny",
+            "--continue-on-error",
+            "--dry-run",
+            "--skip-doctor",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+    )
+
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert "--continue-on-error" in result.stdout
+    assert "--continue-on-error True" not in result.stdout
+
+
+def test_endpoint_url_sets_external_mode():
+    """--endpoint-url enables external endpoint mode for ansible-backed runs."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "cpueval", "run",
+            "--suite", "chat-smoke",
+            "--model", "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+            "--cores", "8",
+            "--endpoint-url", "http://lb.example:8080",
+            "--dry-run",
+            "--skip-doctor",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root()),
+        env={
+            **dict(os.environ),
+            "VLLM_ENDPOINT_MODE": "",
+            "VLLM_ENDPOINT_URL": "",
+        },
+    )
+
+    assert result.returncode == 0, f"STDERR: {result.stderr}"
+    assert "ansible-playbook" in result.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/automation/cli/tests/test_paths.py
+++ b/automation/cli/tests/test_paths.py
@@ -1,0 +1,100 @@
+"""Unit tests for cpueval path helpers."""
+
+import pytest
+from pathlib import Path
+
+from cpueval.paths import find_latest_result, find_latest_embedding_result
+
+
+def _make_llm_result(base: Path, model: str, run: str) -> Path:
+    """Create a fake LLM result dir with benchmarks.json."""
+    d = base / "llm" / model / run
+    d.mkdir(parents=True)
+    (d / "benchmarks.json").write_text("{}")
+    return d
+
+
+def _make_embedding_result(base: Path, model: str, run: str) -> Path:
+    """Create a fake embedding result dir with test-metadata.json."""
+    d = base / "embedding" / model / run
+    d.mkdir(parents=True)
+    (d / "test-metadata.json").write_text("{}")
+    return d
+
+
+# ---------------------------------------------------------------------------
+# find_latest_embedding_result
+# ---------------------------------------------------------------------------
+
+def test_find_latest_embedding_result_basic(tmp_path):
+    """Returns the most-recently modified embedding result dir."""
+    _make_embedding_result(tmp_path, "RedHatAI__all-MiniLM-L6-v2", "run-4C")
+    latest = _make_embedding_result(
+        tmp_path, "RedHatAI__all-MiniLM-L6-v2", "run-8C"
+    )
+
+    from cpueval import paths as paths_mod
+    orig = paths_mod.get_embedding_results_dir
+    paths_mod.get_embedding_results_dir = lambda: tmp_path / "embedding"
+    try:
+        result = find_latest_embedding_result()
+    finally:
+        paths_mod.get_embedding_results_dir = orig
+
+    assert result == latest
+
+
+def test_find_latest_embedding_result_model_filter(tmp_path):
+    """Model filter restricts results to the specified model directory."""
+    _make_embedding_result(
+        tmp_path, "RedHatAI__nomic-embed-text-v1.5", "run-8C"
+    )
+    target = _make_embedding_result(
+        tmp_path, "RedHatAI__all-MiniLM-L6-v2", "run-8C"
+    )
+
+    from cpueval import paths as paths_mod
+    orig = paths_mod.get_embedding_results_dir
+    paths_mod.get_embedding_results_dir = lambda: tmp_path / "embedding"
+    try:
+        result = find_latest_embedding_result(
+            model="RedHatAI/all-MiniLM-L6-v2"
+        )
+    finally:
+        paths_mod.get_embedding_results_dir = orig
+
+    assert result == target
+
+
+def test_find_latest_embedding_result_returns_none_when_empty(tmp_path):
+    """Returns None when the embedding results dir has no metadata files."""
+    (tmp_path / "embedding").mkdir()
+
+    from cpueval import paths as paths_mod
+    orig = paths_mod.get_embedding_results_dir
+    paths_mod.get_embedding_results_dir = lambda: tmp_path / "embedding"
+    try:
+        result = find_latest_embedding_result()
+    finally:
+        paths_mod.get_embedding_results_dir = orig
+
+    assert result is None
+
+
+def test_embedding_suite_does_not_fall_back_to_llm(tmp_path):
+    """Embedding lookup must not return a path inside results/llm."""
+    _make_llm_result(tmp_path, "SomeModel__v1", "chat-run-1")
+    # No embedding results exist
+
+    from cpueval import paths as paths_mod
+    orig_emb = paths_mod.get_embedding_results_dir
+    orig_llm = paths_mod.get_llm_results_dir
+    paths_mod.get_embedding_results_dir = lambda: tmp_path / "embedding"
+    paths_mod.get_llm_results_dir = lambda: tmp_path / "llm"
+    try:
+        result = find_latest_embedding_result()
+    finally:
+        paths_mod.get_embedding_results_dir = orig_emb
+        paths_mod.get_llm_results_dir = orig_llm
+
+    assert result is None

--- a/automation/test-execution/ansible/llm-benchmark-auto.yml
+++ b/automation/test-execution/ansible/llm-benchmark-auto.yml
@@ -11,8 +11,12 @@
 #     -e "requested_cores=16"
 #     -e "requested_tensor_parallel=2"  # optional, auto-calculated if not specified (valid: 1, 2, 4, 8)
 #
-# Socket Pinning (optional):
-#   # Pin vLLM to socket 1 (cores 64-95, NUMA node 1)
+# CPU Pinning (optional):
+#   # Pin vLLM to explicit CPU range (preferred)
+#   -e "vllm_cpus=64-95" \
+#   -e "vllm_numa_node=1" \
+#
+#   # Legacy: pin vLLM by start-core offset (deprecated, use vllm_cpus)
 #   -e "vllm_cpu_start=64" \
 #   -e "vllm_numa_node=1" \
 #
@@ -130,6 +134,15 @@
       when:
         - test_name is defined
         - test_name | length > 0
+
+    - name: Validate vllm_cpus format if provided
+      ansible.builtin.assert:
+        that:
+          - vllm_cpus | string | trim | regex_search('^[0-9]+(-[0-9]+)?(,[0-9]+(-[0-9]+)?)*$') is not none
+        fail_msg: >-
+          vllm_cpus='{{ vllm_cpus }}' is not valid. Expected a range (e.g. '64-95'),
+          a single core ('64'), or a comma-separated list ('64,65,66').
+      when: vllm_cpus is defined and vllm_cpus is not none and vllm_cpus | string | trim != ''
 
     - name: Validate vllm_cpu_start if provided
       ansible.builtin.assert:
@@ -337,6 +350,7 @@
     requested_tensor_parallel: "{{ hostvars['localhost']['requested_tensor_parallel'] | default(omit) }}"
     requested_omp_threads: "{{ hostvars['localhost']['requested_omp_threads'] | default(omit) }}"
     requested_omp_bind: "{{ hostvars['localhost']['requested_omp_bind'] | default(omit) }}"
+    vllm_cpus: "{{ hostvars['localhost']['vllm_cpus'] | default(None) }}"
     vllm_cpu_start: "{{ hostvars['localhost']['vllm_cpu_start'] | default(None) }}"
     vllm_numa_node: "{{ hostvars['localhost']['vllm_numa_node'] | default(None) }}"
 

--- a/automation/test-execution/ansible/llm-benchmark-concurrent-load.yml
+++ b/automation/test-execution/ansible/llm-benchmark-concurrent-load.yml
@@ -108,6 +108,15 @@
       when:
         - vllm_mode == 'external'
 
+    - name: Validate vllm_cpus format if provided
+      ansible.builtin.assert:
+        that:
+          - vllm_cpus | string | trim | regex_search('^[0-9]+(-[0-9]+)?(,[0-9]+(-[0-9]+)?)*$') is not none
+        fail_msg: >-
+          vllm_cpus='{{ vllm_cpus }}' is not valid. Expected a range (e.g. '64-95'),
+          a single core ('64'), or a comma-separated list ('64,65,66').
+      when: vllm_cpus is defined and vllm_cpus | string | trim != ''
+
     - name: Validate vllm_cpu_start if provided
       ansible.builtin.assert:
         that:
@@ -172,6 +181,11 @@
         passthrough_test_model: "{{ test_model | default('__AUTO_DETECT__') }}"
 
     # Set passthrough variables for socket pinning parameters to avoid recursive template references
+    - name: Set passthrough vllm_cpus if defined
+      ansible.builtin.set_fact:
+        passthrough_vllm_cpus: "{{ vllm_cpus }}"
+      when: vllm_cpus is defined
+
     - name: Set passthrough vllm_cpu_start if defined
       ansible.builtin.set_fact:
         passthrough_vllm_cpu_start: "{{ vllm_cpu_start }}"
@@ -217,6 +231,7 @@
     workload_type: "{{ base_workload }}"
     vllm_caching_mode: "baseline"
     requested_cores: "{{ effective_requested_cores }}"
+    vllm_cpus: "{{ hostvars['localhost']['passthrough_vllm_cpus'] | default(None) }}"
     vllm_cpu_start: "{{ hostvars['localhost']['passthrough_vllm_cpu_start'] | default(None) }}"
     vllm_numa_node: "{{ hostvars['localhost']['passthrough_vllm_numa_node'] | default(None) }}"
     guidellm_cpus: "{{ hostvars['localhost']['passthrough_guidellm_cpus'] | default(None) }}"
@@ -245,6 +260,7 @@
     workload_type: "{{ base_workload }}_var"
     vllm_caching_mode: "baseline"
     requested_cores: "{{ effective_requested_cores }}"
+    vllm_cpus: "{{ hostvars['localhost']['passthrough_vllm_cpus'] | default(None) }}"
     vllm_cpu_start: "{{ hostvars['localhost']['passthrough_vllm_cpu_start'] | default(None) }}"
     vllm_numa_node: "{{ hostvars['localhost']['passthrough_vllm_numa_node'] | default(None) }}"
     guidellm_cpus: "{{ hostvars['localhost']['passthrough_guidellm_cpus'] | default(None) }}"
@@ -288,6 +304,7 @@
     workload_type: "{{ base_workload }}_var"
     vllm_caching_mode: "production"
     requested_cores: "{{ effective_requested_cores }}"
+    vllm_cpus: "{{ hostvars['localhost']['passthrough_vllm_cpus'] | default(None) }}"
     vllm_cpu_start: "{{ hostvars['localhost']['passthrough_vllm_cpu_start'] | default(None) }}"
     vllm_numa_node: "{{ hostvars['localhost']['passthrough_vllm_numa_node'] | default(None) }}"
     guidellm_cpus: "{{ hostvars['localhost']['passthrough_guidellm_cpus'] | default(None) }}"

--- a/automation/test-execution/ansible/roles/common/tasks/allocate-cores-from-count.yml
+++ b/automation/test-execution/ansible/roles/common/tasks/allocate-cores-from-count.yml
@@ -15,6 +15,17 @@
       - numa_topology.nodes is defined
     fail_msg: "Missing required variables: requested_cores and numa_topology must be set"
 
+- name: Validate vllm_cpus format if provided
+  ansible.builtin.assert:
+    that:
+      - vllm_cpus | string | trim | regex_search('^[0-9]+(-[0-9]+)?(,[0-9]+(-[0-9]+)?)*$') is not none
+    fail_msg: >-
+      vllm_cpus='{{ vllm_cpus }}' is not valid. Expected a range (e.g. '64-95'),
+      a single core ('64'), or a comma-separated list ('64,65,66').
+  when:
+    - vllm_cpus is defined
+    - vllm_cpus not in [None, ""]
+
 - name: Validate vllm_cpu_start if provided
   ansible.builtin.assert:
     that:
@@ -153,6 +164,13 @@
   ansible.builtin.set_fact:
     auto_core_config: "{{ auto_core_config | combine({'omp_threads_bind': core_allocation_result.omp_threads_bind}) }}"
   when: core_allocation_result.omp_threads_bind is not none
+
+- name: Override cpuset_cpus with explicit vllm_cpus if provided
+  ansible.builtin.set_fact:
+    auto_core_config: "{{ auto_core_config | combine({'cpuset_cpus': vllm_cpus | string | trim}) }}"
+  when:
+    - vllm_cpus is defined
+    - vllm_cpus not in [None, ""]
 
 - name: Display allocation summary
   ansible.builtin.debug:

--- a/automation/test-execution/ansible/roles/common/tasks/allocate-cores-from-count.yml
+++ b/automation/test-execution/ansible/roles/common/tasks/allocate-cores-from-count.yml
@@ -183,7 +183,7 @@
       - "NUMA Nodes: {{ core_allocation_result.allocated_nodes | join(', ') }}"
       - "Cores per Node: {{ core_allocation_result.cores_per_node | join(', ') }}"
       - "Tensor Parallel: {{ core_allocation_result.tensor_parallel }}{{ ' (auto-calculated)' if requested_tensor_parallel is not defined else ' (user-specified)' }}"
-      - "CPU Pinning: {{ core_allocation_result.cpuset_cpus }}"
+      - "CPU Pinning: {{ auto_core_config.cpuset_cpus }}{{ ' (overridden by vllm_cpus)' if (vllm_cpus is defined and vllm_cpus not in [None, '']) else '' }}"
       - "Memory Affinity: {{ core_allocation_result.cpuset_mems }}"
       - "OMP Threads: {{ core_allocation_result.omp_num_threads }}"
       - "OMP Binding: {{ core_allocation_result.omp_threads_bind | default('auto') }}"

--- a/automation/test-execution/scripts/bash/run-audio-suite.sh
+++ b/automation/test-execution/scripts/bash/run-audio-suite.sh
@@ -19,6 +19,12 @@
 #   --cores LIST            Comma-separated core counts
 #                           Default: 32
 #   --skip-models LIST      Comma-separated models to skip
+#   --dtype DTYPE           vLLM dtype override (auto|float16|bfloat16)
+#                           Default: auto (Whisper models work well with auto)
+#                           Set to bfloat16 for non-Whisper models that recommend it
+#   --max-model-len N       Maximum model sequence length override
+#                           Default: 448 (Whisper encoder max position embedding)
+#                           Non-Whisper audio models typically need a larger value
 #   --continue-on-error     Continue if a test fails
 #   --dry-run               Show commands without running
 #   -h, --help              Show this help
@@ -28,6 +34,7 @@
 #   whisper-tiny   - openai/whisper-tiny
 #   whisper-small  - openai/whisper-small
 #   whisper-medium - openai/whisper-medium
+#   Any HuggingFace model ID - passed directly without preset expansion
 #
 # Scenarios:
 #   transcription-throughput, transcription-latency, audio-duration-scaling,
@@ -42,6 +49,14 @@
 #
 #   # Full matrix
 #   ./run-audio-suite.sh --models all --scenarios all --cores "8,16,32"
+#
+#   # Custom (non-Whisper) audio model - override dtype and context length
+#   ./run-audio-suite.sh \
+#     --models fixie-ai/ultravox-v0_5-llama-3_2-1b \
+#     --dtype bfloat16 \
+#     --max-model-len 2048 \
+#     --scenarios transcription-throughput \
+#     --cores 32
 #
 # ==============================================================================
 
@@ -79,6 +94,8 @@ MODELS_INPUT="all"
 SCENARIOS_INPUT="transcription-throughput"
 CORES_INPUT="32"
 SKIP_MODELS_INPUT=""
+DTYPE_INPUT=""
+MAX_MODEL_LEN_INPUT=""
 CONTINUE_ON_ERROR=false
 DRY_RUN=false
 
@@ -92,6 +109,8 @@ while [[ $# -gt 0 ]]; do
         --scenarios) SCENARIOS_INPUT="$2"; shift 2 ;;
         --cores) CORES_INPUT="$2"; shift 2 ;;
         --skip-models) SKIP_MODELS_INPUT="$2"; shift 2 ;;
+        --dtype) DTYPE_INPUT="$2"; shift 2 ;;
+        --max-model-len) MAX_MODEL_LEN_INPUT="$2"; shift 2 ;;
         --continue-on-error) CONTINUE_ON_ERROR=true; shift ;;
         --dry-run) DRY_RUN=true; shift ;;
         -h|--help) show_help; exit 0 ;;
@@ -175,6 +194,13 @@ for model in "${FINAL_MODELS[@]}"; do
                 "-e" "requested_cores=$cores"
                 "-e" '{"vllm_env_vars": {"VLLM_USE_V2_MODEL_RUNNER": "0"}}'
             )
+
+            if [[ -n "${DTYPE_INPUT:-}" ]]; then
+                CMD+=(-e "vllm_dtype=${DTYPE_INPUT}")
+            fi
+            if [[ -n "${MAX_MODEL_LEN_INPUT:-}" ]]; then
+                CMD+=(-e "vllm_max_model_len=${MAX_MODEL_LEN_INPUT}")
+            fi
 
             # Parallel instance overrides — set env vars to run multiple instances
             # simultaneously on the same host (each with its own container, port, NUMA nodes):

--- a/automation/test-execution/scripts/bash/run-concurrent-load-suite.sh
+++ b/automation/test-execution/scripts/bash/run-concurrent-load-suite.sh
@@ -22,7 +22,9 @@
 #   --phase PHASE           Test phase (1|2|3|all)
 #                           Default: 1 (Phase 1: baseline tests only)
 #   --skip-models LIST      Comma-separated models to skip
-#   --vllm-cpu-start NUM    Pin vLLM to start at this CPU core (socket separation)
+#   --vllm-cpus RANGE       Explicit CPU set for vLLM (e.g., 64-95 or 64,65,66)
+#                           Preferred over --vllm-cpu-start
+#   --vllm-cpu-start NUM    (Deprecated) Pin vLLM to start at this CPU core
 #   --vllm-numa-node NUM    Pin vLLM to this NUMA node
 #   --guidellm-cpus RANGE   CPU range for GuideLLM (e.g., 0-31)
 #   --guidellm-numa-node NUM NUMA node for GuideLLM
@@ -103,6 +105,7 @@ PHASE="1"
 CONTINUE_ON_ERROR=false
 DRY_RUN=false
 SKIP_MODELS_INPUT=""
+VLLM_CPUS=""
 VLLM_CPU_START=""
 VLLM_NUMA_NODE=""
 GUIDELLM_CPUS=""
@@ -133,6 +136,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --skip-models)
             SKIP_MODELS_INPUT="$2"
+            shift 2
+            ;;
+        --vllm-cpus)
+            VLLM_CPUS="$2"
             shift 2
             ;;
         --vllm-cpu-start)
@@ -297,6 +304,9 @@ for model in "${FINAL_MODELS[@]}"; do
                 "-e" "skip_phase_3=$SKIP_PHASE_3"
             )
 
+            if [[ -n "${VLLM_CPUS}" ]]; then
+                CMD+=(-e "vllm_cpus=${VLLM_CPUS}")
+            fi
             if [[ -n "${VLLM_CPU_START}" ]]; then
                 CMD+=(-e "vllm_cpu_start=${VLLM_CPU_START}")
             fi

--- a/automation/test-execution/scripts/bash/run-concurrent-load-suite.sh
+++ b/automation/test-execution/scripts/bash/run-concurrent-load-suite.sh
@@ -22,6 +22,11 @@
 #   --phase PHASE           Test phase (1|2|3|all)
 #                           Default: 1 (Phase 1: baseline tests only)
 #   --skip-models LIST      Comma-separated models to skip
+#   --vllm-cpu-start NUM    Pin vLLM to start at this CPU core (socket separation)
+#   --vllm-numa-node NUM    Pin vLLM to this NUMA node
+#   --guidellm-cpus RANGE   CPU range for GuideLLM (e.g., 0-31)
+#   --guidellm-numa-node NUM NUMA node for GuideLLM
+#   --tensor-parallel NUM   Tensor parallel size (1, 2, 4, or 8)
 #   --continue-on-error     Continue testing if a model/workload fails
 #   --dry-run               Show what would run without executing
 #   -h, --help              Show this help
@@ -98,6 +103,11 @@ PHASE="1"
 CONTINUE_ON_ERROR=false
 DRY_RUN=false
 SKIP_MODELS_INPUT=""
+VLLM_CPU_START=""
+VLLM_NUMA_NODE=""
+GUIDELLM_CPUS=""
+GUIDELLM_NUMA_NODE=""
+TENSOR_PARALLEL=""
 
 show_help() {
     sed -n '/^# ===/,/^set -/p' "$0" | sed '$d' | sed '1,3d;$d' | sed 's/^# //; s/^#//'
@@ -123,6 +133,26 @@ while [[ $# -gt 0 ]]; do
             ;;
         --skip-models)
             SKIP_MODELS_INPUT="$2"
+            shift 2
+            ;;
+        --vllm-cpu-start)
+            VLLM_CPU_START="$2"
+            shift 2
+            ;;
+        --vllm-numa-node)
+            VLLM_NUMA_NODE="$2"
+            shift 2
+            ;;
+        --guidellm-cpus)
+            GUIDELLM_CPUS="$2"
+            shift 2
+            ;;
+        --guidellm-numa-node)
+            GUIDELLM_NUMA_NODE="$2"
+            shift 2
+            ;;
+        --tensor-parallel|--tp)
+            TENSOR_PARALLEL="$2"
             shift 2
             ;;
         --continue-on-error)
@@ -266,6 +296,22 @@ for model in "${FINAL_MODELS[@]}"; do
                 "-e" "skip_phase_2=$SKIP_PHASE_2"
                 "-e" "skip_phase_3=$SKIP_PHASE_3"
             )
+
+            if [[ -n "${VLLM_CPU_START}" ]]; then
+                CMD+=(-e "vllm_cpu_start=${VLLM_CPU_START}")
+            fi
+            if [[ -n "${VLLM_NUMA_NODE}" ]]; then
+                CMD+=(-e "vllm_numa_node=${VLLM_NUMA_NODE}")
+            fi
+            if [[ -n "${GUIDELLM_CPUS}" ]]; then
+                CMD+=(-e "guidellm_cpus=${GUIDELLM_CPUS}")
+            fi
+            if [[ -n "${GUIDELLM_NUMA_NODE}" ]]; then
+                CMD+=(-e "guidellm_numa_node=${GUIDELLM_NUMA_NODE}")
+            fi
+            if [[ -n "${TENSOR_PARALLEL}" ]]; then
+                CMD+=(-e "requested_tensor_parallel=${TENSOR_PARALLEL}")
+            fi
 
             # Parallel instance overrides — set env vars to run multiple instances
             # simultaneously on the same host (each with its own container, port, NUMA nodes):

--- a/automation/test-execution/scripts/bash/run-concurrent-load-suite.sh
+++ b/automation/test-execution/scripts/bash/run-concurrent-load-suite.sh
@@ -306,8 +306,7 @@ for model in "${FINAL_MODELS[@]}"; do
 
             if [[ -n "${VLLM_CPUS}" ]]; then
                 CMD+=(-e "vllm_cpus=${VLLM_CPUS}")
-            fi
-            if [[ -n "${VLLM_CPU_START}" ]]; then
+            elif [[ -n "${VLLM_CPU_START}" ]]; then
                 CMD+=(-e "vllm_cpu_start=${VLLM_CPU_START}")
             fi
             if [[ -n "${VLLM_NUMA_NODE}" ]]; then

--- a/automation/test-execution/scripts/bash/run-embedding-suite.sh
+++ b/automation/test-execution/scripts/bash/run-embedding-suite.sh
@@ -18,6 +18,8 @@
 #                           Default: 250
 #   --max-seconds SEC       Per-test time limit in seconds; sets guidellm_max_seconds
 #                           Default: Ansible default (300s); env var GUIDELLM_MAX_SECONDS also accepted
+#   --vllm-bench-cpus RANGE CPU range for vllm-bench loadgen container (e.g., 8-15)
+#   --vllm-bench-numa-node NUM NUMA node for vllm-bench loadgen container
 #   --skip-models LIST      Comma-separated models to skip
 #   --continue-on-error     Continue testing if a model fails
 #   --dry-run               Show what would run without executing
@@ -114,6 +116,8 @@ CORES_INPUT="4,8,16,32"
 SCENARIO="all"
 NUM_PROMPTS=250
 MAX_SECONDS="${GUIDELLM_MAX_SECONDS:-}"
+VLLM_BENCH_CPUS=""
+VLLM_BENCH_NUMA_NODE=""
 CONTINUE_ON_ERROR=false
 DRY_RUN=false
 SKIP_MODELS_INPUT=""
@@ -155,6 +159,14 @@ while [[ $# -gt 0 ]]; do
             ;;
         --max-seconds)
             MAX_SECONDS="$2"
+            shift 2
+            ;;
+        --vllm-bench-cpus)
+            VLLM_BENCH_CPUS="$2"
+            shift 2
+            ;;
+        --vllm-bench-numa-node)
+            VLLM_BENCH_NUMA_NODE="$2"
             shift 2
             ;;
         --skip-models)
@@ -331,6 +343,8 @@ for model in "${MODELS[@]}"; do
         )
 
         [[ -n "${MAX_SECONDS}" ]] && cmd+=(-e "guidellm_max_seconds=${MAX_SECONDS}")
+        [[ -n "${VLLM_BENCH_CPUS}" ]] && cmd+=(-e "vllm_bench_cpus=${VLLM_BENCH_CPUS}")
+        [[ -n "${VLLM_BENCH_NUMA_NODE}" ]] && cmd+=(-e "vllm_bench_numa_node=${VLLM_BENCH_NUMA_NODE}")
 
         # Parallel instance overrides — set env vars to run multiple instances
         # simultaneously on the same host (each with its own container, port, NUMA nodes):

--- a/automation/test-execution/scripts/bash/run-rhaiis-concurrent-load.sh
+++ b/automation/test-execution/scripts/bash/run-rhaiis-concurrent-load.sh
@@ -498,8 +498,7 @@ for model in "${MODELS[@]}"; do
             # Add NUMA/CPU pinning parameters if specified
             if [[ -n "${VLLM_CPUS}" ]]; then
                 cmd+=(-e "vllm_cpus=${VLLM_CPUS}")
-            fi
-            if [[ -n "${VLLM_CPU_START}" ]]; then
+            elif [[ -n "${VLLM_CPU_START}" ]]; then
                 cmd+=(-e "vllm_cpu_start=${VLLM_CPU_START}")
             fi
             if [[ -n "${VLLM_NUMA_NODE}" ]]; then

--- a/automation/test-execution/scripts/bash/run-rhaiis-concurrent-load.sh
+++ b/automation/test-execution/scripts/bash/run-rhaiis-concurrent-load.sh
@@ -25,7 +25,9 @@
 #                           Default: auto-calculated based on NUMA topology
 #   --phase PHASE           Test phase (1|2|3|all)
 #                           Default: 1 (Phase 1: baseline tests only)
-#   --vllm-cpu-start NUM    Starting CPU for vLLM (for socket separation)
+#   --vllm-cpus RANGE       Explicit CPU set for vLLM (e.g., 64-95 or 64,65,66)
+#                           Preferred over --vllm-cpu-start; Env: VLLM_CPUS
+#   --vllm-cpu-start NUM    (Deprecated) Starting CPU for vLLM; use --vllm-cpus
 #                           Env: VLLM_CPU_START
 #   --vllm-numa-node NUM    NUMA node for vLLM (for socket separation)
 #                           Env: VLLM_NUMA_NODE
@@ -139,6 +141,7 @@ SKIP_MODELS_INPUT=""
 
 # NUMA/CPU pinning defaults (for socket separation)
 # Override with environment variables or command line options
+VLLM_CPUS="${VLLM_CPUS:-}"
 VLLM_CPU_START="${VLLM_CPU_START:-}"
 VLLM_NUMA_NODE="${VLLM_NUMA_NODE:-}"
 GUIDELLM_CPUS="${GUIDELLM_CPUS:-}"
@@ -210,6 +213,11 @@ while [[ $# -gt 0 ]]; do
         --phase)
             validate_flag_value "$1" "${2:-}"
             PHASE="$2"
+            shift 2
+            ;;
+        --vllm-cpus)
+            validate_flag_value "$1" "${2:-}"
+            VLLM_CPUS="$2"
             shift 2
             ;;
         --vllm-cpu-start)
@@ -374,10 +382,12 @@ else
 fi
 echo ""
 echo "NUMA/CPU Configuration:"
-if [[ -n "${VLLM_CPU_START}" ]]; then
-    echo "  vLLM CPU start: ${VLLM_CPU_START}"
+if [[ -n "${VLLM_CPUS}" ]]; then
+    echo "  vLLM CPUs: ${VLLM_CPUS}"
+elif [[ -n "${VLLM_CPU_START}" ]]; then
+    echo "  vLLM CPU start: ${VLLM_CPU_START} (deprecated; use --vllm-cpus)"
 else
-    echo "  vLLM CPU start: auto-detect"
+    echo "  vLLM CPUs: auto-detect"
 fi
 if [[ -n "${VLLM_NUMA_NODE}" ]]; then
     echo "  vLLM NUMA node: ${VLLM_NUMA_NODE}"
@@ -486,6 +496,9 @@ for model in "${MODELS[@]}"; do
             )
 
             # Add NUMA/CPU pinning parameters if specified
+            if [[ -n "${VLLM_CPUS}" ]]; then
+                cmd+=(-e "vllm_cpus=${VLLM_CPUS}")
+            fi
             if [[ -n "${VLLM_CPU_START}" ]]; then
                 cmd+=(-e "vllm_cpu_start=${VLLM_CPU_START}")
             fi

--- a/docs/cpueval-cli.md
+++ b/docs/cpueval-cli.md
@@ -493,6 +493,89 @@ Available scenarios for the `audio` suite (`--scenario` flag):
 - `constant-rate-stress` - Stress testing
 - `quick-test` - Fast smoke test
 
+## Testing custom models
+
+Every suite accepts an arbitrary HuggingFace model ID — no changes to any YAML files are needed.
+
+### LLM suites (concurrent-load, rhaiis-sweep, chat-smoke, offline-batch)
+
+Pass any HuggingFace model ID directly:
+
+```bash
+# Single-shot test
+./cpueval --suite chat-smoke \
+  --model my-org/my-llm-model \
+  --cores 32 \
+  --workload chat
+
+# Concurrent load against a custom model
+./cpueval --suite concurrent-load \
+  --model my-org/my-llm-model \
+  --cores 16 \
+  --workload chat
+
+# Offline batch — use-cases mode (comma-separated list also works)
+./cpueval --suite offline-batch \
+  --mode use-cases \
+  --models my-org/my-llm-model \
+  --runs 3
+
+# Offline batch — single benchmark mode
+./cpueval --suite offline-batch \
+  --mode batch-scaling \
+  --model my-org/my-llm-model \
+  --cores 32
+```
+
+> **Gated models:** set `export HF_TOKEN=hf_xxxxx` before running.
+
+### Audio suite
+
+Whisper is the default but any vLLM-compatible audio model works. Non-Whisper models
+typically need a larger `max_model_len` (Whisper's encoder cap is 448 tokens) and
+may require an explicit `dtype`:
+
+```bash
+# Whisper model — defaults work, no overrides needed
+./cpueval --suite audio \
+  --models openai/whisper-small \
+  --scenario transcription-throughput \
+  --cores 32
+
+# Non-Whisper audio model — override max_model_len and dtype
+./cpueval --suite audio \
+  --models fixie-ai/ultravox-v0_5-llama-3_2-1b \
+  --extra dtype=bfloat16 \
+  --extra max_model_len=2048 \
+  --scenario transcription-throughput \
+  --cores 32
+```
+
+| Extra var | Bash flag | When to use |
+|---|---|---|
+| `dtype=float16\|bfloat16\|auto` | `--dtype` | Non-Whisper models that recommend a specific dtype |
+| `max_model_len=N` | `--max-model-len` | Any model whose max sequence length differs from Whisper's 448 |
+
+### Embedding suite
+
+```bash
+./cpueval --suite embedding \
+  --model my-org/my-embedding-model \
+  --cores 16
+```
+
+### Optional: register the model for KV cache metadata
+
+Running with a custom model ID works immediately. To also get accurate KV cache
+sizing (rather than the 40 GiB fallback) and include the model in future
+`--models all` sweeps, add an entry to the relevant model matrix:
+
+- LLM models: [models/llm-models/model-matrix.yaml](../models/llm-models/model-matrix.yaml)
+- Embedding models: [models/embedding-models/model-matrix.yaml](../models/embedding-models/model-matrix.yaml)
+- Audio models: [models/audio-models/model-matrix.yaml](../models/audio-models/model-matrix.yaml)
+
+See [models/models.md](../models/models.md) for the full schema and instructions.
+
 ## Creating Custom Suites
 
 You can also edit an existing suite YAML directly to change its permanent defaults

--- a/docs/cpueval-cli.md
+++ b/docs/cpueval-cli.md
@@ -395,6 +395,13 @@ file anywhere on disk.
 |---------|----------|
 | `dual-socket-split` | Dual-socket system — vLLM pinned to socket 1 (cores 64–95, NUMA 1), GuideLLM pinned to socket 0 (cores 0–31, NUMA 0) |
 
+> **`vllm_cpus` vs `--cores`:** When a profile (or `--vllm-cpus`) sets `vllm_cpus`,
+> it specifies a **fixed CPU set** for vLLM regardless of `--cores`. For example,
+> `--profile dual-socket-split --cores 8` pins vLLM to all 32 cores in `64-95`, not
+> 8 cores starting at 64. Use `vllm_cpus` when you want an explicit range; use
+> `--cores` alone when you want count-based auto-allocation. The two modes are
+> mutually exclusive: `vllm_cpus` always wins.
+
 To list profiles available:
 
 ```bash

--- a/docs/cpueval-cli.md
+++ b/docs/cpueval-cli.md
@@ -104,9 +104,13 @@ ansible-playbook -i inventory/hosts.yml start-vllm-scaleout.yml \
 ansible-playbook -i inventory/hosts.yml stop-vllm-scaleout.yml
 ```
 
-In external mode, `--cores`, `--vllm-cpu-start`, and `--profile` pinning are ignored
-(the endpoint manages its own CPUs). GuideLLM still runs on the load generator with
-normal inventory settings.
+In external mode, `--cores`, `--vllm-cpus`, `--vllm-cpu-start`, and `--profile` pinning
+are ignored (the endpoint manages its own CPUs). GuideLLM still runs on the load
+generator with normal inventory settings.
+
+> **Note:** `--vllm-cpu-start` is deprecated. Use `--vllm-cpus RANGE` instead to
+> specify an explicit CPU set (e.g., `--vllm-cpus 64-95`). The legacy option still
+> works but will emit a deprecation warning.
 
 ## Commands
 

--- a/docs/cpueval-cli.md
+++ b/docs/cpueval-cli.md
@@ -56,12 +56,57 @@ export ANSIBLE_SSH_USER=<user>
 export ANSIBLE_SSH_KEY=<path-to-key>
 ```
 
-**External endpoint mode** (test existing vLLM server):
+**External endpoint mode** (test existing vLLM server or load balancer):
 
 ```bash
 export VLLM_ENDPOINT_MODE=external
 export VLLM_ENDPOINT_URL=http://your-vllm-host:8000
 ```
+
+Or pass the URL per run with `--endpoint-url` (sets both variables automatically):
+
+```bash
+./cpueval --suite concurrent-load \
+  --models tiny --cores 8 --workloads chat \
+  --endpoint-url http://your-vllm-host:8080
+```
+
+### Scale-out workflow (nginx load balancer)
+
+Use this when multiple vLLM instances sit behind a load balancer (for example after
+`start-vllm-scaleout.yml` from the scale-out playbooks). cpueval does not deploy the
+stack today — point benchmarks at the LB URL instead of a single managed instance.
+
+```bash
+# 1. Deploy scale-out on the DUT (Ansible; see docs/vllm-scaleout.md when merged)
+ansible-playbook -i inventory/hosts.yml start-vllm-scaleout.yml \
+  -e "scaleout_num_instances=3 scaleout_cores_per_instance=16"
+
+# 2. Benchmark through the load balancer (port 8080 by default)
+./cpueval --suite concurrent-load \
+  --models tiny \
+  --cores 32 \
+  --workloads chat \
+  --endpoint-url http://<DUT_HOSTNAME>:8080 \
+  --skip-doctor
+
+# 3. Narrow matrix while validating a new instance count
+./cpueval --suite concurrent-load \
+  --models TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
+  --cores 8 \
+  --workload chat \
+  --endpoint-url http://<DUT_HOSTNAME>:8080 \
+  --extra guidellm_profile=synchronous \
+  --extra guidellm_max_seconds=120 \
+  --skip-doctor
+
+# 4. Tear down when done
+ansible-playbook -i inventory/hosts.yml stop-vllm-scaleout.yml
+```
+
+In external mode, `--cores`, `--vllm-cpu-start`, and `--profile` pinning are ignored
+(the endpoint manages its own CPUs). GuideLLM still runs on the load generator with
+normal inventory settings.
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- Fix cpueval silently dropping CPU pinning profile/flags on script-backed suites
- Wire pinning through concurrent-load, rhaiis-sweep, and embedding suite scripts
- Add `--endpoint-url`, `--continue-on-error`, embedding bench pinning, and `--max-seconds`
- Save `results --last` hint for matrix script runs via `find_latest_result()`
- Document custom model usage; add audio dtype/max-model-len forwarding

## Test plan
- [x] `pytest automation/cli/tests/` (74 passed)
- [x] CI green
- [x] Dry-run pinning against EC2 inventory
- [x] Live smoke with `--extra guidellm_profile=synchronous --extra guidellm_max_seconds=60`

Closes #189, #198 (partial)