### PR TITLE
feat(offline-batch): skip already-completed runs when re-running suite

### DIFF
--- a/automation/test-execution/ansible/ansible.cfg
+++ b/automation/test-execution/ansible/ansible.cfg
@@ -20,5 +20,5 @@ deprecation_warnings = False
 [ssh_connection]
 # Send keepalive every 30 s so the connection survives long benchmark runs
 # (CPU offline-batch benchmarks can take 15-60 min per config)
-ssh_args = -o ServerAliveInterval=30 -o ServerAliveCountMax=120 -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no
+ssh_args = -o ServerAliveInterval=30 -o ServerAliveCountMax=120 -o ControlMaster=auto -o ControlPersist=60s
 pipelining = True

--- a/automation/test-execution/ansible/ansible.cfg
+++ b/automation/test-execution/ansible/ansible.cfg
@@ -16,3 +16,9 @@ timeout = 30
 
 # Suppress deprecation warnings from third-party collections
 deprecation_warnings = False
+
+[ssh_connection]
+# Send keepalive every 30 s so the connection survives long benchmark runs
+# (CPU offline-batch benchmarks can take 15-60 min per config)
+ssh_args = -o ServerAliveInterval=30 -o ServerAliveCountMax=120 -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no
+pipelining = True

--- a/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
+++ b/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
@@ -38,12 +38,13 @@
       ansible.builtin.assert:
         that:
           - test_model is defined
+          - test_model is match('^[a-zA-Z0-9][a-zA-Z0-9._-]*/[a-zA-Z0-9][a-zA-Z0-9._-]*$')
           - dataset_name is defined
           - num_prompts is defined
           - requested_cores is defined
         fail_msg: |
-          Missing required variables. Please provide:
-          -e "test_model=<model>"
+          Missing or invalid required variables. Please provide:
+          -e "test_model=<namespace/repo>"   (e.g. RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8)
           -e "dataset_name=<sonnet|random|sharegpt>"
           -e "num_prompts=<100|1000|...>"
           -e "requested_cores=<8|16|24|32>"
@@ -104,46 +105,58 @@
         mode: "0755"
 
     - name: Check if model is already cached
-      ansible.builtin.shell: |
-        find {{ dut_cache_dir }}/models--{{ test_model | replace('/', '--') }}/snapshots \
-          -mindepth 1 -maxdepth 1 -type d 2>/dev/null | grep -q .
+      ansible.builtin.command:
+        argv:
+          - find
+          - "{{ dut_cache_dir }}/models--{{ test_model | replace('/', '--') }}/snapshots"
+          - -mindepth
+          - "1"
+          - -maxdepth
+          - "1"
+          - -type
+          - d
       register: model_cache_check
-      failed_when: false
       changed_when: false
+      failed_when: false
 
     - name: Display cache status
       ansible.builtin.debug:
-        msg: "Model {{ test_model }} {{ 'found in cache (complete snapshot)' if model_cache_check.rc == 0 else 'not found or incomplete, will download using container' }}"
+        msg: "Model {{ test_model }} {{ 'found in cache' if (model_cache_check.rc == 0 and model_cache_check.stdout | trim != '') else 'not found, will download using container' }}"
 
     - name: Download model using container
       ansible.builtin.shell: |
         podman run --rm \
-          --user root \
           -v "{{ dut_cache_dir }}:/root/.cache/huggingface:z" \
           -e HF_TOKEN \
-          -e HF_HUB_OFFLINE=0 \
           --entrypoint python3 \
           {{ hostvars['localhost']['vllm_container_image'] }} \
           -c "from huggingface_hub import snapshot_download; snapshot_download('{{ test_model }}', cache_dir='/root/.cache/huggingface')"
       environment:
         HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-      when: model_cache_check.rc != 0
+      when: model_cache_check.rc != 0 or model_cache_check.stdout | trim == ''
       register: model_download
       changed_when: model_download.rc == 0
       no_log: true
 
     - name: Get model snapshot path
-      ansible.builtin.shell: |
-        ls -d {{ dut_cache_dir }}/models--{{ test_model | replace('/', '--') }}/snapshots/* 2>/dev/null | head -1
+      ansible.builtin.command:
+        argv:
+          - find
+          - "{{ dut_cache_dir }}/models--{{ test_model | replace('/', '--') }}/snapshots"
+          - -mindepth
+          - "1"
+          - -maxdepth
+          - "1"
+          - -type
+          - d
       register: model_snapshot_path
       changed_when: false
-      failed_when: model_snapshot_path.stdout | trim | length == 0
 
     - name: Set model facts for localhost
       ansible.builtin.set_fact:
         dut_cache_dir: "{{ dut_cache_dir }}"
         model_repo_name: "models--{{ test_model | replace('/', '--') }}"
-        model_snapshot_hash: "{{ model_snapshot_path.stdout | basename }}"
+        model_snapshot_hash: "{{ model_snapshot_path.stdout_lines | first | basename }}"
       delegate_to: localhost
       delegate_facts: true
 
@@ -152,8 +165,8 @@
         msg:
           - "Model: {{ test_model }}"
           - "Cache directory: {{ dut_cache_dir }}"
-          - "Snapshot hash: {{ model_snapshot_path.stdout | basename }}"
-          - "Full path: {{ model_snapshot_path.stdout }}"
+          - "Snapshot hash: {{ model_snapshot_path.stdout_lines | first | basename }}"
+          - "Full path: {{ model_snapshot_path.stdout_lines | first }}"
 
 - name: "Offline Batch Benchmark - Prepare Dataset"
   hosts: dut
@@ -230,18 +243,16 @@
         msg: "LD_PRELOAD={{ vllm_ld_preload | default('(not set - libomp not found in container)') }}"
 
     - name: Detect NUMA topology on DUT
+      become: true
       ansible.builtin.include_role:
         name: common
         tasks_from: detect-numa-topology
-        apply:
-          become: true
 
     - name: Allocate cores from NUMA topology
+      become: true
       ansible.builtin.include_role:
         name: common
         tasks_from: allocate-cores-from-count
-        apply:
-          become: true
 
     - name: Set CPU pinning from NUMA allocation
       ansible.builtin.set_fact:
@@ -250,7 +261,10 @@
 
     - name: Set effective container name for offline batch
       ansible.builtin.set_fact:
-        _batch_container_name: "{{ vllm_container_name }}"
+        _batch_container_name: >-
+          {{ vllm_container_name
+             if (vllm_container_name != 'vllm-server')
+             else 'vllm-batch-' + dataset_name + '-' + (requested_cores | string) + 'c-' + hostvars['localhost']['test_run_id'] }}
 
     - name: Build benchmark command (sonnet dataset with file)
       ansible.builtin.set_fact:
@@ -326,26 +340,20 @@
         HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
       register: benchmark_output
       changed_when: false
-      ignore_errors: true
       no_log: true
 
-    - name: Display benchmark failure output
-      ansible.builtin.debug:
-        msg: "{{ (['Benchmark FAILED (rc=' + (benchmark_output.rc | string) + '):'] + benchmark_output.stderr_lines[-80:]) }}"
-      when: benchmark_output.rc != 0
-
-    - name: Fail if benchmark failed
-      ansible.builtin.fail:
-        msg: "Benchmark failed with rc={{ benchmark_output.rc }}"
-      when: benchmark_output.rc != 0
+    - name: Build combined benchmark log for metric parsing
+      ansible.builtin.set_fact:
+        benchmark_combined_log: "{{ benchmark_output.stdout }}{% if benchmark_output.stderr | default('') | length > 0 %}\n{{ benchmark_output.stderr }}{% endif %}"
+        benchmark_combined_lines: "{{ benchmark_output.stdout_lines + (benchmark_output.stderr_lines | default([])) }}"
 
     - name: Display benchmark output
       ansible.builtin.debug:
-        msg: "{{ benchmark_output.stdout_lines }}"
+        msg: "{{ benchmark_combined_lines }}"
 
     - name: Save raw benchmark output
       ansible.builtin.copy:
-        content: "{{ benchmark_output.stdout }}"
+        content: "{{ benchmark_combined_log }}"
         dest: "{{ hostvars['localhost']['results_base'] }}/{{ hostvars['localhost']['model_safe'] }}/offline-batch-{{ hostvars['localhost']['test_timestamp'] }}/{{ hostvars['localhost']['config_id'] }}/benchmark.log"
       delegate_to: localhost
 
@@ -356,16 +364,16 @@
   tasks:
     - name: Extract throughput metrics from output
       ansible.builtin.set_fact:
-        throughput_line: "{{ hostvars[groups['dut'][0]]['benchmark_output'].stdout_lines | select('search', 'Throughput:') | first }}"
-      when: hostvars[groups['dut'][0]]['benchmark_output'].stdout_lines | select('search', 'Throughput:') | list | length > 0
+        throughput_line: "{{ hostvars[groups['dut'][0]]['benchmark_combined_lines'] | select('search', 'Throughput:') | first }}"
+      when: hostvars[groups['dut'][0]]['benchmark_combined_lines'] | select('search', 'Throughput:') | list | length > 0
 
     - name: Extract token counts from output
       ansible.builtin.set_fact:
-        prompt_tokens_line: "{{ hostvars[groups['dut'][0]]['benchmark_output'].stdout_lines | select('search', 'Total num prompt tokens:') | first }}"
-        output_tokens_line: "{{ hostvars[groups['dut'][0]]['benchmark_output'].stdout_lines | select('search', 'Total num output tokens:') | first }}"
+        prompt_tokens_line: "{{ hostvars[groups['dut'][0]]['benchmark_combined_lines'] | select('search', 'Total num prompt tokens:') | first }}"
+        output_tokens_line: "{{ hostvars[groups['dut'][0]]['benchmark_combined_lines'] | select('search', 'Total num output tokens:') | first }}"
       when:
-        - hostvars[groups['dut'][0]]['benchmark_output'].stdout_lines | select('search', 'Total num prompt tokens:') | list | length > 0
-        - hostvars[groups['dut'][0]]['benchmark_output'].stdout_lines | select('search', 'Total num output tokens:') | list | length > 0
+        - hostvars[groups['dut'][0]]['benchmark_combined_lines'] | select('search', 'Total num prompt tokens:') | list | length > 0
+        - hostvars[groups['dut'][0]]['benchmark_combined_lines'] | select('search', 'Total num output tokens:') | list | length > 0
 
     - name: Parse throughput values
       ansible.builtin.set_fact:
@@ -384,7 +392,7 @@
 
     - name: Extract streaming metrics from logs (prefill/decode throughput, KV cache, prefix cache)
       ansible.builtin.set_fact:
-        engine_logs: "{{ hostvars[groups['dut'][0]]['benchmark_output'].stdout_lines | select('search', 'Engine 000:') | list }}"
+        engine_logs: "{{ hostvars[groups['dut'][0]]['benchmark_combined_lines'] | select('search', 'Engine 000:') | list }}"
 
     - name: Parse average prefill throughput from streaming logs
       ansible.builtin.set_fact:

--- a/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
+++ b/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
@@ -105,7 +105,7 @@
 
     - name: Check if model is already cached
       ansible.builtin.stat:
-        path: "{{ dut_cache_dir }}/models--{{ test_model | replace('/', '--') }}"
+        path: "{{ dut_cache_dir }}/models--{{ test_model | replace('/', '--') }}/snapshots"
       register: model_cache_check
 
     - name: Display cache status
@@ -131,9 +131,10 @@
 
     - name: Get model snapshot path
       ansible.builtin.shell: |
-        ls -d {{ dut_cache_dir }}/models--{{ test_model | replace('/', '--') }}/snapshots/* | head -1
+        ls -d {{ dut_cache_dir }}/models--{{ test_model | replace('/', '--') }}/snapshots/* 2>/dev/null | head -1
       register: model_snapshot_path
       changed_when: false
+      failed_when: model_snapshot_path.stdout | trim | length == 0
 
     - name: Set model facts for localhost
       ansible.builtin.set_fact:

--- a/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
+++ b/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
@@ -323,7 +323,18 @@
         HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
       register: benchmark_output
       changed_when: false
+      ignore_errors: true
       no_log: true
+
+    - name: Display benchmark failure output
+      ansible.builtin.debug:
+        msg: "{{ (['Benchmark FAILED (rc=' + (benchmark_output.rc | string) + '):'] + benchmark_output.stderr_lines[-80:]) }}"
+      when: benchmark_output.rc != 0
+
+    - name: Fail if benchmark failed
+      ansible.builtin.fail:
+        msg: "Benchmark failed with rc={{ benchmark_output.rc }}"
+      when: benchmark_output.rc != 0
 
     - name: Display benchmark output
       ansible.builtin.debug:

--- a/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
+++ b/automation/test-execution/ansible/llm-benchmark-offline-batch.yml
@@ -104,13 +104,16 @@
         mode: "0755"
 
     - name: Check if model is already cached
-      ansible.builtin.stat:
-        path: "{{ dut_cache_dir }}/models--{{ test_model | replace('/', '--') }}/snapshots"
+      ansible.builtin.shell: |
+        find {{ dut_cache_dir }}/models--{{ test_model | replace('/', '--') }}/snapshots \
+          -mindepth 1 -maxdepth 1 -type d 2>/dev/null | grep -q .
       register: model_cache_check
+      failed_when: false
+      changed_when: false
 
     - name: Display cache status
       ansible.builtin.debug:
-        msg: "Model {{ test_model }} {{ 'found in cache' if model_cache_check.stat.exists else 'not found, will download using container' }}"
+        msg: "Model {{ test_model }} {{ 'found in cache (complete snapshot)' if model_cache_check.rc == 0 else 'not found or incomplete, will download using container' }}"
 
     - name: Download model using container
       ansible.builtin.shell: |
@@ -124,7 +127,7 @@
           -c "from huggingface_hub import snapshot_download; snapshot_download('{{ test_model }}', cache_dir='/root/.cache/huggingface')"
       environment:
         HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
-      when: not model_cache_check.stat.exists
+      when: model_cache_check.rc != 0
       register: model_download
       changed_when: model_download.rc == 0
       no_log: true

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/3_📊_Embedding_Metrics.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/3_📊_Embedding_Metrics.py
@@ -109,7 +109,7 @@ def load_embedding_data(results_dir: str) -> pd.DataFrame:
 
                         # Extract test_name from test_run_id (format: test_name-YYYYMMDD-HHMMSS or just YYYYMMDD-HHMMSS)
                         test_run_id = metadata.get('test_run_id', 'unknown')
-                        test_name = None
+                        test_name = ''
                         if test_run_id != 'unknown' and '-' in test_run_id:
                             parts = test_run_id.split('-')
                             # If more than 2 parts (date-time), first part(s) are test_name
@@ -1560,10 +1560,25 @@ def main():
         with col6:
             # Scenario filter - remove empty strings and deduplicate
             scenarios = sorted(set([s for s in df['scenario'].unique() if s and s.strip()]))
+            # Auto-select newly available scenarios: Streamlit preserves widget state across
+            # reruns, so if the session started when only 'baseline' existed, 'latency' and
+            # 'all' would silently stay deselected after data is added. Fix: whenever the
+            # available scenario set grows, merge the new scenarios into the selection.
+            _scenario_key = '_embedding_scenario_filter'
+            _scenario_opts_key = '_embedding_scenario_opts'
+            if st.session_state.get(_scenario_opts_key) != scenarios:
+                prev_selection = set(st.session_state.get(_scenario_key, scenarios))
+                prev_opts = set(st.session_state.get(_scenario_opts_key, []))
+                new_scenarios = set(scenarios) - prev_opts
+                st.session_state[_scenario_key] = sorted(
+                    (prev_selection & set(scenarios)) | new_scenarios
+                )
+                st.session_state[_scenario_opts_key] = scenarios
             selected_scenarios = st.multiselect(
                 "Scenario",
                 options=scenarios,
                 default=scenarios,
+                key=_scenario_key,
                 help="Test scenario: baseline, latency, or all"
             )
 

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/4_📦_Offline_Batch.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/4_📦_Offline_Batch.py
@@ -8,9 +8,10 @@ time estimates, core scaling, prefill/decode.
 """
 
 import json
+import re
 import sys
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional, Sequence
 
 import pandas as pd
 import plotly.graph_objects as go
@@ -138,6 +139,111 @@ USE_CASE_REFERENCE = [
     },
 ]
 
+# Full-suite prompt counts (run-offline-batch-suite.sh reference values).
+REFERENCE_PROMPTS_BY_SLUG: Dict[str, int] = {
+    'summarization': 1000,
+    'classification': 1000,
+    'translation': 500,
+    'entity_extraction': 1000,
+    'dataset_generation': 5000,
+    'code_generation': 500,
+    'etl': 500,
+    'long_summarization': 500,
+    'rag_batch': 500,
+    'shared_prefix': 1000,
+    'short_labeling': 2000,
+}
+
+RUN_AGGREGATION_MODES = ('Latest run only', 'Mean of all runs', 'Best of all runs')
+
+EXPECTED_CORE_COUNTS = (8, 16, 24, 32)
+VARIANCE_CV_THRESHOLD = 0.10
+SERVER_METRICS_PAGE = 'pages/2_🖥️_Server_Metrics.py'
+
+PRODUCT_USE_CASE_DISPLAYS = [
+    USE_CASE_MAP[slug]
+    for slug in USE_CASE_MAP
+    if slug not in TECHNICAL_USE_CASES
+]
+
+METRIC_RPS = 'metric_throughput_requests_per_sec'
+METRIC_TOK_S = 'metric_throughput_total_tokens_per_sec'
+PREFILL_COL = 'metric_prefill_throughput_tokens_per_sec'
+DECODE_COL = 'metric_decode_throughput_tokens_per_sec'
+
+# Bump when dashboard layout/features change (shown in UI for verification).
+DASHBOARD_BUILD = '2026-08-06-import'
+
+TAB_GUIDES = {
+    'overview': """
+**Suite health** — top metrics show how complete your benchmark matrix is.
+
+| Section | What it tells you |
+|--------|-------------------|
+| **Throughput heatmap** | Best items/hour per model × use case at one core count |
+| **Best configuration** | Highest-throughput model@cores per use case |
+| **Capacity snapshot** | Planning estimate for one use case (items/hr, time for 10k) |
+| **Data completeness** | Missing sweeps (prefill/decode, multi-core) + commands to fix |
+| **Expected vs actual** | Which of the 11 product use cases × models have any runs |
+| **Run variance** | Spread across repeated runs (high CV = less trustworthy) |
+| **Version regression** | Req/s change between vLLM versions |
+| **Coverage** | How many runs exist per model@cores × use case |
+""",
+    'use_cases': """
+Pick a **use case** to compare configurations for that workload.
+
+| Chart | Meaning |
+|-------|---------|
+| **Processing capacity** | Items/hour per model@cores (one bar each — best config if duplicates exist) |
+| **Time estimates** | Wall-clock time for a chosen batch size |
+| **Workload planner** | Enter volume + deadline → which configs qualify |
+| **Cache metrics** | KV-cache usage and prefix-cache hit rate (shared-prefix / RAG) |
+| **Prefill vs decode** | Prompt processing vs token generation speed (bottleneck hint) |
+""",
+    'scaling': """
+**Core scaling** needs multiple core counts (8/16/24/32) for the same use case + model.
+
+| Section | Meaning |
+|---------|---------|
+| **Core scaling chart** | Items/hr and tokens/sec/core vs CPU cores |
+| **Scaling efficiency** | Actual speedup vs ideal linear scaling |
+| **Technical sweeps** | KV capacity, context length, batch size experiments |
+""",
+    'all_runs': """
+Raw benchmark rows — use for debugging and exports.
+
+| Tool | Purpose |
+|------|---------|
+| **CSV export** | Download filtered results or capacity summary |
+| **Config comparison** | Side-by-side delta for two runs |
+| **Log preview** | Tail of `benchmark.log` (engine stats, errors) |
+| **Results table** | Every loaded run with config fingerprint |
+""",
+    'sidebar': """
+| Control | Effect |
+|---------|--------|
+| **Results Directory** | Path to `results/llm/` |
+| **Additional directory** | Merge a second `results/llm` tree (e.g. from a teammate) |
+| **Import CSV** | Upload a CSV exported from **All Runs → Download** |
+| **Run aggregation** | Collapse repeats: latest, mean, or best req/s |
+| **Hide capped runs** | Drop smoke tests with fewer prompts than full suite |
+| **Minimum runs** | Hide configs with too few repeats |
+| **Focus use case** | Pin one use case across tabs |
+""",
+}
+
+
+def _render_tab_guide(tab_key: str) -> None:
+    """Collapsed help for the active tab."""
+    label = {
+        'overview': 'ℹ️ How to read Overview',
+        'use_cases': 'ℹ️ How to read Use Cases',
+        'scaling': 'ℹ️ How to read Scaling',
+        'all_runs': 'ℹ️ How to read All Runs',
+    }.get(tab_key, 'ℹ️ Help')
+    with st.expander(label, expanded=False):
+        st.markdown(TAB_GUIDES.get(tab_key, ''))
+
 
 def compute_items_per_hour(requests_per_sec: float) -> float:
     """Convert req/s to items/hour."""
@@ -170,6 +276,875 @@ def format_duration(seconds: float) -> str:
     if seconds < 3600:
         return f"{seconds / 60:.1f} min"
     return f"{seconds / 3600:.1f} hr"
+
+
+def collapse_by_model_cores(
+    df: pd.DataFrame,
+    metric_col: str = METRIC_RPS,
+) -> pd.DataFrame:
+    """One row per model@cores for bar charts.
+
+    Plotly stacks bars that share the same x-axis category. Multiple benchmark
+    configs (prompt counts, token lengths) can share model@cores labels.
+    """
+    if df.empty:
+        return df.copy()
+
+    working = df.copy()
+    if 'items_per_hour' not in working.columns:
+        working['items_per_hour'] = working[metric_col].apply(
+            compute_items_per_hour
+        )
+
+    idx = working.groupby(
+        ['model_short', 'cores'], dropna=False
+    )[metric_col].idxmax()
+    collapsed = working.loc[idx].copy()
+    collapsed['config_label'] = (
+        collapsed['model_short'].astype(str)
+        + '\n'
+        + collapsed['cores'].astype(str)
+        + ' cores'
+    )
+    return collapsed.sort_values('items_per_hour', ascending=False)
+
+
+def config_group_columns(df: pd.DataFrame) -> List[str]:
+    """Columns that uniquely identify an offline-batch configuration."""
+    cols = ['model_short', 'use_case', 'cores', 'dataset', 'num_prompts']
+    for optional in ('config_input_len', 'config_output_len', 'use_case_slug'):
+        if optional in df.columns:
+            cols.append(optional)
+    return cols
+
+
+def build_config_fingerprint(row: dict) -> str:
+    """Compact label for a benchmark configuration."""
+    parts = [
+        f"{row.get('cores', '?')}c",
+        str(row.get('dataset', '?')),
+        f"{row.get('num_prompts', '?')} prompts",
+    ]
+    in_len = row.get('config_input_len')
+    out_len = row.get('config_output_len')
+    if pd.notna(in_len) if in_len is not None else False:
+        parts.append(f"in={int(in_len)}")
+    if pd.notna(out_len) if out_len is not None else False:
+        parts.append(f"out={int(out_len)}")
+    return ' / '.join(parts)
+
+
+def is_capped_run(use_case_slug: str, num_prompts: int) -> bool:
+    """True when num_prompts is below the full-suite reference for this slug."""
+    if not use_case_slug:
+        return False
+    reference = REFERENCE_PROMPTS_BY_SLUG.get(use_case_slug)
+    if reference is None:
+        return False
+    return num_prompts < reference
+
+
+def capped_run_note(use_case_slug: str, num_prompts: int) -> str:
+    """Human-readable note for capped prompt counts, or empty string."""
+    if not is_capped_run(use_case_slug, num_prompts):
+        return ''
+    reference = REFERENCE_PROMPTS_BY_SLUG[use_case_slug]
+    return (
+        f"Capped run: {num_prompts} prompts "
+        f"(full suite uses {reference}; set OFFLINE_BATCH_MAX_PROMPTS=0)"
+    )
+
+
+def apply_run_aggregation(
+    df: pd.DataFrame,
+    mode: str,
+    metric_col: str = METRIC_RPS,
+) -> pd.DataFrame:
+    """Collapse multiple runs per config to one row per configuration."""
+    if df.empty:
+        return df.copy()
+
+    group_cols = config_group_columns(df)
+    metric_cols = [
+        c for c in df.columns
+        if c.startswith('metric_') and pd.api.types.is_numeric_dtype(df[c])
+    ]
+
+    if mode == 'Latest run only':
+        idx = df.groupby(group_cols, dropna=False)['timestamp'].idxmax()
+        out = df.loc[idx].copy()
+        out['n_runs'] = df.groupby(group_cols, dropna=False).size().values
+        return out.reset_index(drop=True)
+
+    if mode == 'Best of all runs':
+        idx = df.groupby(group_cols, dropna=False)[metric_col].idxmax()
+        out = df.loc[idx].copy()
+        out['n_runs'] = df.groupby(group_cols, dropna=False).size().values
+        return out.reset_index(drop=True)
+
+    # Mean of all runs (default)
+    agg_map = {col: 'mean' for col in metric_cols}
+    grouped = df.groupby(group_cols, dropna=False).agg(agg_map)
+    stats = df.groupby(group_cols, dropna=False)[metric_col].agg(
+        ['count', 'std', 'min', 'max']
+    )
+    stats = stats.rename(columns={
+        'count': 'n_runs',
+        'std': f'{metric_col}_std',
+        'min': f'{metric_col}_min',
+        'max': f'{metric_col}_max',
+    })
+    out = grouped.join(stats)
+    if f'{metric_col}_std' in out.columns:
+        out[f'{metric_col}_std'] = out[f'{metric_col}_std'].fillna(0.0)
+    latest_idx = df.groupby(group_cols, dropna=False)['timestamp'].idxmax()
+    out['latest_timestamp'] = df.loc[latest_idx, 'timestamp'].values
+    return out.reset_index()
+
+
+def build_coverage_pivot(df: pd.DataFrame) -> pd.DataFrame:
+    """Pivot: rows=model@cores, columns=use case, values=run count."""
+    if df.empty:
+        return pd.DataFrame()
+    working = df.copy()
+    working['model_cores'] = (
+        working['model_short'].astype(str)
+        + ' @ '
+        + working['cores'].astype(str)
+        + 'c'
+    )
+    counts = (
+        working.groupby(['model_cores', 'use_case'])
+        .size()
+        .unstack(fill_value=0)
+    )
+    return counts.sort_index()
+
+
+def coverage_cell_style(value: int) -> str:
+    """Background color for coverage heatmap cells."""
+    if value <= 0:
+        return 'background-color: #f0f0f0; color: #888'
+    if value < 3:
+        return 'background-color: #fff3cd; color: #664d03'
+    return 'background-color: #d1e7dd; color: #0f5132'
+
+
+def style_coverage_pivot(pivot: pd.DataFrame):
+    """Return a pandas Styler for the coverage matrix."""
+    return pivot.style.map(coverage_cell_style).format('{:.0f}')
+
+
+def build_best_configs_table(
+    df: pd.DataFrame,
+    metric_col: str = METRIC_RPS,
+) -> pd.DataFrame:
+    """One best row per product use case (highest req/s)."""
+    if df.empty:
+        return pd.DataFrame()
+
+    rows = []
+    for use_case in sorted(df['use_case'].unique()):
+        uc_df = df[df['use_case'] == use_case]
+        best_idx = uc_df[metric_col].idxmax()
+        best = uc_df.loc[best_idx]
+        units = get_use_case_units(use_case)
+        rps = best.get(metric_col, 0) or 0
+        rows.append({
+            'Use Case': use_case,
+            'Model': best['model_short'],
+            'Cores': best['cores'],
+            'Config': best.get('config_fingerprint', ''),
+            'Req/s': round(rps, 3),
+            f"{units['plural'].capitalize()}/hr": int(compute_items_per_hour(rps)),
+            'Runs': int(best.get('n_runs', 1)),
+        })
+    return pd.DataFrame(rows)
+
+
+def apply_quality_filters(
+    df: pd.DataFrame,
+    hide_capped: bool = False,
+    min_runs: int = 1,
+) -> pd.DataFrame:
+    """Filter raw runs by capped status and minimum run count per config."""
+    if df.empty:
+        return df.copy()
+
+    out = df.copy()
+    if hide_capped and 'is_capped' in out.columns:
+        out = out[~out['is_capped'].fillna(False)]
+
+    if min_runs > 1:
+        group_cols = config_group_columns(out)
+        counts = out.groupby(group_cols, dropna=False).transform('size')
+        out = out[counts >= min_runs]
+
+    return out.reset_index(drop=True)
+
+
+def _has_prefill_decode(row: pd.Series) -> bool:
+    prefill = row.get(PREFILL_COL, 0) or 0
+    decode = row.get(DECODE_COL, 0) or 0
+    return prefill > 0 or decode > 0
+
+
+def build_completeness_report(df_product: pd.DataFrame) -> Dict[str, object]:
+    """Summarize suite data quality and gaps."""
+    if df_product.empty:
+        return {
+            'total_runs': 0,
+            'use_cases_seen': 0,
+            'use_cases_expected': len(PRODUCT_USE_CASE_DISPLAYS),
+            'models_seen': 0,
+            'prefill_decode_pct': 0.0,
+            'multi_core_pct': 0.0,
+            'capped_count': 0,
+            'suite_completion_pct': 0.0,
+        }
+
+    use_cases_seen = set(df_product['use_case'].unique())
+    models_seen = set(df_product['model_short'].unique())
+    prefill_ok = int(df_product.apply(_has_prefill_decode, axis=1).sum())
+    capped_count = int(df_product['is_capped'].sum()) if 'is_capped' in df_product.columns else 0
+
+    multi_core_use_cases = 0
+    for _, group in df_product.groupby('use_case'):
+        if len(group['cores'].dropna().unique()) > 1:
+            multi_core_use_cases += 1
+
+    expected_cells = (
+        len(PRODUCT_USE_CASE_DISPLAYS) * max(len(models_seen), 1)
+    )
+    actual_cells = len(
+        df_product.groupby(['use_case', 'model_short']).size()
+    )
+    suite_pct = (
+        min(100.0, (actual_cells / expected_cells) * 100)
+        if expected_cells > 0
+        else 0.0
+    )
+
+    return {
+        'total_runs': len(df_product),
+        'use_cases_seen': len(use_cases_seen),
+        'use_cases_expected': len(PRODUCT_USE_CASE_DISPLAYS),
+        'models_seen': len(models_seen),
+        'prefill_decode_pct': round(
+            100.0 * prefill_ok / len(df_product), 1
+        ),
+        'multi_core_pct': round(
+            100.0 * multi_core_use_cases / max(len(use_cases_seen), 1), 1
+        ),
+        'capped_count': capped_count,
+        'suite_completion_pct': round(suite_pct, 1),
+    }
+
+
+def build_data_gaps_table(df_product: pd.DataFrame) -> pd.DataFrame:
+    """Actionable gaps: missing prefill/decode, single-core, capped, low runs."""
+    if df_product.empty:
+        return pd.DataFrame()
+
+    rows = []
+    group_cols = config_group_columns(df_product)
+
+    for (keys, group) in df_product.groupby(group_cols, dropna=False):
+        if not isinstance(keys, tuple):
+            keys = (keys,)
+        row = dict(zip(group_cols, keys))
+        use_case = row.get('use_case', '')
+        slug = row.get('use_case_slug', '') or _get_use_case_slug(use_case)
+        cli_name = use_case_cli_name(use_case, slug)
+        n_runs = len(group)
+        cores = sorted(group['cores'].dropna().unique().tolist())
+        has_pd = group.apply(_has_prefill_decode, axis=1).any()
+        is_cap = bool(group['is_capped'].any()) if 'is_capped' in group.columns else False
+
+        gaps = []
+        if not has_pd:
+            gaps.append('prefill/decode')
+        if len(cores) <= 1:
+            gaps.append('multi-core')
+        if is_cap:
+            gaps.append('capped')
+        if n_runs < 3:
+            gaps.append(f'low runs ({n_runs})')
+
+        if gaps:
+            cmd = (
+                f'./run-offline-batch-suite.sh use-case-sweep '
+                f'{cli_name} all 8,16,24,32'
+            )
+            rows.append({
+                'Use Case': use_case,
+                'Model': row.get('model_short', ''),
+                'Cores': ', '.join(str(c) for c in cores),
+                'Runs': n_runs,
+                'Gaps': ', '.join(gaps),
+                'Suggested Command': cmd,
+            })
+
+    if not rows:
+        return pd.DataFrame()
+    return pd.DataFrame(rows).sort_values(['Use Case', 'Model'])
+
+
+def build_expected_vs_actual_matrix(
+    df_product: pd.DataFrame,
+    models: Optional[Sequence[str]] = None,
+) -> pd.DataFrame:
+    """Expected product use cases vs models; cell = run count (0 if missing)."""
+    if models is None:
+        models = sorted(df_product['model_short'].unique().tolist()) if not df_product.empty else []
+
+    matrix = []
+    for uc in PRODUCT_USE_CASE_DISPLAYS:
+        row = {'Use Case': uc}
+        for model in models:
+            if df_product.empty:
+                count = 0
+            else:
+                count = len(df_product[
+                    (df_product['use_case'] == uc)
+                    & (df_product['model_short'] == model)
+                ])
+            row[model] = count
+        matrix.append(row)
+    return pd.DataFrame(matrix)
+
+
+def build_model_usecase_heatmap(
+    df_product_view: pd.DataFrame,
+    cores: Optional[int] = None,
+    metric_col: str = METRIC_RPS,
+) -> pd.DataFrame:
+    """Pivot for heatmap: rows=models, columns=use cases, values=items/hr."""
+    if df_product_view.empty:
+        return pd.DataFrame()
+
+    working = df_product_view.copy()
+    if cores is not None:
+        working = working[working['cores'] == cores]
+    if working.empty:
+        return pd.DataFrame()
+
+    working['items_per_hour'] = working[metric_col].apply(
+        compute_items_per_hour
+    )
+    pivot = working.pivot_table(
+        index='model_short',
+        columns='use_case',
+        values='items_per_hour',
+        aggfunc='max',
+    )
+    return pivot.sort_index()
+
+
+def compute_coefficient_of_variation(mean: float, std: float) -> float:
+    if mean <= 0 or std != std:  # NaN check
+        return 0.0
+    return std / mean
+
+
+def build_variance_summary(df_product: pd.DataFrame) -> pd.DataFrame:
+    """Per-config run variance from raw (unaggregated) data."""
+    if df_product.empty:
+        return pd.DataFrame()
+
+    group_cols = config_group_columns(df_product)
+    rows = []
+    for keys, group in df_product.groupby(group_cols, dropna=False):
+        if not isinstance(keys, tuple):
+            keys = (keys,)
+        row = dict(zip(group_cols, keys))
+        n = len(group)
+        mean_rps = group[METRIC_RPS].mean()
+        std_rps = group[METRIC_RPS].std() if n > 1 else 0.0
+        cv = compute_coefficient_of_variation(mean_rps, std_rps or 0.0)
+        high_var = n > 1 and cv > VARIANCE_CV_THRESHOLD
+        rows.append({
+            'Use Case': row.get('use_case', ''),
+            'Model': row.get('model_short', ''),
+            'Cores': row.get('cores', ''),
+            'Runs': n,
+            'Mean Req/s': round(mean_rps, 3),
+            'Std Dev': round(std_rps or 0.0, 3),
+            'CV %': round(cv * 100, 1),
+            'High Variance': '⚠️ Yes' if high_var else 'No',
+        })
+    return pd.DataFrame(rows).sort_values(['Use Case', 'Model', 'Cores'])
+
+
+def build_scaling_efficiency_table(df_cs: pd.DataFrame) -> pd.DataFrame:
+    """Actual vs theoretical core scaling speedup."""
+    if df_cs.empty or len(df_cs) < 2:
+        return pd.DataFrame()
+
+    sorted_df = df_cs.sort_values('cores')
+    base = sorted_df.iloc[0]
+    base_cores = float(base['cores'])
+    base_rps = float(base.get(METRIC_RPS, 0) or 0)
+    if base_rps <= 0:
+        return pd.DataFrame()
+
+    rows = []
+    for _, row in sorted_df.iloc[1:].iterrows():
+        cores = float(row['cores'])
+        rps = float(row.get(METRIC_RPS, 0) or 0)
+        theoretical = cores / base_cores
+        actual = rps / base_rps if base_rps > 0 else 0
+        efficiency = (actual / theoretical * 100) if theoretical > 0 else 0
+
+        if actual < 1.0:
+            verdict = '❌ Degraded'
+        elif efficiency < 50:
+            verdict = '⚠️ Poor'
+        elif efficiency < 80:
+            verdict = '⚠️ Fair'
+        else:
+            verdict = '✅ Good'
+
+        rows.append({
+            'Baseline': f"{int(base_cores)}c",
+            'Comparison': f"{int(cores)}c",
+            'Theoretical': f"{theoretical:.1f}x",
+            'Actual': f"{actual:.2f}x",
+            'Efficiency %': f"{efficiency:.1f}%",
+            'Verdict': verdict,
+        })
+    return pd.DataFrame(rows)
+
+
+def find_configs_for_deadline(
+    df: pd.DataFrame,
+    use_case: str,
+    batch_size: int,
+    deadline_hours: float,
+) -> pd.DataFrame:
+    """Configs that can process batch_size within deadline_hours."""
+    if df.empty or deadline_hours <= 0:
+        return pd.DataFrame()
+
+    uc_df = df[df['use_case'] == use_case].copy()
+    if uc_df.empty:
+        return pd.DataFrame()
+
+    units = get_use_case_units(use_case)
+    deadline_sec = deadline_hours * 3600.0
+    uc_df['time_sec'] = uc_df[METRIC_RPS].apply(
+        lambda r: compute_time_for_batch(r, batch_size)
+    )
+    uc_df['items_per_hour'] = uc_df[METRIC_RPS].apply(compute_items_per_hour)
+    qualifying = uc_df[uc_df['time_sec'] <= deadline_sec].copy()
+    if qualifying.empty:
+        return pd.DataFrame()
+
+    qualifying = qualifying.sort_values('time_sec')
+    return qualifying[[
+        'model_short', 'cores', 'config_fingerprint',
+        METRIC_RPS, 'items_per_hour', 'time_sec',
+    ]].assign(
+        time_display=lambda d: d['time_sec'].apply(format_duration),
+        unit=units['plural'],
+    )
+
+
+def build_version_regression_table(df_product: pd.DataFrame) -> pd.DataFrame:
+    """Compare latest version vs previous per use case / model / cores."""
+    if df_product.empty or df_product['vllm_version'].nunique() < 2:
+        return pd.DataFrame()
+
+    rows = []
+    group_cols = ['use_case', 'model_short', 'cores']
+    for keys, group in df_product.groupby(group_cols, dropna=False):
+        versions = sorted(group['vllm_version'].unique())
+        if len(versions) < 2:
+            continue
+        prev_v, latest_v = versions[-2], versions[-1]
+        prev_rps = group[group['vllm_version'] == prev_v][METRIC_RPS].mean()
+        latest_rps = group[group['vllm_version'] == latest_v][METRIC_RPS].mean()
+        if prev_rps <= 0:
+            continue
+        pct_change = ((latest_rps - prev_rps) / prev_rps) * 100
+        if pct_change < -5:
+            flag = '🔴 Regression'
+        elif pct_change > 5:
+            flag = '🟢 Improvement'
+        else:
+            flag = '— Stable'
+        if not isinstance(keys, tuple):
+            keys = (keys,)
+        row = dict(zip(group_cols, keys))
+        rows.append({
+            'Use Case': row['use_case'],
+            'Model': row['model_short'],
+            'Cores': row['cores'],
+            'Previous': prev_v,
+            'Latest': latest_v,
+            'Prev Req/s': round(prev_rps, 3),
+            'Latest Req/s': round(latest_rps, 3),
+            'Change %': f"{pct_change:+.1f}%",
+            'Status': flag,
+        })
+    if not rows:
+        return pd.DataFrame()
+    return pd.DataFrame(rows).sort_values(['Use Case', 'Model'])
+
+
+def build_time_trend_data(df_product: pd.DataFrame) -> pd.DataFrame:
+    """Items/hr over time per config for trend charts."""
+    if df_product.empty or 'timestamp' not in df_product.columns:
+        return pd.DataFrame()
+
+    working = df_product.copy()
+    working['items_per_hour'] = working[METRIC_RPS].apply(compute_items_per_hour)
+    working['config_label'] = (
+        working['use_case'].astype(str)
+        + ' / '
+        + working['model_short'].astype(str)
+        + ' @ '
+        + working['cores'].astype(str)
+        + 'c'
+    )
+    return working[[
+        'timestamp', 'config_label', 'items_per_hour', METRIC_RPS,
+        'use_case', 'model_short', 'cores', 'vllm_version',
+    ]].sort_values('timestamp')
+
+
+def compare_config_rows(row_a: pd.Series, row_b: pd.Series) -> pd.DataFrame:
+    """Side-by-side delta for two benchmark rows."""
+    metrics = [
+        ('Req/s', METRIC_RPS),
+        ('Items/hr', None),
+        ('Tokens/s', METRIC_TOK_S),
+        ('Prefill tok/s', PREFILL_COL),
+        ('Decode tok/s', DECODE_COL),
+        ('KV Cache %', 'metric_max_kv_cache_usage_percent'),
+        ('Prefix Cache %', 'metric_avg_prefix_cache_hit_rate_percent'),
+    ]
+    rows = []
+    for label, col in metrics:
+        if label == 'Items/hr':
+            val_a = compute_items_per_hour(row_a.get(METRIC_RPS, 0) or 0)
+            val_b = compute_items_per_hour(row_b.get(METRIC_RPS, 0) or 0)
+        else:
+            val_a = row_a.get(col, 0) or 0
+            val_b = row_b.get(col, 0) or 0
+        delta = val_b - val_a
+        pct = (delta / val_a * 100) if val_a else 0
+        rows.append({
+            'Metric': label,
+            'Config A': round(val_a, 3),
+            'Config B': round(val_b, 3),
+            'Delta': round(delta, 3),
+            'Change %': f"{pct:+.1f}%" if val_a else 'N/A',
+        })
+
+    rows.append({
+        'Metric': 'Config fingerprint',
+        'Config A': row_a.get('config_fingerprint', ''),
+        'Config B': row_b.get('config_fingerprint', ''),
+        'Delta': '',
+        'Change %': '',
+    })
+    return pd.DataFrame(rows)
+
+
+def config_diff_notes(row_a: pd.Series, row_b: pd.Series) -> List[str]:
+    """Human-readable config differences."""
+    diffs = []
+    for field, label in [
+        ('cores', 'cores'),
+        ('num_prompts', 'prompts'),
+        ('config_input_len', 'input len'),
+        ('config_output_len', 'output len'),
+        ('vllm_version', 'vLLM version'),
+        ('dataset', 'dataset'),
+    ]:
+        a, b = row_a.get(field), row_b.get(field)
+        if pd.notna(a) and pd.notna(b) and a != b:
+            diffs.append(f"{label}: {a} → {b}")
+    if row_a.get('is_capped') != row_b.get('is_capped'):
+        diffs.append('capped status differs')
+    return diffs
+
+
+def tail_benchmark_log(result_dir: str, max_lines: int = 40) -> str:
+    """Return trailing lines from benchmark.log, engine stats highlighted."""
+    log_path = Path(result_dir) / 'benchmark.log'
+    if not log_path.exists():
+        return '(benchmark.log not found)'
+    try:
+        lines = log_path.read_text(encoding='utf-8', errors='replace').splitlines()
+    except OSError as exc:
+        return f'(error reading log: {exc})'
+    tail = lines[-max_lines:] if len(lines) > max_lines else lines
+    return '\n'.join(tail)
+
+
+def build_capacity_summary_csv(df_product_view: pd.DataFrame) -> str:
+    """CSV export of best config per use case."""
+    best_df = build_best_configs_table(df_product_view)
+    if best_df.empty:
+        return ''
+    return best_df.to_csv(index=False)
+
+
+def build_filtered_results_csv(df: pd.DataFrame) -> str:
+    """CSV export of all filtered runs."""
+    if df.empty:
+        return ''
+    export = df.copy()
+    if METRIC_RPS in export.columns:
+        export['items_per_hour'] = export[METRIC_RPS].apply(compute_items_per_hour)
+    cols = [
+        c for c in [
+            'timestamp', 'use_case', 'model_short', 'cores', 'num_prompts',
+            'config_fingerprint', METRIC_RPS, 'items_per_hour', METRIC_TOK_S,
+            PREFILL_COL, DECODE_COL, 'vllm_version', 'test_run_id', 'result_dir',
+        ]
+        if c in export.columns
+    ]
+    return export[cols].to_csv(index=False)
+
+
+# Friendly CSV headers (from All Runs export) → internal column names
+IMPORT_CSV_COLUMN_MAP: Dict[str, str] = {
+    'Req/sec': METRIC_RPS,
+    'Tokens/sec': METRIC_TOK_S,
+    'Prefill tok/s': PREFILL_COL,
+    'Decode tok/s': DECODE_COL,
+    'Items/hr': 'items_per_hour',
+    'Use Case': 'use_case',
+    'Model': 'model_short',
+    'Cores': 'cores',
+    'Batch Size': 'num_prompts',
+    'Config': 'config_fingerprint',
+    'Run ID': 'test_run_id',
+    'vLLM Version': 'vllm_version',
+    'Result Path': 'result_dir',
+    'Input Len': 'config_input_len',
+    'Output Len': 'config_output_len',
+    'Timestamp': 'timestamp',
+}
+
+IMPORT_CSV_BARE_METRICS: Dict[str, str] = {
+    'throughput_requests_per_sec': METRIC_RPS,
+    'throughput_total_tokens_per_sec': METRIC_TOK_S,
+    'prefill_throughput_tokens_per_sec': PREFILL_COL,
+    'decode_throughput_tokens_per_sec': DECODE_COL,
+}
+
+
+def enrich_offline_batch_row(row: dict) -> dict:
+    """Fill derived fields on a directory-loaded or imported row."""
+    combined = dict(row)
+    model = combined.get('model') or combined.get('model_short') or 'unknown'
+    combined['model'] = model
+    combined['model_short'] = str(model).split('/')[-1]
+
+    if METRIC_RPS not in combined or pd.isna(combined.get(METRIC_RPS)):
+        items_hr = combined.get('items_per_hour')
+        if items_hr not in (None, '', 0):
+            combined[METRIC_RPS] = float(items_hr) / 3600.0
+
+    slug = combined.get('use_case_slug') or _get_use_case_slug(
+        combined.get('use_case', '')
+    )
+    combined['use_case_slug'] = slug
+    if not combined.get('config_fingerprint'):
+        combined['config_fingerprint'] = build_config_fingerprint(combined)
+
+    num_prompts = int(combined.get('num_prompts', 0) or 0)
+    combined['is_capped'] = is_capped_run(slug, num_prompts)
+    combined['capped_note'] = capped_run_note(slug, num_prompts)
+    combined.setdefault('dataset', 'unknown')
+    combined.setdefault('container_image', 'imported')
+    if combined.get('vllm_version'):
+        combined['vllm_version'] = normalize_vllm_version(
+            str(combined['vllm_version'])
+        )
+    else:
+        combined['vllm_version'] = 'imported'
+    combined.setdefault(
+        'test_run_id',
+        f"imported-{combined.get('timestamp', '')}",
+    )
+    combined['source'] = combined.get('source', 'import')
+    return combined
+
+
+def normalize_imported_offline_batch_df(df: pd.DataFrame) -> pd.DataFrame:
+    """Map an uploaded CSV to the internal offline-batch schema."""
+    if df.empty:
+        return df.copy()
+
+    out = df.copy()
+    for src, dst in IMPORT_CSV_COLUMN_MAP.items():
+        if src in out.columns and dst not in out.columns:
+            out[dst] = out[src]
+
+    for bare, col in IMPORT_CSV_BARE_METRICS.items():
+        if bare in out.columns and col not in out.columns:
+            out[col] = pd.to_numeric(out[bare], errors='coerce')
+
+    if METRIC_RPS not in out.columns and 'items_per_hour' in out.columns:
+        out[METRIC_RPS] = (
+            pd.to_numeric(out['items_per_hour'], errors='coerce') / 3600.0
+        )
+
+    missing = [
+        c for c in ('use_case', 'cores', METRIC_RPS)
+        if c not in out.columns
+    ]
+    if missing:
+        raise ValueError(
+            f"CSV missing required columns: {missing}. "
+            "Export from **All Runs → Download filtered runs (CSV)** "
+            "or include Use Case, Cores, and Req/sec."
+        )
+
+    out['cores'] = pd.to_numeric(out['cores'], errors='coerce')
+    out[METRIC_RPS] = pd.to_numeric(out[METRIC_RPS], errors='coerce')
+    if 'timestamp' in out.columns:
+        out['timestamp'] = pd.to_datetime(out['timestamp'])
+    else:
+        out['timestamp'] = pd.Timestamp.utcnow()
+    if 'num_prompts' in out.columns:
+        out['num_prompts'] = (
+            pd.to_numeric(out['num_prompts'], errors='coerce')
+            .fillna(0)
+            .astype(int)
+        )
+    else:
+        out['num_prompts'] = 0
+
+    rows = [enrich_offline_batch_row(r) for r in out.to_dict('records')]
+    return pd.DataFrame(rows)
+
+
+def merge_benchmark_dataframes(*frames: pd.DataFrame) -> pd.DataFrame:
+    """Concatenate directory + imported data, dedupe on test_run_id."""
+    parts = [f for f in frames if f is not None and not f.empty]
+    if not parts:
+        return pd.DataFrame()
+    merged = pd.concat(parts, ignore_index=True)
+    if 'test_run_id' in merged.columns:
+        merged = merged.drop_duplicates(subset=['test_run_id'], keep='last')
+    if 'model' in merged.columns:
+        merged['model_short'] = merged['model'].apply(
+            lambda x: str(x).split('/')[-1]
+        )
+    return merged
+
+
+def parse_streaming_metrics_from_log(log_text: str) -> Dict[str, float]:
+    """Extract prefill/decode/KV metrics from vLLM engine log lines.
+
+    vLLM prints periodic engine stats (often on stderr) like:
+    Engine 000: Avg prompt throughput: X tokens/s, Avg generation throughput: Y ...
+    """
+    prefill_samples: List[float] = []
+    decode_samples: List[float] = []
+    kv_samples: List[float] = []
+    prefix_samples: List[float] = []
+
+    for line in log_text.splitlines():
+        prefill_m = re.search(
+            r'Avg prompt throughput:\s*([0-9.]+)\s*tokens/s', line
+        )
+        if prefill_m:
+            prefill_samples.append(float(prefill_m.group(1)))
+
+        decode_m = re.search(
+            r'Avg generation throughput:\s*([0-9.]+)\s*tokens/s', line
+        )
+        if decode_m:
+            decode_samples.append(float(decode_m.group(1)))
+
+        kv_m = re.search(
+            r'(?:GPU|CPU) KV cache usage:\s*([0-9.]+)%', line
+        )
+        if kv_m:
+            kv_samples.append(float(kv_m.group(1)))
+
+        prefix_m = re.search(
+            r'Prefix cache hit rate:\s*([0-9.]+)%', line
+        )
+        if prefix_m:
+            prefix_samples.append(float(prefix_m.group(1)))
+
+    def _avg(values: List[float]) -> float:
+        return round(sum(values) / len(values), 2) if values else 0.0
+
+    return {
+        PREFILL_COL: _avg(prefill_samples),
+        DECODE_COL: _avg(decode_samples),
+        'metric_max_kv_cache_usage_percent': (
+            round(max(kv_samples), 2) if kv_samples else 0.0
+        ),
+        'metric_avg_prefix_cache_hit_rate_percent': _avg(prefix_samples),
+    }
+
+
+def backfill_streaming_metrics(combined: dict, config_dir: Path) -> None:
+    """Fill missing streaming metrics from benchmark.log when results.json has zeros."""
+    log_path = config_dir / 'benchmark.log'
+    if not log_path.exists():
+        return
+
+    needs_backfill = (
+        combined.get(PREFILL_COL, 0) in (0, None, 0.0)
+        or combined.get(DECODE_COL, 0) in (0, None, 0.0)
+    )
+    if not needs_backfill:
+        return
+
+    try:
+        log_metrics = parse_streaming_metrics_from_log(
+            log_path.read_text(encoding='utf-8', errors='replace')
+        )
+    except OSError:
+        return
+
+    for key, value in log_metrics.items():
+        if value and combined.get(key, 0) in (0, None, 0.0):
+            combined[key] = value
+
+
+def format_run_stats(row: pd.Series, metric_col: str = METRIC_RPS) -> str:
+    """Short stats string for hover text or captions."""
+    n = int(row.get('n_runs', 1))
+    val = row.get(metric_col, 0) or 0
+    if n <= 1:
+        return f"{val:.3f} req/s (n=1)"
+    std_col = f'{metric_col}_std'
+    if std_col in row.index and pd.notna(row[std_col]):
+        return (
+            f"{val:.3f} ± {row[std_col]:.3f} req/s "
+            f"(n={n}, min={row.get(f'{metric_col}_min', val):.3f}, "
+            f"max={row.get(f'{metric_col}_max', val):.3f})"
+        )
+    return f"{val:.3f} req/s (n={n})"
+
+
+def resolve_focus_use_case(
+    focus_choice: str,
+    available: Sequence[str],
+    tab_key: str,
+) -> Optional[str]:
+    """Pick the active use case from sidebar focus or a tab-local selectbox."""
+    if focus_choice != 'All':
+        return focus_choice
+    if not available:
+        return None
+    return st.selectbox(
+        'Use case:',
+        options=available,
+        key=tab_key,
+    )
 
 
 def get_use_case_units(use_case: str) -> Dict[str, str]:
@@ -343,15 +1318,65 @@ def _get_use_case_slug(display_name: str) -> str:
 # Data loading
 # ---------------------------------------------------------------------------
 
-@st.cache_data
-def load_benchmark_results(results_base_dir: str) -> pd.DataFrame:
-    """Load all offline batch benchmark results from the results directory."""
-    results: List[dict] = []
-    results_path = Path(results_base_dir)
+def _load_result_from_config_dir(config_dir: Path) -> Optional[dict]:
+    """Load one offline-batch result from a config directory."""
+    results_file = config_dir / 'results.json'
+    metadata_file = config_dir / 'test-metadata.json'
+    if not (results_file.exists() and metadata_file.exists()):
+        return None
 
+    with open(results_file, 'r') as f:
+        result_data = json.load(f)
+    with open(metadata_file, 'r') as f:
+        metadata = json.load(f)
+
+    combined = {
+        'model': metadata['model'],
+        'timestamp': metadata['timestamp'],
+        'test_run_id': metadata['test_run_id'],
+        'cores': metadata['configuration']['cores'],
+        'dataset': metadata['configuration']['dataset'],
+        'num_prompts': metadata['configuration']['num_prompts'],
+        'container_image': metadata['environment'].get(
+            'container_image', 'unknown'
+        ),
+        'vllm_version': normalize_vllm_version(
+            metadata['environment'].get('vllm_version', 'unknown')
+        ),
+        'result_dir': str(config_dir),
+        'source': 'directory',
+    }
+
+    dataset_config = metadata['configuration'].get('dataset_config', {})
+    if 'input_len' in dataset_config:
+        combined['config_input_len'] = dataset_config['input_len']
+    if 'output_len' in dataset_config:
+        combined['config_output_len'] = dataset_config['output_len']
+
+    combined['use_case_slug'] = dataset_config.get('use_case', '')
+
+    metrics = result_data.get('metrics', {})
+    for metric_name, metric_value in metrics.items():
+        combined[f'metric_{metric_name}'] = metric_value
+
+    combined['use_case'] = infer_use_case(metadata)
+    combined['config_fingerprint'] = build_config_fingerprint(combined)
+    slug = combined.get('use_case_slug', '')
+    combined['is_capped'] = is_capped_run(slug, int(combined['num_prompts']))
+    combined['capped_note'] = capped_run_note(
+        slug,
+        int(combined['num_prompts']),
+    )
+
+    backfill_streaming_metrics(combined, config_dir)
+    return combined
+
+
+def scan_results_directory(results_path: Path) -> List[dict]:
+    """Walk a results/llm tree and return raw result dicts."""
+    results: List[dict] = []
     if not results_path.exists():
-        st.error(f"Results directory not found: {results_base_dir}")
-        return pd.DataFrame()
+        return results
 
     for model_dir in results_path.iterdir():
         if not model_dir.is_dir():
@@ -367,71 +1392,44 @@ def load_benchmark_results(results_base_dir: str) -> pd.DataFrame:
             for config_dir in timestamp_dir.iterdir():
                 if not config_dir.is_dir():
                     continue
+                try:
+                    row = _load_result_from_config_dir(config_dir)
+                    if row:
+                        results.append(row)
+                except Exception as exc:
+                    st.warning(f"Error loading {config_dir}: {exc}")
 
-                results_file = config_dir / 'results.json'
-                metadata_file = config_dir / 'test-metadata.json'
+    return results
 
-                if results_file.exists() and metadata_file.exists():
-                    try:
-                        with open(results_file, 'r') as f:
-                            result_data = json.load(f)
-                        with open(metadata_file, 'r') as f:
-                            metadata = json.load(f)
 
-                        combined = {
-                            'model': metadata['model'],
-                            'timestamp': metadata['timestamp'],
-                            'test_run_id': metadata['test_run_id'],
-                            'cores': metadata['configuration']['cores'],
-                            'dataset': metadata['configuration']['dataset'],
-                            'num_prompts': metadata['configuration'][
-                                'num_prompts'
-                            ],
-                            'container_image': metadata['environment'].get(
-                                'container_image', 'unknown'
-                            ),
-                            'vllm_version': normalize_vllm_version(
-                                metadata['environment'].get(
-                                    'vllm_version', 'unknown'
-                                )
-                            ),
-                        }
-
-                        dataset_config = metadata['configuration'].get(
-                            'dataset_config', {}
-                        )
-                        if 'input_len' in dataset_config:
-                            combined['config_input_len'] = dataset_config[
-                                'input_len'
-                            ]
-                        if 'output_len' in dataset_config:
-                            combined['config_output_len'] = dataset_config[
-                                'output_len'
-                            ]
-
-                        # Store raw use_case slug for technical detection
-                        combined['use_case_slug'] = dataset_config.get(
-                            'use_case', ''
-                        )
-
-                        metrics = result_data.get('metrics', {})
-                        for metric_name, metric_value in metrics.items():
-                            combined[f'metric_{metric_name}'] = metric_value
-
-                        combined['use_case'] = infer_use_case(metadata)
-
-                        results.append(combined)
-
-                    except Exception as e:
-                        st.warning(f"Error loading {config_dir}: {e}")
-                        continue
-
+def results_list_to_dataframe(results: List[dict]) -> pd.DataFrame:
     if not results:
         return pd.DataFrame()
-
     df = pd.DataFrame(results)
     df['timestamp'] = pd.to_datetime(df['timestamp'])
     return df
+
+
+@st.cache_data
+def load_benchmark_results_from_dirs(*dir_paths: str) -> pd.DataFrame:
+    """Load and merge offline-batch results from one or more directories."""
+    all_rows: List[dict] = []
+    for dir_path in dir_paths:
+        if not dir_path or not str(dir_path).strip():
+            continue
+        path = Path(dir_path)
+        if not path.exists():
+            continue
+        all_rows.extend(scan_results_directory(path))
+    return results_list_to_dataframe(all_rows)
+
+
+def load_benchmark_results(results_base_dir: str) -> pd.DataFrame:
+    """Load all offline batch benchmark results from a single directory."""
+    path = Path(results_base_dir)
+    if not path.exists():
+        return pd.DataFrame()
+    return results_list_to_dataframe(scan_results_directory(path))
 
 
 # ---------------------------------------------------------------------------
@@ -443,6 +1441,1052 @@ def _safe_metric(df: pd.DataFrame, col: str, default: float = 0.0):
     if col in df.columns:
         return df[col].fillna(default)
     return pd.Series([default] * len(df), index=df.index)
+
+
+def _render_environment_banner(df_filtered: pd.DataFrame) -> None:
+    if 'container_image' not in df_filtered.columns:
+        return
+
+    unique_containers = df_filtered['container_image'].unique()
+    unique_versions = (
+        df_filtered['vllm_version'].unique()
+        if 'vllm_version' in df_filtered.columns
+        else []
+    )
+
+    if len(unique_containers) > 1 or len(unique_versions) > 1:
+        st.warning(
+            f"**Mixed environments** — "
+            f"{len(unique_containers)} container image(s), "
+            f"{len(unique_versions)} vLLM version(s). "
+            "Compare with care."
+        )
+        with st.expander("View environment details"):
+            for container in unique_containers:
+                count = len(
+                    df_filtered[df_filtered['container_image'] == container]
+                )
+                st.write(f"- **{container}**: {count} test(s)")
+    else:
+        container_short = (
+            unique_containers[0].split('/')[-1]
+            if len(unique_containers) > 0
+            else 'unknown'
+        )
+        version = (
+            unique_versions[0] if len(unique_versions) > 0 else 'unknown'
+        )
+        st.info(f"🐳 **Environment**: {container_short} (vLLM {version})")
+
+
+def _render_overview_tab(
+    df_product: pd.DataFrame,
+    df_product_view: pd.DataFrame,
+    focus_use_case: str,
+    all_models: List[str],
+) -> None:
+    """Suite overview: completeness, coverage, heatmap, best configs, trends."""
+    _render_tab_guide('overview')
+    st.subheader("Suite Overview")
+
+    if df_product.empty:
+        st.info("No product use-case results match the current filters.")
+        return
+
+    report = build_completeness_report(df_product)
+    col1, col2, col3, col4 = st.columns(4)
+    with col1:
+        st.metric("Raw runs", report['total_runs'])
+    with col2:
+        st.metric(
+            "Use cases",
+            f"{report['use_cases_seen']}/{report['use_cases_expected']}",
+        )
+    with col3:
+        st.metric("Suite completion", f"{report['suite_completion_pct']}%")
+    with col4:
+        st.metric("Prefill/decode coverage", f"{report['prefill_decode_pct']}%")
+
+    capped_count = report['capped_count']
+    if capped_count > 0:
+        st.warning(
+            f"**{capped_count} capped run(s)** detected. "
+            "Enable **Hide capped runs** in the sidebar for planning views."
+        )
+
+    # --- Primary visuals (always visible) ---
+    st.markdown("### Throughput heatmap")
+    st.caption(
+        "Items per hour by model (rows) and use case (columns) at one core count. "
+        "Darker green = higher throughput — quick answer to *which model for which job?*"
+    )
+    heatmap_cores_opts = sorted(df_product_view['cores'].unique().tolist())
+    hm_cores = (
+        st.selectbox(
+            "Core count for heatmap:",
+            heatmap_cores_opts,
+            key="heatmap_cores",
+        )
+        if len(heatmap_cores_opts) > 1
+        else heatmap_cores_opts[0]
+    )
+    heatmap_pivot = build_model_usecase_heatmap(df_product_view, cores=hm_cores)
+    if not heatmap_pivot.empty:
+        fig_hm = go.Figure(data=go.Heatmap(
+            z=heatmap_pivot.values,
+            x=heatmap_pivot.columns.tolist(),
+            y=heatmap_pivot.index.tolist(),
+            colorscale='Greens',
+            hovertemplate='%{y}<br>%{x}<br>%{z:,.0f} items/hr<extra></extra>',
+        ))
+        fig_hm.update_layout(
+            xaxis_title="Use Case",
+            yaxis_title="Model",
+            height=max(300, len(heatmap_pivot) * 50),
+        )
+        st.plotly_chart(fig_hm, use_container_width=True)
+    else:
+        st.info(
+            "No throughput data for the selected core count. "
+            "Check sidebar filters or load product use-case results."
+        )
+
+    st.markdown("### Best configuration per use case")
+    st.caption("Highest req/s per use case after run aggregation (sidebar setting).")
+    best_df = build_best_configs_table(df_product_view)
+    if not best_df.empty:
+        st.dataframe(best_df, hide_index=True, use_container_width=True)
+
+    use_cases_available = sorted(df_product['use_case'].unique().tolist())
+    active_uc = resolve_focus_use_case(
+        focus_use_case, use_cases_available, 'overview_use_case'
+    )
+    if active_uc:
+        st.markdown("### Capacity snapshot")
+        st.caption(
+            "Planning estimate for one use case — throughput, 10k-item runtime, "
+            "and prefill/decode bottleneck if available."
+        )
+        uc_df = df_product_view[df_product_view['use_case'] == active_uc]
+        if not uc_df.empty:
+            best_idx = uc_df[METRIC_RPS].idxmax()
+            best = uc_df.loc[best_idx]
+            units = get_use_case_units(active_uc)
+            rps = best.get(METRIC_RPS, 0) or 0
+            items_hr = compute_items_per_hour(rps)
+            secs_10k = compute_time_for_batch(rps, 10_000)
+
+            prefill = best.get(PREFILL_COL, 0) or 0
+            decode = best.get(DECODE_COL, 0) or 0
+            bottleneck = ''
+            if prefill > 0 and decode > 0:
+                if decode < prefill * 0.5:
+                    bottleneck = 'Decode-bound (generation is the bottleneck).'
+                elif prefill < decode * 0.5:
+                    bottleneck = 'Prefill-bound (prompt processing is the bottleneck).'
+                else:
+                    bottleneck = 'Balanced prefill/decode.'
+
+            st.markdown(
+                f"**{active_uc}** — {best['model_short']} @ "
+                f"{best['cores']} cores  \n"
+                f"Config: `{best.get('config_fingerprint', '')}`  \n"
+                f"**{items_hr:,.0f}** {units['plural']}/hour "
+                f"({format_run_stats(best)})  \n"
+                f"10,000 {units['plural']} → ~**{format_duration(secs_10k)}**"
+            )
+            if best.get('capped_note'):
+                st.caption(best['capped_note'])
+            if bottleneck:
+                st.caption(bottleneck)
+
+    # --- Detail tables (collapsed by default) ---
+    gaps_df = build_data_gaps_table(df_product)
+    gap_label = (
+        f"Data completeness & gaps ({len(gaps_df)} items)"
+        if not gaps_df.empty
+        else "Data completeness & gaps"
+    )
+    with st.expander(gap_label, expanded=False):
+        st.markdown(
+            "Shows configs missing **prefill/decode metrics**, **multi-core sweeps**, "
+            "**full prompt counts**, or **enough repeated runs**. "
+            "Use the suggested `use-case-sweep` command to fill gaps."
+        )
+        if not gaps_df.empty:
+            st.dataframe(gaps_df, hide_index=True, use_container_width=True)
+        else:
+            st.success("No major data gaps for current filters.")
+
+    with st.expander("Expected vs actual matrix", expanded=False):
+        st.markdown(
+            "All 11 product use cases × each model in your results. "
+            "Cell = number of raw runs (0 = never benchmarked)."
+        )
+        expected_df = build_expected_vs_actual_matrix(df_product, all_models)
+        if not expected_df.empty:
+            st.dataframe(expected_df, hide_index=True, use_container_width=True)
+
+    variance_df = build_variance_summary(df_product)
+    if not variance_df.empty and (variance_df['Runs'] > 1).any():
+        with st.expander("Run variance (repeatability)", expanded=False):
+            st.markdown(
+                f"Coefficient of variation (CV) across repeated runs. "
+                f"Flagged when CV > {VARIANCE_CV_THRESHOLD * 100:.0f}% — "
+                "treat those configs with caution."
+            )
+            st.dataframe(variance_df, hide_index=True, use_container_width=True)
+
+    version_df = build_version_regression_table(df_product)
+    if not version_df.empty:
+        with st.expander("Version regression", expanded=False):
+            st.markdown(
+                "Compares mean req/s between the two newest vLLM versions "
+                "per use case / model / cores."
+            )
+            st.dataframe(version_df, hide_index=True, use_container_width=True)
+
+    trend_df = build_time_trend_data(df_product)
+    if not trend_df.empty and trend_df['timestamp'].nunique() > 1:
+        with st.expander("Performance over time", expanded=False):
+            st.markdown(
+                "Track items/hour across benchmark dates — useful after "
+                "vLLM upgrades or hardware changes."
+            )
+            trend_configs = sorted(trend_df['config_label'].unique().tolist())
+            selected_trends = st.multiselect(
+                "Configs to plot:",
+                trend_configs,
+                default=trend_configs[: min(5, len(trend_configs))],
+                key="trend_configs",
+            )
+            if selected_trends:
+                plot_df = trend_df[trend_df['config_label'].isin(selected_trends)]
+                fig_trend = go.Figure()
+                for label in selected_trends:
+                    sub = plot_df[plot_df['config_label'] == label]
+                    fig_trend.add_trace(go.Scatter(
+                        x=sub['timestamp'],
+                        y=sub['items_per_hour'],
+                        mode='lines+markers',
+                        name=label,
+                    ))
+                fig_trend.update_layout(
+                    xaxis_title="Timestamp",
+                    yaxis_title="Items/hour",
+                    height=400,
+                )
+                st.plotly_chart(fig_trend, use_container_width=True)
+
+    with st.expander("Coverage matrix (runs per model@cores × use case)", expanded=False):
+        st.markdown(
+            "How many raw runs exist for each combination. "
+            "**Green** ≥3 runs · **Yellow** 1–2 · **Gray** 0."
+        )
+        pivot = build_coverage_pivot(df_product)
+        if not pivot.empty:
+            st.dataframe(style_coverage_pivot(pivot), use_container_width=True)
+
+
+def _render_use_cases_tab(
+    df_product_view: pd.DataFrame,
+    focus_use_case: str,
+    selected_cores: List,
+) -> None:
+    """Capacity, planner, cache metrics, prefill/decode, model comparison."""
+    _render_tab_guide('use_cases')
+    use_cases_available = sorted(
+        df_product_view['use_case'].unique().tolist()
+    ) if not df_product_view.empty else []
+
+    if not use_cases_available:
+        st.info("No product use-case results match the current filters.")
+        return
+
+    active_uc = resolve_focus_use_case(
+        focus_use_case, use_cases_available, 'usecases_use_case'
+    )
+    if not active_uc:
+        return
+
+    st.subheader(f"Use Case: {active_uc}")
+    uc_df = df_product_view[df_product_view['use_case'] == active_uc].copy()
+    units = get_use_case_units(active_uc)
+
+    # Processing capacity
+    st.markdown("**Processing capacity (items per hour)**")
+    st.caption(
+        "Throughput per model@cores. One bar each — if multiple configs share "
+        "the same label, the best req/s is shown."
+    )
+    df_cap_g = collapse_by_model_cores(uc_df)
+    if len(uc_df) > len(df_cap_g):
+        st.caption(
+            "Multiple configs share the same model@cores — "
+            "showing best throughput per bar (Plotly stacks duplicate labels)."
+        )
+
+    fig_cap = go.Figure()
+    error_y = None
+    std_col = f'{METRIC_RPS}_std'
+    if std_col in df_cap_g.columns and (df_cap_g['n_runs'].fillna(1) > 1).any():
+        error_y = dict(
+            type='data',
+            array=df_cap_g[std_col].fillna(0).tolist(),
+            visible=True,
+        )
+    fig_cap.add_trace(
+        go.Bar(
+            x=df_cap_g['config_label'],
+            y=df_cap_g['items_per_hour'],
+            text=df_cap_g['items_per_hour'].round(0).astype(int),
+            textposition='auto',
+            marker_color='#2ca02c',
+            error_y=error_y,
+            customdata=df_cap_g.apply(
+                lambda r: format_run_stats(r), axis=1
+            ),
+            hovertemplate=(
+                '<b>%{x}</b><br>'
+                + f'{units["plural"].capitalize()}/hour: %{{y:,.0f}}<br>'
+                + '%{customdata}<extra></extra>'
+            ),
+        )
+    )
+    fig_cap.update_layout(
+        xaxis_title="Configuration",
+        yaxis_title=f"{units['plural'].capitalize()} per Hour",
+        height=400,
+        showlegend=False,
+    )
+    st.plotly_chart(fig_cap, use_container_width=True)
+
+    best_rps = df_cap_g[METRIC_RPS].max()
+    if best_rps > 0:
+        secs_10k = compute_time_for_batch(best_rps, 10_000)
+        st.info(
+            f"At the best configuration, 10,000 {units['plural']} "
+            f"takes ~**{format_duration(secs_10k)}**."
+        )
+
+    # Time estimates
+    st.divider()
+    with st.expander("Processing time estimates", expanded=True):
+        st.caption(
+            "Wall-clock time to finish a batch at each model@cores configuration."
+        )
+        batch_size = st.selectbox(
+            "Batch size:",
+            options=[1000, 5000, 10000, 50000, 100000],
+            index=2,
+            key="time_batch_size",
+        )
+        df_time_g = collapse_by_model_cores(uc_df)
+        df_time_g['time_sec'] = df_time_g[METRIC_RPS].apply(
+            lambda r: compute_time_for_batch(r, batch_size)
+        )
+        df_time_g['time_minutes'] = df_time_g['time_sec'] / 60.0
+        df_time_g = df_time_g[df_time_g['time_sec'] < float('inf')]
+        df_time_g = df_time_g.sort_values('time_minutes')
+
+        if not df_time_g.empty:
+            max_time = df_time_g['time_minutes'].max()
+            if max_time >= 60:
+                df_time_g['time_display'] = df_time_g['time_minutes'] / 60
+                time_unit = "hours"
+                time_labels = [f"{t:.1f}h" for t in df_time_g['time_display']]
+            else:
+                df_time_g['time_display'] = df_time_g['time_minutes']
+                time_unit = "minutes"
+                time_labels = [f"{t:.1f}min" for t in df_time_g['time_display']]
+
+            fig_time = go.Figure()
+            fig_time.add_trace(
+                go.Bar(
+                    y=df_time_g['config_label'],
+                    x=df_time_g['time_display'],
+                    orientation='h',
+                    text=time_labels,
+                    textposition='auto',
+                    marker_color='#ff7f0e',
+                )
+            )
+            fig_time.update_layout(
+                xaxis_title=f"Processing Time ({time_unit})",
+                yaxis_title="Configuration",
+                height=max(300, len(df_time_g) * 40),
+                showlegend=False,
+            )
+            st.plotly_chart(fig_time, use_container_width=True)
+
+    # Workload planner
+    with st.expander("Workload planner", expanded=False):
+        st.markdown(
+            "Enter how many items you need to process and a deadline — "
+            "lists configs that meet the SLA at current throughput."
+        )
+        plan_col1, plan_col2, plan_col3 = st.columns(3)
+        with plan_col1:
+            plan_batch = st.number_input(
+                "Items to process:",
+                min_value=100,
+                value=10000,
+                step=1000,
+                key="planner_batch",
+            )
+        with plan_col2:
+            plan_hours = st.number_input(
+                "Deadline (hours):",
+                min_value=0.1,
+                value=8.0,
+                step=0.5,
+                key="planner_hours",
+            )
+        with plan_col3:
+            st.write("")
+            st.write("")
+            plan_clicked = st.button("Find qualifying configs", key="planner_go")
+
+        if plan_clicked:
+            qualifying = find_configs_for_deadline(
+                df_product_view, active_uc, int(plan_batch), float(plan_hours)
+            )
+            if qualifying.empty:
+                st.warning(
+                    f"No configuration can process **{plan_batch:,}** "
+                    f"{units['plural']} within **{plan_hours}** hours."
+                )
+            else:
+                st.success(
+                    f"**{len(qualifying)}** config(s) meet the deadline."
+                )
+                show_cols = {
+                    'model_short': 'Model',
+                    'cores': 'Cores',
+                    'config_fingerprint': 'Config',
+                    METRIC_RPS: 'Req/s',
+                    'items_per_hour': 'Items/hr',
+                    'time_display': 'Est. Time',
+                }
+                avail = {k: v for k, v in show_cols.items() if k in qualifying.columns}
+                st.dataframe(
+                    qualifying[list(avail.keys())].rename(columns=avail),
+                    hide_index=True,
+                    use_container_width=True,
+                )
+
+    # Prefix / KV cache (product use cases)
+    kv_col = 'metric_max_kv_cache_usage_percent'
+    prefix_col = 'metric_avg_prefix_cache_hit_rate_percent'
+    has_cache = (
+        (kv_col in uc_df.columns and (uc_df[kv_col].fillna(0) > 0).any())
+        or (prefix_col in uc_df.columns and (uc_df[prefix_col].fillna(0) > 0).any())
+    )
+    cache_relevant = any(
+        k in active_uc.lower() or e in active_uc
+        for k, e in [('prefix', '📋'), ('rag', '🔍'), ('shared', '📋')]
+    )
+    if has_cache or cache_relevant:
+        with st.expander("Cache metrics (KV & prefix)", expanded=False):
+            st.caption(
+                "KV-cache pressure and prefix-cache hit rate — "
+                "most relevant for shared-prefix and RAG workloads."
+            )
+            df_cache = uc_df.copy()
+            df_cache['config_label'] = (
+                df_cache['model_short'] + ' @ ' + df_cache['cores'].astype(str) + 'c'
+            )
+            fig_cache = go.Figure()
+            if kv_col in df_cache.columns and (df_cache[kv_col].fillna(0) > 0).any():
+                fig_cache.add_trace(go.Bar(
+                    name='KV Cache %',
+                    x=df_cache['config_label'],
+                    y=df_cache[kv_col].fillna(0),
+                    marker_color='#9467bd',
+                ))
+            if prefix_col in df_cache.columns and (df_cache[prefix_col].fillna(0) > 0).any():
+                fig_cache.add_trace(go.Bar(
+                    name='Prefix Cache Hit %',
+                    x=df_cache['config_label'],
+                    y=df_cache[prefix_col].fillna(0),
+                    marker_color='#17becf',
+                ))
+            if fig_cache.data:
+                fig_cache.update_layout(
+                    barmode='group',
+                    yaxis_title='Percent',
+                    height=350,
+                )
+                st.plotly_chart(fig_cache, use_container_width=True)
+            elif cache_relevant:
+                st.info("Cache metrics not yet captured for this use case.")
+
+    # Prefill vs decode
+    with st.expander("Prefill vs decode throughput", expanded=True):
+        st.caption(
+            "**Prefill** = prompt processing speed. **Decode** = generation speed. "
+            "If decode is much lower, generation is the bottleneck."
+        )
+        has_prefill = (
+            PREFILL_COL in uc_df.columns
+            and (uc_df[PREFILL_COL].fillna(0) > 0).any()
+        )
+        if has_prefill:
+            df_pd_g = collapse_by_model_cores(
+                uc_df[
+                    (uc_df[PREFILL_COL].fillna(0) > 0)
+                    | (uc_df[DECODE_COL].fillna(0) > 0)
+                ]
+            )
+            if not df_pd_g.empty:
+                fig_pd = go.Figure()
+                fig_pd.add_trace(go.Bar(
+                    name='Prefill',
+                    x=df_pd_g['config_label'],
+                    y=df_pd_g[PREFILL_COL].fillna(0),
+                    marker_color='#1f77b4',
+                ))
+                fig_pd.add_trace(go.Bar(
+                    name='Decode',
+                    x=df_pd_g['config_label'],
+                    y=df_pd_g[DECODE_COL].fillna(0),
+                    marker_color='#ff7f0e',
+                ))
+                fig_pd.update_layout(
+                    barmode='group',
+                    xaxis_title="Configuration",
+                    yaxis_title="Throughput (tokens/sec)",
+                    height=400,
+                )
+                st.plotly_chart(fig_pd, use_container_width=True)
+        else:
+            st.info(
+                "Prefill/decode metrics are not in your results yet. "
+                "They come from vLLM engine log lines (`Avg prompt throughput` / "
+                "`Avg generation throughput`) captured during the benchmark.\n\n"
+                "**If you ran before a recent fix:** engine stats were on stderr — "
+                "re-run the benchmark to populate them.\n\n"
+                "**Check:** `benchmark.log` in the **All Runs** tab."
+            )
+
+    # Model comparison
+    if uc_df['model_short'].nunique() > 1:
+        with st.expander("Model comparison", expanded=False):
+            st.caption("Items/hour across models at a fixed core count.")
+            mc_cores_opts = sorted(uc_df['cores'].unique().tolist())
+            mc_cores = (
+                st.selectbox("Core count:", mc_cores_opts, key="model_comp_cores")
+                if len(mc_cores_opts) > 1
+                else mc_cores_opts[0]
+            )
+            df_mc = collapse_by_model_cores(
+                uc_df[uc_df['cores'] == mc_cores]
+            )
+            fig_mc = go.Figure()
+            fig_mc.add_trace(go.Bar(
+                x=df_mc['model_short'],
+                y=df_mc['items_per_hour'],
+                text=df_mc['items_per_hour'].round(0).astype(int),
+                textposition='auto',
+                marker_color='#1f77b4',
+            ))
+            fig_mc.update_layout(
+                xaxis_title="Model",
+                yaxis_title=f"{units['plural'].capitalize()}/hr ({mc_cores} cores)",
+                height=400,
+                showlegend=False,
+            )
+            st.plotly_chart(fig_mc, use_container_width=True)
+
+
+def use_case_cli_name(use_case_display: str, slug: str = '') -> str:
+    """Map dashboard use-case label to run-offline-batch-suite.sh CLI name."""
+    if slug:
+        return slug.replace('_', '-')
+    reverse = {v: k for k, v in USE_CASE_MAP.items()}
+    return reverse.get(use_case_display, use_case_display).replace('_', '-')
+
+
+def build_core_availability(df: pd.DataFrame) -> pd.DataFrame:
+    """Summarize which core counts exist per use case (from raw results)."""
+    if df.empty or 'cores' not in df.columns:
+        return pd.DataFrame()
+
+    if 'use_case_slug' in df.columns:
+        product_df = df[~df['use_case_slug'].apply(is_technical_use_case)].copy()
+    else:
+        product_df = df.copy()
+
+    if product_df.empty:
+        return pd.DataFrame()
+
+    rows = []
+    for use_case, group in product_df.groupby('use_case'):
+        cores = sorted(group['cores'].dropna().unique().tolist())
+        rows.append({
+            'use_case': use_case,
+            'cores_tested': ', '.join(str(c) for c in cores),
+            'core_count': len(cores),
+        })
+    return pd.DataFrame(rows).sort_values('use_case')
+
+
+def _render_scaling_tab(
+    df_product_view: pd.DataFrame,
+    df_technical: pd.DataFrame,
+    df_filtered: pd.DataFrame,
+    focus_use_case: str,
+    selected_cores: List,
+) -> None:
+    """Core scaling and technical benchmark sweeps."""
+    _render_tab_guide('scaling')
+    use_cases_available = sorted(
+        df_product_view['use_case'].unique().tolist()
+    ) if not df_product_view.empty else []
+
+    st.subheader("CPU core scaling")
+    st.caption(
+        "Requires benchmark runs at multiple core counts (8, 16, 24, 32) "
+        "for the same use case + model. Run: "
+        "`use-case-sweep <use-case> all 8,16,24,32`"
+    )
+
+    core_availability = build_core_availability(df_filtered)
+    if not core_availability.empty:
+        with st.expander("Core counts in your results", expanded=False):
+            st.dataframe(
+                core_availability,
+                use_container_width=True,
+                hide_index=True,
+            )
+
+    if not use_cases_available:
+        st.info("No product use-case results found yet.")
+    elif len(selected_cores) <= 1:
+        st.info(
+            "Need results at **multiple core counts** (8, 16, 24, 32) to plot "
+            "scaling. Your current filter has only "
+            f"**{selected_cores[0] if selected_cores else 'one'}** core(s).\n\n"
+            "The default `use-cases` suite runs most workloads at **16 cores** "
+            "only (ETL sweeps 8–32). For scaling charts, run:\n\n"
+            "```\n"
+            "./run-offline-batch-suite.sh use-case-sweep <use-case> all "
+            "8,16,24,32\n"
+            "```"
+        )
+    else:
+        active_uc = resolve_focus_use_case(
+            focus_use_case, use_cases_available, 'scaling_use_case'
+        )
+        if active_uc:
+            cs_models = sorted(
+                df_product_view[df_product_view['use_case'] == active_uc][
+                    'model_short'
+                ].unique().tolist()
+            )
+            cs_model = st.selectbox(
+                "Model:", options=cs_models, key="core_scaling_model"
+            )
+            df_cs = df_product_view[
+                (df_product_view['use_case'] == active_uc)
+                & (df_product_view['model_short'] == cs_model)
+            ].copy().sort_values('cores')
+
+            if len(df_cs) <= 1:
+                raw_subset = df_filtered[
+                    (df_filtered['use_case'] == active_uc)
+                    & (df_filtered['model_short'] == cs_model)
+                ]
+                raw_cores = sorted(
+                    raw_subset['cores'].dropna().unique().tolist()
+                )
+                slug = (
+                    raw_subset['use_case_slug'].iloc[0]
+                    if not raw_subset.empty
+                    and 'use_case_slug' in raw_subset.columns
+                    else ''
+                )
+                cli_name = use_case_cli_name(active_uc, slug)
+                st.info(
+                    f"Only **{len(raw_cores)}** core count(s) found for "
+                    f"**{active_uc}** / **{cs_model}**: "
+                    f"{', '.join(str(c) for c in raw_cores) or 'none'}.\n\n"
+                    "Run a multi-core sweep to populate this chart:\n\n"
+                    "```\n"
+                    f"./run-offline-batch-suite.sh use-case-sweep "
+                    f"{cli_name} all 8,16,24,32\n"
+                    "```"
+                )
+            else:
+                cs_units = get_use_case_units(active_uc)
+                df_cs['items_per_hour'] = df_cs[METRIC_RPS].apply(
+                    compute_items_per_hour
+                )
+                df_cs['tok_per_core'] = df_cs[METRIC_TOK_S] / df_cs['cores']
+
+                fig_cs = go.Figure()
+                fig_cs.add_trace(go.Scatter(
+                    x=df_cs['cores'],
+                    y=df_cs['items_per_hour'],
+                    mode='lines+markers',
+                    name=f'{cs_units["plural"].capitalize()}/hr',
+                    line=dict(width=3, color='#d62728'),
+                ))
+                fig_cs.add_trace(go.Scatter(
+                    x=df_cs['cores'],
+                    y=df_cs['tok_per_core'],
+                    mode='lines+markers',
+                    name='Tokens/sec/core',
+                    yaxis='y2',
+                    line=dict(width=2, dash='dot', color='#9467bd'),
+                ))
+                fig_cs.update_layout(
+                    xaxis_title="CPU Cores",
+                    yaxis_title=f"{cs_units['plural'].capitalize()}/hr",
+                    yaxis2=dict(
+                        title="Tokens/sec/core",
+                        overlaying='y',
+                        side='right',
+                    ),
+                    height=400,
+                )
+                st.plotly_chart(fig_cs, use_container_width=True)
+
+                eff_df = build_scaling_efficiency_table(df_cs)
+                if not eff_df.empty:
+                    with st.expander("Scaling efficiency table", expanded=False):
+                        st.markdown(
+                            "Compares actual speedup to ideal linear scaling "
+                            "from the lowest core count. "
+                            "**Good** ≥80% efficiency · **Poor** <50% · "
+                            "**Degraded** = slower than baseline."
+                        )
+                        st.dataframe(
+                            eff_df, hide_index=True, use_container_width=True
+                        )
+
+    if not df_technical.empty:
+        with st.expander("Technical benchmark sweeps (KV, context, batch)", expanded=False):
+            st.header("Technical Benchmarks")
+            tech_use_cases = sorted(df_technical['use_case'].unique().tolist())
+
+            kv_label = '📊 KV-Cache Capacity'
+            if kv_label in tech_use_cases:
+                st.subheader("KV-Cache Capacity")
+                df_kv = df_technical[df_technical['use_case'] == kv_label].copy()
+                kv_model = st.selectbox(
+                    "Model:", sorted(df_kv['model_short'].unique()), key="kv_model"
+                )
+                df_kv = df_kv[df_kv['model_short'] == kv_model]
+                kv_cache_col = 'metric_max_kv_cache_usage_percent'
+                has_kv = (
+                    kv_cache_col in df_kv.columns
+                    and (df_kv[kv_cache_col].fillna(0) > 0).any()
+                )
+                df_kv_g = (
+                    df_kv.groupby('num_prompts')
+                    .agg({
+                        METRIC_RPS: 'mean',
+                        METRIC_TOK_S: 'mean',
+                        **({kv_cache_col: 'mean'} if has_kv else {}),
+                    })
+                    .reset_index()
+                    .sort_values('num_prompts')
+                )
+                if len(df_kv_g) > 1:
+                    fig_kv = go.Figure()
+                    if has_kv:
+                        fig_kv.add_trace(go.Scatter(
+                            x=df_kv_g['num_prompts'],
+                            y=df_kv_g[kv_cache_col],
+                            mode='lines+markers',
+                            name='KV Cache %',
+                        ))
+                    fig_kv.add_trace(go.Scatter(
+                        x=df_kv_g['num_prompts'],
+                        y=df_kv_g[METRIC_TOK_S],
+                        mode='lines+markers',
+                        name='Throughput (tok/s)',
+                        yaxis='y2',
+                    ))
+                    fig_kv.update_layout(
+                        xaxis_title="Batch Size (num_prompts)",
+                        yaxis2=dict(
+                            title="Throughput (tokens/sec)",
+                            overlaying='y',
+                            side='right',
+                        ),
+                        height=400,
+                    )
+                    st.plotly_chart(fig_kv, use_container_width=True)
+
+            ctx_label = '📏 Context Scaling'
+            if ctx_label in tech_use_cases:
+                st.subheader("Context Length Scaling")
+                df_ctx = df_technical[df_technical['use_case'] == ctx_label].copy()
+                ctx_model = st.selectbox(
+                    "Model:", sorted(df_ctx['model_short'].unique()), key="ctx_model"
+                )
+                df_ctx = df_ctx[df_ctx['model_short'] == ctx_model]
+                if 'config_input_len' in df_ctx.columns:
+                    df_ctx_g = (
+                        df_ctx.groupby('config_input_len')
+                        .agg({METRIC_TOK_S: 'mean', METRIC_RPS: 'mean'})
+                        .reset_index()
+                        .sort_values('config_input_len')
+                    )
+                    if len(df_ctx_g) > 1:
+                        fig_ctx = go.Figure()
+                        fig_ctx.add_trace(go.Scatter(
+                            x=df_ctx_g['config_input_len'],
+                            y=df_ctx_g[METRIC_TOK_S],
+                            mode='lines+markers',
+                            name='Total tok/s',
+                        ))
+                        fig_ctx.update_layout(
+                            xaxis_title="Input Length (tokens)",
+                            yaxis_title="Throughput (tokens/sec)",
+                            height=400,
+                        )
+                        st.plotly_chart(fig_ctx, use_container_width=True)
+
+    with st.expander("Batch size scaling", expanded=False):
+        st.caption("Throughput vs number of prompts when batch size was varied.")
+        df_batch_candidates = df_filtered[
+            df_filtered.groupby(['use_case', 'model_short', 'cores'])['num_prompts']
+            .transform('nunique') > 1
+        ].copy()
+        if not df_batch_candidates.empty:
+            batch_uc_opts = sorted(df_batch_candidates['use_case'].unique())
+            batch_uc = st.selectbox(
+                "Use case:", batch_uc_opts, key="batch_scaling_use_case"
+            )
+            batch_models = sorted(
+                df_batch_candidates[df_batch_candidates['use_case'] == batch_uc][
+                    'model_short'
+                ].unique().tolist()
+            )
+            batch_model = st.selectbox(
+                "Model:", batch_models, key="batch_scaling_model"
+            )
+            df_bs = df_batch_candidates[
+                (df_batch_candidates['use_case'] == batch_uc)
+                & (df_batch_candidates['model_short'] == batch_model)
+            ]
+            df_bs_g = (
+                df_bs.groupby('num_prompts')
+                .agg({METRIC_TOK_S: 'mean', METRIC_RPS: 'mean'})
+                .reset_index()
+                .sort_values('num_prompts')
+            )
+            if len(df_bs_g) > 1:
+                bs_units = get_use_case_units(batch_uc)
+                df_bs_g['items_per_hour'] = df_bs_g[METRIC_RPS].apply(
+                    compute_items_per_hour
+                )
+                fig_bs = go.Figure()
+                fig_bs.add_trace(go.Scatter(
+                    x=df_bs_g['num_prompts'],
+                    y=df_bs_g['items_per_hour'],
+                    mode='lines+markers',
+                    name=f'{bs_units["plural"].capitalize()}/hr',
+                ))
+                fig_bs.update_layout(
+                    xaxis_title="Batch Size (number of prompts)",
+                    yaxis_title=f"{bs_units['plural'].capitalize()} per Hour",
+                    height=400,
+                )
+                st.plotly_chart(fig_bs, use_container_width=True)
+        else:
+            st.info("No batch size variation in current results.")
+
+
+def _render_all_runs_tab(
+    df_filtered: pd.DataFrame,
+    df_product_view: pd.DataFrame,
+) -> None:
+    """Detailed table, comparison, log preview, exports."""
+    _render_tab_guide('all_runs')
+    st.subheader("All Results")
+
+    col_exp1, col_exp2 = st.columns(2)
+    with col_exp1:
+        csv_all = build_filtered_results_csv(df_filtered)
+        if csv_all:
+            st.download_button(
+                "⬇️ Download filtered runs (CSV)",
+                csv_all,
+                file_name="offline_batch_runs.csv",
+                mime="text/csv",
+                key="dl_all_runs",
+            )
+    with col_exp2:
+        csv_summary = build_capacity_summary_csv(df_product_view)
+        if csv_summary:
+            st.download_button(
+                "⬇️ Download capacity summary (CSV)",
+                csv_summary,
+                file_name="offline_batch_capacity_summary.csv",
+                mime="text/csv",
+                key="dl_capacity_summary",
+            )
+
+    if len(df_filtered) >= 2:
+        with st.expander("Compare two runs side-by-side", expanded=False):
+            st.caption(
+                "Pick any two benchmark runs to see metric deltas and "
+                "config fingerprint differences."
+            )
+            run_labels = df_filtered.apply(
+                lambda r: (
+                    f"{r['timestamp']} | {r['use_case']} | {r['model_short']} "
+                    f"@ {r['cores']}c | {r.get('config_fingerprint', '')}"
+                ),
+                axis=1,
+            ).tolist()
+            cmp_col1, cmp_col2 = st.columns(2)
+            with cmp_col1:
+                idx_a = st.selectbox(
+                    "Config A:", range(len(run_labels)),
+                    format_func=lambda i: run_labels[i],
+                    key="cmp_a",
+                )
+            with cmp_col2:
+                idx_b = st.selectbox(
+                    "Config B:", range(len(run_labels)),
+                    format_func=lambda i: run_labels[i],
+                    index=min(1, len(run_labels) - 1),
+                    key="cmp_b",
+                )
+            row_a = df_filtered.iloc[idx_a]
+            row_b = df_filtered.iloc[idx_b]
+            st.dataframe(
+                compare_config_rows(row_a, row_b),
+                hide_index=True,
+                use_container_width=True,
+            )
+            diffs = config_diff_notes(row_a, row_b)
+            if diffs:
+                st.caption("Config differences: " + '; '.join(diffs))
+
+    if 'result_dir' in df_filtered.columns and not df_filtered.empty:
+        with st.expander("Benchmark log preview", expanded=False):
+            st.caption(
+                "Tail of `benchmark.log` — look for `Avg prompt throughput` "
+                "and error messages."
+            )
+            log_labels = df_filtered.apply(
+                lambda r: (
+                    f"{r['timestamp']} | {r['use_case']} | {r['model_short']} "
+                    f"@ {r['cores']}c"
+                ),
+                axis=1,
+            ).tolist()
+            log_idx = st.selectbox(
+                "Select run:", range(len(log_labels)),
+                format_func=lambda i: log_labels[i],
+                key="log_preview_select",
+            )
+            log_row = df_filtered.iloc[log_idx]
+            st.code(
+                tail_benchmark_log(log_row['result_dir']),
+                language='text',
+            )
+            if 'test_run_id' in log_row.index:
+                run_id = log_row['test_run_id']
+                st.caption(f"Run ID: `{run_id}`")
+                try:
+                    st.page_link(
+                        SERVER_METRICS_PAGE,
+                        label="Open Server Metrics (search by Run ID)",
+                        icon="🖥️",
+                    )
+                except Exception:
+                    st.caption(
+                        "Open the **Server Metrics** page and filter by this Run ID."
+                    )
+
+    with st.expander(f"Full results table ({len(df_filtered)} runs)", expanded=False):
+        results_table = df_filtered.copy()
+        results_table['items_per_hour'] = results_table[METRIC_RPS].apply(
+            compute_items_per_hour
+        )
+
+        display_cols = {
+            'timestamp': 'Timestamp',
+            'use_case': 'Use Case',
+            'model_short': 'Model',
+            'cores': 'Cores',
+            'config_fingerprint': 'Config',
+            'num_prompts': 'Batch Size',
+            'items_per_hour': 'Items/hr',
+            METRIC_RPS: 'Req/sec',
+            METRIC_TOK_S: 'Tokens/sec',
+            'test_run_id': 'Run ID',
+        }
+        for optional, label in [
+            ('config_input_len', 'Input Len'),
+            ('config_output_len', 'Output Len'),
+            (PREFILL_COL, 'Prefill tok/s'),
+            (DECODE_COL, 'Decode tok/s'),
+            ('metric_max_kv_cache_usage_percent', 'KV Cache %'),
+            ('metric_total_time_sec', 'Total Time (s)'),
+            ('vllm_version', 'vLLM Version'),
+            ('capped_note', 'Notes'),
+            ('result_dir', 'Result Path'),
+        ]:
+            if optional in results_table.columns:
+                display_cols[optional] = label
+
+        if 'container_image' in results_table.columns:
+            results_table['container_short'] = results_table['container_image'].apply(
+                lambda x: x.split('/')[-1] if isinstance(x, str) else x
+            )
+            display_cols['container_short'] = 'Container'
+
+        available = {k: v for k, v in display_cols.items() if k in results_table.columns}
+        display_df = results_table[list(available.keys())].copy()
+        display_df.columns = list(available.values())
+
+        for col in display_df.columns:
+            if display_df[col].dtype in ['float64', 'float32']:
+                display_df[col] = display_df[col].round(2)
+
+        st.dataframe(
+            display_df.sort_values(
+                ['Timestamp', 'Use Case', 'Model', 'Cores'],
+                ascending=[False, True, True, True],
+            ),
+            use_container_width=True,
+            hide_index=True,
+        )
+
+
+def _render_export_sidebar(
+    df_filtered: pd.DataFrame,
+    df_product_view: pd.DataFrame,
+) -> None:
+    """Sidebar export section (called after data is ready)."""
+    st.markdown("---")
+    st.subheader("Export")
+    csv_all = build_filtered_results_csv(df_filtered)
+    if csv_all:
+        st.download_button(
+            "Filtered runs CSV",
+            csv_all,
+            file_name="offline_batch_runs.csv",
+            mime="text/csv",
+            key="sidebar_dl_runs",
+        )
+    csv_summary = build_capacity_summary_csv(df_product_view)
+    if csv_summary:
+        st.download_button(
+            "Capacity summary CSV",
+            csv_summary,
+            file_name="offline_batch_capacity_summary.csv",
+            mime="text/csv",
+            key="sidebar_dl_summary",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -457,6 +2501,10 @@ def main():
     )
 
     st.title("📦 Offline Batch Benchmarking")
+    st.caption(
+        f"Dashboard build: **{DASHBOARD_BUILD}** — expand **ℹ️ How to read** "
+        "on each tab for a feature guide."
+    )
     st.markdown(
         "Results from `vllm bench throughput` — capacity planning for "
         "batch processing workloads."
@@ -481,6 +2529,49 @@ def main():
         if st.button("🔄 Reload Data"):
             st.cache_data.clear()
             st.rerun()
+
+        with st.expander("📥 Import results", expanded=False):
+            st.markdown(
+                "Merge data from another machine without copying files into "
+                "your main `results/llm` tree."
+            )
+            st.text_input(
+                "Additional results directory",
+                value="",
+                placeholder="/path/to/other/results/llm",
+                help="Optional second results/llm path to merge with the primary directory.",
+                key="offline_batch_extra_dir",
+            )
+            uploaded_csv = st.file_uploader(
+                "Upload CSV",
+                type=["csv"],
+                help=(
+                    "Use a file exported via **All Runs → Download filtered runs**. "
+                    "Required columns: Use Case, Cores, Req/sec (or Items/hr)."
+                ),
+                key="offline_batch_csv_upload",
+            )
+            if uploaded_csv is not None:
+                try:
+                    imported_raw = pd.read_csv(uploaded_csv)
+                    imported_df = normalize_imported_offline_batch_df(imported_raw)
+                    st.session_state["imported_offline_batch_df"] = imported_df
+                    st.success(
+                        f"✓ {len(imported_df)} row(s) from **{uploaded_csv.name}** "
+                        "(merged on reload)"
+                    )
+                except Exception as exc:
+                    st.error(f"CSV import failed: {exc}")
+
+            if "imported_offline_batch_df" in st.session_state:
+                n_imp = len(st.session_state["imported_offline_batch_df"])
+                st.caption(f"{n_imp} CSV row(s) in this browser session")
+                if st.button("Clear imported CSV", key="clear_offline_batch_csv"):
+                    del st.session_state["imported_offline_batch_df"]
+                    st.rerun()
+
+        with st.expander("ℹ️ Sidebar controls", expanded=False):
+            st.markdown(TAB_GUIDES['sidebar'])
 
         st.markdown("---")
         st.markdown("**Use Case Reference:**")
@@ -514,15 +2605,31 @@ def main():
                 "sonnet (baseline)"
             )
             st.caption(
-                "*Shared-Prefix does **not** enable prefix caching "
-                "(random prompts have no shared prefix)."
+                "Reference configs use full prompt counts. "
+                "Capped runs (OFFLINE_BATCH_MAX_PROMPTS) show fewer prompts."
             )
 
-    # Load data
-    df = load_benchmark_results(results_dir_input)
+    # Load data (primary dir + optional extra dir + optional CSV import)
+    extra_results_dir = st.session_state.get("offline_batch_extra_dir", "").strip()
+    df_disk = load_benchmark_results_from_dirs(
+        results_dir_input,
+        extra_results_dir,
+    )
+    imported_count = 0
+    if "imported_offline_batch_df" in st.session_state:
+        imported_df = st.session_state["imported_offline_batch_df"]
+        imported_count = len(imported_df)
+        df = merge_benchmark_dataframes(df_disk, imported_df)
+    else:
+        df = df_disk
 
     if df.empty:
-        st.warning("No benchmark results found. Run some benchmarks first!")
+        st.warning("No benchmark results found.")
+        st.info(
+            "**Load results:** set **Results Directory** to your `results/llm` path, "
+            "add an **Additional results directory**, or **Import CSV** in the sidebar "
+            "(export from **All Runs → Download filtered runs**)."
+        )
         st.code(
             "# Run a benchmark (from repository root):\n"
             "./cpueval --suite offline-batch\n"
@@ -547,10 +2654,16 @@ def main():
         )
         return
 
-    st.success(f"Loaded {len(df)} benchmark results")
+    disk_count = len(df_disk)
+    msg = f"Loaded {len(df)} benchmark results ({disk_count} from disk"
+    if imported_count:
+        msg += f", {imported_count} from CSV"
+    msg += ")"
+    st.success(msg)
 
-    # Short model names
-    df['model_short'] = df['model'].apply(lambda x: x.split('/')[-1])
+    # Short model names (if not already set by merge)
+    if 'model_short' not in df.columns:
+        df['model_short'] = df['model'].apply(lambda x: x.split('/')[-1])
 
     # ------------------------------------------------------------------
     # Global sidebar filters (after data is loaded so we know the options)
@@ -603,6 +2716,35 @@ def main():
         else:
             selected_versions = df['vllm_version'].unique().tolist()
 
+        st.markdown("---")
+        st.subheader("Analysis")
+
+        run_aggregation = st.selectbox(
+            "Run aggregation",
+            options=list(RUN_AGGREGATION_MODES),
+            index=1,
+            help=(
+                "How to collapse multiple runs of the same configuration: "
+                "latest, mean, or best throughput."
+            ),
+            key="global_run_agg",
+        )
+
+        hide_capped = st.checkbox(
+            "Hide capped runs",
+            value=False,
+            help="Exclude runs with prompt counts below full-suite reference.",
+            key="global_hide_capped",
+        )
+        min_runs = st.slider(
+            "Minimum runs per config",
+            min_value=1,
+            max_value=10,
+            value=1,
+            help="Filter out configurations with fewer than N raw runs.",
+            key="global_min_runs",
+        )
+
     # Apply global filters
     df_filtered = df[
         (df['use_case'].isin(selected_use_cases))
@@ -618,983 +2760,64 @@ def main():
         )
         return
 
-    # Environment banner
-    if 'container_image' in df_filtered.columns:
-        unique_containers = df_filtered['container_image'].unique()
-        unique_versions = (
-            df_filtered['vllm_version'].unique()
-            if 'vllm_version' in df_filtered.columns
-            else []
-        )
+    _render_environment_banner(df_filtered)
 
-        if len(unique_containers) > 1 or len(unique_versions) > 1:
-            st.warning(
-                f"**Mixed environments** — "
-                f"{len(unique_containers)} container image(s), "
-                f"{len(unique_versions)} vLLM version(s). "
-                "Compare with care."
-            )
-            with st.expander("View environment details"):
-                for container in unique_containers:
-                    count = len(
-                        df_filtered[
-                            df_filtered['container_image'] == container
-                        ]
-                    )
-                    st.write(f"- **{container}**: {count} test(s)")
-        else:
-            container_short = (
-                unique_containers[0].split('/')[-1]
-                if len(unique_containers) > 0
-                else 'unknown'
-            )
-            version = (
-                unique_versions[0] if len(unique_versions) > 0 else 'unknown'
-            )
-            st.info(f"🐳 **Environment**: {container_short} (vLLM {version})")
-
-    # Separate product vs technical use cases in the filtered data
     df_filtered['_is_technical'] = df_filtered['use_case_slug'].apply(
         is_technical_use_case
     )
     df_product = df_filtered[~df_filtered['_is_technical']].copy()
     df_technical = df_filtered[df_filtered['_is_technical']].copy()
 
-    # ==================================================================
-    # PRODUCT USE-CASE SECTIONS
-    # ==================================================================
-    st.header("📊 Performance Analysis")
-
-    use_cases_available = sorted(
-        df_product['use_case'].unique().tolist()
-    ) if not df_product.empty else []
-
-    # ---- Section 1: Processing Capacity ----
-    st.divider()
-    st.subheader("1️⃣ Processing Capacity")
-    st.markdown("**How many items can you process per hour?**")
-
-    if use_cases_available:
-        capacity_use_case = st.selectbox(
-            "Select use case:",
-            options=use_cases_available,
-            key="capacity_use_case",
-        )
-
-        df_cap = df_product[
-            df_product['use_case'] == capacity_use_case
-        ].copy()
-
-        df_cap_g = (
-            df_cap.groupby(['model_short', 'cores'])
-            .agg({'metric_throughput_requests_per_sec': 'mean'})
-            .reset_index()
-        )
-        df_cap_g['items_per_hour'] = df_cap_g[
-            'metric_throughput_requests_per_sec'
-        ].apply(compute_items_per_hour)
-        df_cap_g['config_label'] = (
-            df_cap_g['model_short']
-            + '\n'
-            + df_cap_g['cores'].astype(str)
-            + ' cores'
-        )
-        df_cap_g = df_cap_g.sort_values('items_per_hour', ascending=False)
-
-        units = get_use_case_units(capacity_use_case)
-
-        fig_cap = go.Figure()
-        fig_cap.add_trace(
-            go.Bar(
-                x=df_cap_g['config_label'],
-                y=df_cap_g['items_per_hour'],
-                text=df_cap_g['items_per_hour'].round(0).astype(int),
-                textposition='auto',
-                marker_color='#2ca02c',
-                hovertemplate=(
-                    '<b>%{x}</b><br>'
-                    + f'{units["plural"].capitalize()}/hour: '
-                    + '%{y:,.0f}<br><extra></extra>'
-                ),
-            )
-        )
-        fig_cap.update_layout(
-            xaxis_title="Configuration",
-            yaxis_title=f"{units['plural'].capitalize()} per Hour",
-            height=400,
-            showlegend=False,
-        )
-        st.plotly_chart(fig_cap, use_container_width=True)
-
-        # Capacity tip — time for 10k items at best config
-        best_rps = df_cap_g['metric_throughput_requests_per_sec'].max()
-        if best_rps > 0:
-            secs_10k = compute_time_for_batch(best_rps, 10_000)
-            st.info(
-                f"💡 At the best configuration above, 10,000 "
-                f"{units['plural']} takes ~**{format_duration(secs_10k)}**."
-            )
-    else:
-        st.info("No product use-case results match the current filters.")
-
-    # ---- Section 2: Processing Time Estimates ----
-    st.divider()
-    st.subheader("2️⃣ Processing Time Estimates")
-    st.markdown("**How long to process a batch?**")
-
-    if use_cases_available:
-        col1, col2 = st.columns(2)
-        with col1:
-            time_use_case = st.selectbox(
-                "Use case:",
-                options=use_cases_available,
-                key="time_use_case",
-            )
-        with col2:
-            batch_size = st.selectbox(
-                "Batch size:",
-                options=[1000, 5000, 10000, 50000, 100000],
-                index=2,
-                key="time_batch_size",
-            )
-
-        df_time = df_product[
-            df_product['use_case'] == time_use_case
-        ].copy()
-        df_time_g = (
-            df_time.groupby(['model_short', 'cores'])
-            .agg({'metric_throughput_requests_per_sec': 'mean'})
-            .reset_index()
-        )
-        df_time_g['config_label'] = (
-            df_time_g['model_short']
-            + '\n'
-            + df_time_g['cores'].astype(str)
-            + ' cores'
-        )
-        df_time_g['time_sec'] = df_time_g[
-            'metric_throughput_requests_per_sec'
-        ].apply(lambda r: compute_time_for_batch(r, batch_size))
-        df_time_g['time_minutes'] = df_time_g['time_sec'] / 60.0
-        df_time_g = df_time_g[df_time_g['time_sec'] < float('inf')]
-        df_time_g = df_time_g.sort_values('time_minutes')
-
-        if not df_time_g.empty:
-            units = get_use_case_units(time_use_case)
-
-            max_time = df_time_g['time_minutes'].max()
-            if max_time >= 60:
-                df_time_g['time_display'] = df_time_g['time_minutes'] / 60
-                time_unit = "hours"
-                time_labels = [
-                    f"{t:.1f}h" for t in df_time_g['time_display']
-                ]
-            else:
-                df_time_g['time_display'] = df_time_g['time_minutes']
-                time_unit = "minutes"
-                time_labels = [
-                    f"{t:.1f}min" for t in df_time_g['time_display']
-                ]
-
-            fig_time = go.Figure()
-            fig_time.add_trace(
-                go.Bar(
-                    y=df_time_g['config_label'],
-                    x=df_time_g['time_display'],
-                    orientation='h',
-                    text=time_labels,
-                    textposition='auto',
-                    marker_color='#ff7f0e',
-                    hovertemplate=(
-                        '<b>%{y}</b><br>'
-                        + f'Time for {batch_size:,} {units["plural"]}: '
-                        + '%{text}<br><extra></extra>'
-                    ),
-                )
-            )
-            fig_time.update_layout(
-                xaxis_title=f"Processing Time ({time_unit})",
-                yaxis_title="Configuration",
-                height=max(300, len(df_time_g) * 40),
-                showlegend=False,
-            )
-            st.plotly_chart(fig_time, use_container_width=True)
-
-            fastest = time_labels[0]
-            slowest = time_labels[-1]
-            st.success(
-                f"💡 To process {batch_size:,} {units['plural']}, "
-                f"fastest: **{fastest}**, slowest: **{slowest}**"
-            )
-        else:
-            st.info("No throughput data available for time estimates.")
-    else:
-        st.info("No product use-case results match the current filters.")
-
-    # ---- Section 3: Prefill vs Decode ----
-    st.divider()
-    st.subheader("3️⃣ Prefill vs Decode Throughput")
-    st.markdown(
-        "**Where is the bottleneck — prompt processing (prefill) "
-        "or token generation (decode)?**"
+    df_product = apply_quality_filters(
+        df_product, hide_capped=hide_capped, min_runs=min_runs
     )
-
-    prefill_col = 'metric_prefill_throughput_tokens_per_sec'
-    decode_col = 'metric_decode_throughput_tokens_per_sec'
-    has_prefill_data = (
-        prefill_col in df_product.columns
-        and (df_product[prefill_col].fillna(0) > 0).any()
-    )
-
-    if has_prefill_data and use_cases_available:
-        pd_use_case = st.selectbox(
-            "Use case:",
-            options=use_cases_available,
-            key="prefill_decode_use_case",
+    if df_product.empty and not df_technical.empty:
+        st.warning(
+            "All product use-case runs were filtered out. "
+            "Try disabling **Hide capped runs** or lowering **Minimum runs**."
         )
 
-        df_pd = df_product[df_product['use_case'] == pd_use_case].copy()
-        df_pd_g = (
-            df_pd.groupby(['model_short', 'cores'])
-            .agg({
-                prefill_col: 'mean',
-                decode_col: 'mean',
-            })
-            .reset_index()
+    df_product_view = apply_run_aggregation(df_product, run_aggregation)
+    all_models = sorted(df['model_short'].unique().tolist())
+
+    product_use_cases = sorted(df_product['use_case'].unique().tolist())
+    with st.sidebar:
+        focus_use_case = st.selectbox(
+            "Focus use case",
+            options=['All'] + product_use_cases,
+            help="Pin a use case across tabs, or pick per tab with All.",
+            key="global_focus_uc",
         )
-        df_pd_g = df_pd_g[
-            (df_pd_g[prefill_col].fillna(0) > 0)
-            | (df_pd_g[decode_col].fillna(0) > 0)
-        ]
+        _render_export_sidebar(df_filtered, df_product_view)
 
-        if not df_pd_g.empty:
-            df_pd_g['config_label'] = (
-                df_pd_g['model_short']
-                + '\n'
-                + df_pd_g['cores'].astype(str)
-                + ' cores'
-            )
+    tab_overview, tab_use_cases, tab_scaling, tab_runs = st.tabs([
+        "Overview",
+        "Use Cases",
+        "Scaling",
+        "All Runs",
+    ])
 
-            fig_pd = go.Figure()
-            fig_pd.add_trace(
-                go.Bar(
-                    name='Prefill (prompt processing)',
-                    x=df_pd_g['config_label'],
-                    y=df_pd_g[prefill_col].fillna(0),
-                    marker_color='#1f77b4',
-                )
-            )
-            fig_pd.add_trace(
-                go.Bar(
-                    name='Decode (token generation)',
-                    x=df_pd_g['config_label'],
-                    y=df_pd_g[decode_col].fillna(0),
-                    marker_color='#ff7f0e',
-                )
-            )
-            fig_pd.update_layout(
-                barmode='group',
-                xaxis_title="Configuration",
-                yaxis_title="Throughput (tokens/sec)",
-                height=400,
-                legend=dict(orientation="h", yanchor="bottom", y=1.02),
-            )
-            st.plotly_chart(fig_pd, use_container_width=True)
-
-            st.caption(
-                "**Prefill** = processing the input prompt (higher is "
-                "better for long-input workloads). "
-                "**Decode** = generating output tokens (higher is better "
-                "for long-output workloads). "
-                "When prefill >> decode, generation is the bottleneck."
-            )
-        else:
-            st.info(
-                "No prefill/decode data for this use case. "
-                "These metrics come from vLLM engine streaming logs."
-            )
-    else:
-        st.info(
-            "Prefill/decode metrics not available in current results. "
-            "These are extracted from vLLM engine streaming logs during "
-            "benchmarking."
+    with tab_overview:
+        _render_overview_tab(
+            df_product, df_product_view, focus_use_case, all_models
         )
 
-    # ---- Section 4: Core Scaling ----
-    st.divider()
-    st.subheader("4️⃣ CPU Core Scaling")
-    st.markdown("**How performance scales with CPU cores**")
-
-    if use_cases_available and len(selected_cores) > 1:
-        col1, col2 = st.columns(2)
-        with col1:
-            cs_use_case = st.selectbox(
-                "Use case:",
-                options=use_cases_available,
-                key="core_scaling_use_case",
-            )
-        with col2:
-            cs_models = sorted(
-                df_product[df_product['use_case'] == cs_use_case][
-                    'model_short'
-                ]
-                .unique()
-                .tolist()
-            )
-            cs_model = st.selectbox(
-                "Model:", options=cs_models, key="core_scaling_model"
-            )
-
-        df_cs = df_product[
-            (df_product['use_case'] == cs_use_case)
-            & (df_product['model_short'] == cs_model)
-        ].copy()
-
-        df_cs_g = (
-            df_cs.groupby('cores')
-            .agg({
-                'metric_throughput_total_tokens_per_sec': 'mean',
-                'metric_throughput_requests_per_sec': 'mean',
-            })
-            .reset_index()
-            .sort_values('cores')
+    with tab_use_cases:
+        _render_use_cases_tab(
+            df_product_view, focus_use_case, selected_cores
         )
 
-        if len(df_cs_g) > 1:
-            cs_units = get_use_case_units(cs_use_case)
-            df_cs_g['items_per_hour'] = df_cs_g[
-                'metric_throughput_requests_per_sec'
-            ].apply(compute_items_per_hour)
-            df_cs_g['tok_per_core'] = (
-                df_cs_g['metric_throughput_total_tokens_per_sec']
-                / df_cs_g['cores']
-            )
-
-            fig_cs = go.Figure()
-
-            # Primary: items/hr
-            fig_cs.add_trace(
-                go.Scatter(
-                    x=df_cs_g['cores'],
-                    y=df_cs_g['items_per_hour'],
-                    mode='lines+markers',
-                    name=f'{cs_units["plural"].capitalize()}/hr',
-                    line=dict(width=3, color='#d62728'),
-                    marker=dict(size=10),
-                    hovertemplate=(
-                        '<b>%{x} cores</b><br>'
-                        + f'{cs_units["plural"].capitalize()}/hr: '
-                        + '%{y:,.0f}<br><extra></extra>'
-                    ),
-                )
-            )
-
-            # Secondary: tokens/sec/core efficiency
-            fig_cs.add_trace(
-                go.Scatter(
-                    x=df_cs_g['cores'],
-                    y=df_cs_g['tok_per_core'],
-                    mode='lines+markers',
-                    name='Tokens/sec/core',
-                    line=dict(width=2, dash='dot', color='#9467bd'),
-                    marker=dict(size=8),
-                    yaxis='y2',
-                    hovertemplate=(
-                        '<b>%{x} cores</b><br>'
-                        'Tokens/sec/core: %{y:.1f}<br><extra></extra>'
-                    ),
-                )
-            )
-
-            fig_cs.update_layout(
-                xaxis_title="CPU Cores",
-                yaxis_title=f"{cs_units['plural'].capitalize()}/hr",
-                yaxis2=dict(
-                    title="Tokens/sec/core",
-                    overlaying='y',
-                    side='right',
-                ),
-                height=400,
-                legend=dict(orientation="h", yanchor="bottom", y=1.02),
-            )
-            st.plotly_chart(fig_cs, use_container_width=True)
-
-            # Best efficiency insight
-            best_eff_idx = df_cs_g['tok_per_core'].idxmax()
-            best_eff_cores = df_cs_g.loc[best_eff_idx, 'cores']
-            best_eff_val = df_cs_g.loc[best_eff_idx, 'tok_per_core']
-            best_eff_iph = df_cs_g.loc[best_eff_idx, 'items_per_hour']
-            st.info(
-                f"💡 **Best efficiency**: {best_eff_cores} cores — "
-                f"{best_eff_val:.1f} tokens/sec/core "
-                f"({best_eff_iph:,.0f} {cs_units['plural']}/hr)"
-            )
-        else:
-            st.info(
-                "Need results with multiple core counts to show scaling. "
-                "The suite tests 8, 16, 24, 32 cores."
-            )
-    elif len(selected_cores) <= 1:
-        st.info(
-            "Need results with multiple core counts to show scaling. "
-            "The suite tests 8, 16, 24, 32 cores."
+    with tab_scaling:
+        _render_scaling_tab(
+            df_product_view,
+            df_technical,
+            df_filtered,
+            focus_use_case,
+            selected_cores,
         )
-    else:
-        st.info("No product use-case results match the current filters.")
 
-    # ---- Section 5: Model Comparison ----
-    if df_product['model'].nunique() > 1 and use_cases_available:
-        st.divider()
-        st.subheader("5️⃣ Model Comparison")
-        st.markdown("**Compare models on the same task (by capacity)**")
-
-        col1, col2 = st.columns(2)
-        with col1:
-            mc_use_case = st.selectbox(
-                "Use case:",
-                options=use_cases_available,
-                key="model_comp_use_case",
-            )
-        with col2:
-            mc_cores_opts = sorted(
-                df_product[df_product['use_case'] == mc_use_case]['cores']
-                .unique()
-                .tolist()
-            )
-            if len(mc_cores_opts) > 1:
-                mc_cores = st.selectbox(
-                    "Core count:",
-                    options=mc_cores_opts,
-                    key="model_comp_cores",
-                )
-            else:
-                mc_cores = mc_cores_opts[0] if mc_cores_opts else None
-                if mc_cores is not None:
-                    st.write(f"**Cores:** {mc_cores}")
-
-        if mc_cores is not None:
-            df_mc = df_product[
-                (df_product['use_case'] == mc_use_case)
-                & (df_product['cores'] == mc_cores)
-            ].copy()
-
-            agg_dict = {
-                'metric_throughput_requests_per_sec': 'mean',
-                'metric_throughput_total_tokens_per_sec': 'mean',
-            }
-
-            df_mc_g = (
-                df_mc.groupby('model_short')
-                .agg(agg_dict)
-                .reset_index()
-            )
-            mc_units = get_use_case_units(mc_use_case)
-            df_mc_g['items_per_hour'] = df_mc_g[
-                'metric_throughput_requests_per_sec'
-            ].apply(compute_items_per_hour)
-            df_mc_g = df_mc_g.sort_values(
-                'items_per_hour', ascending=False
-            )
-
-            fig_mc = go.Figure()
-
-            fig_mc.add_trace(
-                go.Bar(
-                    x=df_mc_g['model_short'],
-                    y=df_mc_g['items_per_hour'],
-                    text=df_mc_g['items_per_hour'].round(0).astype(int),
-                    textposition='auto',
-                    marker_color='#1f77b4',
-                    hovertemplate=(
-                        '<b>%{x}</b><br>'
-                        + f'{mc_units["plural"].capitalize()}/hr: '
-                        + '%{y:,.0f}<br><extra></extra>'
-                    ),
-                )
-            )
-
-            fig_mc.update_layout(
-                xaxis_title="Model",
-                yaxis_title=(
-                    f"{mc_units['plural'].capitalize()}/hr "
-                    f"({mc_cores} cores)"
-                ),
-                height=400,
-                showlegend=False,
-            )
-            st.plotly_chart(fig_mc, use_container_width=True)
-
-            # Secondary: tokens/sec for reference
-            with st.expander("Tokens/sec comparison"):
-                fig_mc_tok = go.Figure()
-                fig_mc_tok.add_trace(
-                    go.Bar(
-                        x=df_mc_g['model_short'],
-                        y=df_mc_g[
-                            'metric_throughput_total_tokens_per_sec'
-                        ],
-                        text=df_mc_g[
-                            'metric_throughput_total_tokens_per_sec'
-                        ]
-                        .round(0)
-                        .astype(int),
-                        textposition='auto',
-                        marker_color='#17becf',
-                    )
-                )
-                fig_mc_tok.update_layout(
-                    xaxis_title="Model",
-                    yaxis_title="Throughput (tokens/sec)",
-                    height=350,
-                    showlegend=False,
-                )
-                st.plotly_chart(fig_mc_tok, use_container_width=True)
-
-    # ==================================================================
-    # TECHNICAL BENCHMARKS
-    # ==================================================================
-    if not df_technical.empty:
-        st.divider()
-        st.header("🔬 Technical Benchmarks")
-
-        tech_use_cases = sorted(df_technical['use_case'].unique().tolist())
-
-        # ---- KV-Cache Capacity ----
-        kv_label = '📊 KV-Cache Capacity'
-        if kv_label in tech_use_cases:
-            st.subheader("KV-Cache Capacity")
-            st.markdown(
-                "**How large a batch before KV-cache saturation?**"
-            )
-
-            df_kv = df_technical[
-                df_technical['use_case'] == kv_label
-            ].copy()
-            kv_models = sorted(
-                df_kv['model_short'].unique().tolist()
-            )
-            kv_model = st.selectbox(
-                "Model:", options=kv_models, key="kv_model"
-            )
-            df_kv = df_kv[df_kv['model_short'] == kv_model]
-
-            kv_cache_col = 'metric_max_kv_cache_usage_percent'
-            has_kv = (
-                kv_cache_col in df_kv.columns
-                and (df_kv[kv_cache_col].fillna(0) > 0).any()
-            )
-
-            df_kv_g = (
-                df_kv.groupby('num_prompts')
-                .agg({
-                    'metric_throughput_requests_per_sec': 'mean',
-                    'metric_throughput_total_tokens_per_sec': 'mean',
-                    **(
-                        {kv_cache_col: 'mean'} if has_kv else {}
-                    ),
-                })
-                .reset_index()
-                .sort_values('num_prompts')
-            )
-
-            if len(df_kv_g) > 1:
-                fig_kv = go.Figure()
-
-                if has_kv:
-                    fig_kv.add_trace(
-                        go.Scatter(
-                            x=df_kv_g['num_prompts'],
-                            y=df_kv_g[kv_cache_col],
-                            mode='lines+markers',
-                            name='KV Cache Usage %',
-                            line=dict(width=3, color='#d62728'),
-                            marker=dict(size=10),
-                            hovertemplate=(
-                                '<b>Batch: %{x}</b><br>'
-                                'KV Cache: %{y:.1f}%<br>'
-                                '<extra></extra>'
-                            ),
-                        )
-                    )
-                    fig_kv.update_layout(
-                        yaxis_title="KV Cache Usage (%)",
-                    )
-
-                fig_kv.add_trace(
-                    go.Scatter(
-                        x=df_kv_g['num_prompts'],
-                        y=df_kv_g[
-                            'metric_throughput_total_tokens_per_sec'
-                        ],
-                        mode='lines+markers',
-                        name='Throughput (tok/s)',
-                        line=dict(width=2, dash='dot', color='#2ca02c'),
-                        marker=dict(size=8),
-                        yaxis='y2',
-                        hovertemplate=(
-                            '<b>Batch: %{x}</b><br>'
-                            'Throughput: %{y:,.0f} tok/s<br>'
-                            '<extra></extra>'
-                        ),
-                    )
-                )
-
-                fig_kv.update_layout(
-                    xaxis_title="Batch Size (num_prompts)",
-                    yaxis2=dict(
-                        title="Throughput (tokens/sec)",
-                        overlaying='y',
-                        side='right',
-                    ),
-                    height=400,
-                    legend=dict(
-                        orientation="h", yanchor="bottom", y=1.02
-                    ),
-                )
-                st.plotly_chart(fig_kv, use_container_width=True)
-                st.caption(
-                    "KV-cache usage increases with batch size. "
-                    "Once saturated, throughput may degrade or "
-                    "requests start queueing."
-                )
-            else:
-                st.info(
-                    "Need multiple batch sizes for KV capacity analysis."
-                )
-
-        # ---- Context Scaling ----
-        ctx_label = '📏 Context Scaling'
-        if ctx_label in tech_use_cases:
-            st.divider()
-            st.subheader("Context Length Scaling")
-            st.markdown(
-                "**How does throughput degrade with longer context?**"
-            )
-
-            df_ctx = df_technical[
-                df_technical['use_case'] == ctx_label
-            ].copy()
-            ctx_models = sorted(
-                df_ctx['model_short'].unique().tolist()
-            )
-            ctx_model = st.selectbox(
-                "Model:", options=ctx_models, key="ctx_model"
-            )
-            df_ctx = df_ctx[df_ctx['model_short'] == ctx_model]
-
-            if 'config_input_len' in df_ctx.columns:
-                df_ctx_g = (
-                    df_ctx.groupby('config_input_len')
-                    .agg({
-                        'metric_throughput_total_tokens_per_sec': 'mean',
-                        'metric_throughput_requests_per_sec': 'mean',
-                    })
-                    .reset_index()
-                    .sort_values('config_input_len')
-                )
-
-                if len(df_ctx_g) > 1:
-                    fig_ctx = go.Figure()
-                    fig_ctx.add_trace(
-                        go.Scatter(
-                            x=df_ctx_g['config_input_len'],
-                            y=df_ctx_g[
-                                'metric_throughput_total_tokens_per_sec'
-                            ],
-                            mode='lines+markers',
-                            name='Total tok/s',
-                            line=dict(width=3, color='#1f77b4'),
-                            marker=dict(size=10),
-                            hovertemplate=(
-                                '<b>Input: %{x} tokens</b><br>'
-                                'Throughput: %{y:,.0f} tok/s<br>'
-                                '<extra></extra>'
-                            ),
-                        )
-                    )
-                    fig_ctx.add_trace(
-                        go.Scatter(
-                            x=df_ctx_g['config_input_len'],
-                            y=df_ctx_g[
-                                'metric_throughput_requests_per_sec'
-                            ],
-                            mode='lines+markers',
-                            name='Req/s',
-                            line=dict(
-                                width=2, dash='dot', color='#ff7f0e'
-                            ),
-                            marker=dict(size=8),
-                            yaxis='y2',
-                            hovertemplate=(
-                                '<b>Input: %{x} tokens</b><br>'
-                                'Req/s: %{y:.2f}<br>'
-                                '<extra></extra>'
-                            ),
-                        )
-                    )
-                    fig_ctx.update_layout(
-                        xaxis_title="Input Length (tokens)",
-                        yaxis_title="Throughput (tokens/sec)",
-                        yaxis2=dict(
-                            title="Request Rate (req/s)",
-                            overlaying='y',
-                            side='right',
-                        ),
-                        height=400,
-                        legend=dict(
-                            orientation="h", yanchor="bottom", y=1.02
-                        ),
-                    )
-                    st.plotly_chart(fig_ctx, use_container_width=True)
-                    st.caption(
-                        "Longer input context increases prefill cost. "
-                        "Request rate (req/s) drops more steeply than "
-                        "total tokens/sec because each request is bigger."
-                    )
-                else:
-                    st.info(
-                        "Need multiple input lengths for context scaling."
-                    )
-            else:
-                st.info("No input_len variation found for context scaling.")
-
-        # ---- Batch Size Scaling (for technical data) ----
-        # Show batch scaling for any technical use case with varying
-        # num_prompts, or for product data when applicable
-        st.divider()
-        st.subheader("📈 Batch Size Scaling")
-        st.markdown("**How batch size affects throughput**")
-
-        # Combine candidates: technical with batch variation,
-        # or product with batch variation
-        df_batch_candidates = df_filtered[
-            df_filtered.groupby(['use_case', 'model_short', 'cores'])[
-                'num_prompts'
-            ].transform('nunique')
-            > 1
-        ].copy()
-
-        if not df_batch_candidates.empty:
-            batch_uc_opts = sorted(
-                df_batch_candidates['use_case'].unique().tolist()
-            )
-            col1, col2, col3 = st.columns(3)
-            with col1:
-                batch_uc = st.selectbox(
-                    "Use case:",
-                    options=batch_uc_opts,
-                    key="batch_scaling_use_case",
-                )
-            with col2:
-                batch_models = sorted(
-                    df_batch_candidates[
-                        df_batch_candidates['use_case'] == batch_uc
-                    ]['model_short']
-                    .unique()
-                    .tolist()
-                )
-                batch_model = st.selectbox(
-                    "Model:",
-                    options=batch_models,
-                    key="batch_scaling_model",
-                )
-            with col3:
-                batch_cores_opts = sorted(
-                    df_batch_candidates[
-                        (df_batch_candidates['use_case'] == batch_uc)
-                        & (
-                            df_batch_candidates['model_short']
-                            == batch_model
-                        )
-                    ]['cores']
-                    .unique()
-                    .tolist()
-                )
-                if len(batch_cores_opts) > 1:
-                    batch_cores = st.selectbox(
-                        "Cores:",
-                        options=batch_cores_opts,
-                        key="batch_scaling_cores",
-                    )
-                else:
-                    batch_cores = (
-                        batch_cores_opts[0] if batch_cores_opts else None
-                    )
-                    if batch_cores is not None:
-                        st.write(f"**Cores:** {batch_cores}")
-
-            if batch_cores is not None:
-                df_bs = df_batch_candidates[
-                    (df_batch_candidates['use_case'] == batch_uc)
-                    & (df_batch_candidates['model_short'] == batch_model)
-                    & (df_batch_candidates['cores'] == batch_cores)
-                ].copy()
-
-                df_bs_g = (
-                    df_bs.groupby('num_prompts')
-                    .agg({
-                        'metric_throughput_total_tokens_per_sec': 'mean',
-                        'metric_throughput_requests_per_sec': 'mean',
-                    })
-                    .reset_index()
-                    .sort_values('num_prompts')
-                )
-
-                if len(df_bs_g) > 1:
-                    bs_units = get_use_case_units(batch_uc)
-                    df_bs_g['items_per_hour'] = df_bs_g[
-                        'metric_throughput_requests_per_sec'
-                    ].apply(compute_items_per_hour)
-
-                    fig_bs = go.Figure()
-                    fig_bs.add_trace(
-                        go.Scatter(
-                            x=df_bs_g['num_prompts'],
-                            y=df_bs_g['items_per_hour'],
-                            mode='lines+markers',
-                            name=f'{bs_units["plural"].capitalize()}/hr',
-                            line=dict(width=3, color='#9467bd'),
-                            marker=dict(size=10),
-                            hovertemplate=(
-                                '<b>Batch: %{x}</b><br>'
-                                + f'{bs_units["plural"].capitalize()}/hr: '
-                                + '%{y:,.0f}<br><extra></extra>'
-                            ),
-                        )
-                    )
-                    fig_bs.add_trace(
-                        go.Scatter(
-                            x=df_bs_g['num_prompts'],
-                            y=df_bs_g[
-                                'metric_throughput_total_tokens_per_sec'
-                            ],
-                            mode='lines+markers',
-                            name='Tokens/sec',
-                            line=dict(
-                                width=2, dash='dot', color='#17becf'
-                            ),
-                            marker=dict(size=8),
-                            yaxis='y2',
-                            hovertemplate=(
-                                '<b>Batch: %{x}</b><br>'
-                                'Tokens/sec: %{y:,.0f}<br>'
-                                '<extra></extra>'
-                            ),
-                        )
-                    )
-                    fig_bs.update_layout(
-                        xaxis_title="Batch Size (number of prompts)",
-                        yaxis_title=(
-                            f"{bs_units['plural'].capitalize()} per Hour"
-                        ),
-                        yaxis2=dict(
-                            title="Throughput (tokens/sec)",
-                            overlaying='y',
-                            side='right',
-                        ),
-                        height=400,
-                        legend=dict(
-                            orientation="h", yanchor="bottom", y=1.02
-                        ),
-                    )
-                    st.plotly_chart(fig_bs, use_container_width=True)
-
-                    st.info(
-                        "💡 Larger batches typically improve throughput up "
-                        "to a point, then plateau due to memory/scheduling "
-                        "overhead."
-                    )
-                else:
-                    st.info(
-                        "Only one batch size found for this configuration."
-                    )
-        else:
-            st.info(
-                "No batch size variation in the current results. "
-                "Run technical benchmarks (batch-scaling, kv-capacity) "
-                "to populate this chart."
-            )
-
-    # ==================================================================
-    # DETAILED RESULTS TABLE
-    # ==================================================================
-    st.divider()
-    with st.expander("📋 View All Results", expanded=False):
-        results_table = df_filtered.copy()
-
-        display_cols = {
-            'use_case': 'Use Case',
-            'model_short': 'Model',
-            'cores': 'Cores',
-            'num_prompts': 'Batch Size',
-            'metric_throughput_requests_per_sec': 'Req/sec',
-            'metric_throughput_total_tokens_per_sec': 'Tokens/sec',
-        }
-
-        if 'config_input_len' in results_table.columns:
-            display_cols['config_input_len'] = 'Input Len'
-        if 'config_output_len' in results_table.columns:
-            display_cols['config_output_len'] = 'Output Len'
-
-        if (
-            'metric_prefill_throughput_tokens_per_sec'
-            in results_table.columns
-        ):
-            display_cols[
-                'metric_prefill_throughput_tokens_per_sec'
-            ] = 'Prefill tok/s'
-        if (
-            'metric_decode_throughput_tokens_per_sec'
-            in results_table.columns
-        ):
-            display_cols[
-                'metric_decode_throughput_tokens_per_sec'
-            ] = 'Decode tok/s'
-
-        kv_col = 'metric_max_kv_cache_usage_percent'
-        if kv_col in results_table.columns:
-            display_cols[kv_col] = 'KV Cache %'
-
-        if 'metric_avg_input_tokens' in results_table.columns:
-            display_cols['metric_avg_input_tokens'] = 'Avg In Tok'
-        if 'metric_avg_output_tokens' in results_table.columns:
-            display_cols['metric_avg_output_tokens'] = 'Avg Out Tok'
-
-        if 'metric_total_time_sec' in results_table.columns:
-            display_cols['metric_total_time_sec'] = 'Total Time (s)'
-
-        if 'vllm_version' in results_table.columns:
-            display_cols['vllm_version'] = 'vLLM Version'
-        if 'container_image' in results_table.columns:
-            results_table['container_short'] = results_table[
-                'container_image'
-            ].apply(
-                lambda x: x.split('/')[-1] if isinstance(x, str) else x
-            )
-            display_cols['container_short'] = 'Container'
-
-        available_display_cols = {
-            k: v
-            for k, v in display_cols.items()
-            if k in results_table.columns
-        }
-
-        display_df = results_table[
-            list(available_display_cols.keys())
-        ].copy()
-        display_df.columns = list(available_display_cols.values())
-
-        for col in display_df.columns:
-            if display_df[col].dtype in ['float64', 'float32']:
-                display_df[col] = display_df[col].round(2)
-
-        st.dataframe(
-            display_df.sort_values(
-                ['Use Case', 'Model', 'Cores', 'Batch Size']
-            ),
-            use_container_width=True,
-            hide_index=True,
-        )
+    with tab_runs:
+        _render_all_runs_tab(df_filtered, df_product_view)
 
 
 if __name__ == "__main__":

--- a/automation/test-execution/scripts/bash/helpers/offline-batch-helpers.sh
+++ b/automation/test-execution/scripts/bash/helpers/offline-batch-helpers.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Shared helpers for run-offline-batch-suite.sh.
+# Sourced by the suite script and the unit test harness.
+
+# ANSI colors — safe to define when sourced from any context.
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Count completed results for a model/use_case/cores/dataset/num_prompts combination.
+# Only existing results.json files count; failed or partial runs are excluded.
+# Requires: REPO_ROOT set to the repository root.
+count_existing_results() {
+    local model="$1"
+    local ansible_use_case="$2"
+    local cores="$3"
+    local dataset="$4"
+    local num_prompts="$5"
+    local sanitized_model="${model//\//__}"
+    local results_base="${REPO_ROOT}/results/llm/${sanitized_model}"
+
+    if [[ ! -d "$results_base" ]]; then
+        echo 0
+        return
+    fi
+
+    local file_list
+    file_list=$(find "$results_base" \
+        -path "*/${cores}cores-${dataset}-${num_prompts}prompts/results.json" 2>/dev/null)
+    if [[ -z "$file_list" ]]; then
+        echo 0
+        return
+    fi
+    local count
+    count=$(echo "$file_list" | xargs grep -l "\"use_case\": \"${ansible_use_case}\"" 2>/dev/null | wc -l | tr -d ' ') || true
+    echo "${count:-0}"
+}
+
+# Run a single config with skip/resume logic.
+# Skips if existing results >= runs (unless OFFLINE_BATCH_FORCE=1).
+# Resumes partial runs, preserving correct run_display numbering.
+# Returns 0 if all runs succeeded or were skipped, 1 if any run failed.
+# Requires: count_existing_results, run_test (provided by caller), OFFLINE_BATCH_FORCE.
+# Args: model ansible_use_case dataset num_prompts cores runs [extra_args...]
+run_with_resume() {
+    local model="$1" ansible_use_case="$2" dataset="$3" num_prompts="$4"
+    local cores="$5" runs="$6"
+    shift 6
+
+    local existing_runs=0 remaining=$runs
+
+    if [[ "${OFFLINE_BATCH_FORCE:-0}" != "1" ]]; then
+        existing_runs=$(count_existing_results "$model" "$ansible_use_case" "$cores" "$dataset" "$num_prompts")
+        remaining=$((runs - existing_runs))
+        if [[ $remaining -le 0 ]]; then
+            echo "  Cores: $cores - SKIP ($existing_runs/$runs runs already complete)"
+            return 0
+        fi
+        if [[ $existing_runs -gt 0 ]]; then
+            echo "  Cores: $cores ($existing_runs/$runs done, running $remaining more)"
+        else
+            echo "  Cores: $cores"
+        fi
+    else
+        echo "  Cores: $cores (force: running all $runs)"
+    fi
+
+    local run_failed=0
+    for run in $(seq 1 $remaining); do
+        local run_display=$((existing_runs + run))
+        echo "    Run $run_display/$runs..."
+        if ! run_test "$model" "$dataset" "$num_prompts" "$cores" "$@"; then
+            echo -e "${RED}    FAILED: Run $run_display/$runs${NC}"
+            run_failed=1
+        fi
+    done
+    return $run_failed
+}

--- a/automation/test-execution/scripts/bash/helpers/offline-batch-helpers.sh
+++ b/automation/test-execution/scripts/bash/helpers/offline-batch-helpers.sh
@@ -38,6 +38,16 @@ count_existing_results() {
     echo "${count:-0}"
 }
 
+# cap_prompts N — return N capped at OFFLINE_BATCH_MAX_PROMPTS (0 or unset = no cap)
+cap_prompts() {
+    local n=$1
+    if [[ "${OFFLINE_BATCH_MAX_PROMPTS:-0}" -gt 0 && "$n" -gt "$OFFLINE_BATCH_MAX_PROMPTS" ]]; then
+        echo "$OFFLINE_BATCH_MAX_PROMPTS"
+    else
+        echo "$n"
+    fi
+}
+
 # Run a single config with skip/resume logic.
 # Skips if existing results >= runs (unless OFFLINE_BATCH_FORCE=1).
 # Resumes partial runs, preserving correct run_display numbering.

--- a/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
+++ b/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
@@ -31,6 +31,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 
+# Shared helpers: count_existing_results, run_with_resume, color vars
+source "${SCRIPT_DIR}/lib/offline-batch-helpers.sh"
+
 # Ensure we're in the repo root
 cd "${REPO_ROOT}"
 
@@ -98,13 +101,6 @@ if command -v timeout &> /dev/null; then
 elif command -v gtimeout &> /dev/null; then
     TIMEOUT_CMD="gtimeout"
 fi
-
-# Colors
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-BLUE='\033[0;34m'
-NC='\033[0m'
 
 # Print usage
 usage() {
@@ -216,74 +212,6 @@ calculate_timeout() {
     local num_prompts=$1
     local timeout=$((BASE_TIMEOUT + (num_prompts * TIMEOUT_PER_PROMPT)))
     echo $timeout
-}
-
-# Count completed results for a model/use_case/cores/dataset/num_prompts combination.
-# Only existing results.json files count; failed or partial runs are excluded.
-count_existing_results() {
-    local model="$1"
-    local ansible_use_case="$2"
-    local cores="$3"
-    local dataset="$4"
-    local num_prompts="$5"
-    local sanitized_model="${model//\//__}"
-    local results_base="${REPO_ROOT}/results/llm/${sanitized_model}"
-
-    if [[ ! -d "$results_base" ]]; then
-        echo 0
-        return
-    fi
-
-    local file_list
-    file_list=$(find "$results_base" \
-        -path "*/${cores}cores-${dataset}-${num_prompts}prompts/results.json" 2>/dev/null)
-    if [[ -z "$file_list" ]]; then
-        echo 0
-        return
-    fi
-    local count
-    count=$(echo "$file_list" | xargs grep -l "\"use_case\": \"${ansible_use_case}\"" 2>/dev/null | wc -l | tr -d ' ') || true
-    echo "${count:-0}"
-}
-
-# Run a single config with skip/resume logic.
-# Skips if existing results >= runs (unless OFFLINE_BATCH_FORCE=1).
-# Resumes partial runs, preserving correct run_display numbering.
-# Returns 0 if all runs succeeded or were skipped, 1 if any run failed.
-# Args: model ansible_use_case dataset num_prompts cores runs [extra_args...]
-run_with_resume() {
-    local model="$1" ansible_use_case="$2" dataset="$3" num_prompts="$4"
-    local cores="$5" runs="$6"
-    shift 6
-
-    local existing_runs=0 remaining=$runs
-
-    if [[ "${OFFLINE_BATCH_FORCE:-0}" != "1" ]]; then
-        existing_runs=$(count_existing_results "$model" "$ansible_use_case" "$cores" "$dataset" "$num_prompts")
-        remaining=$((runs - existing_runs))
-        if [[ $remaining -le 0 ]]; then
-            echo "  Cores: $cores - SKIP ($existing_runs/$runs runs already complete)"
-            return 0
-        fi
-        if [[ $existing_runs -gt 0 ]]; then
-            echo "  Cores: $cores ($existing_runs/$runs done, running $remaining more)"
-        else
-            echo "  Cores: $cores"
-        fi
-    else
-        echo "  Cores: $cores (force: running all $runs)"
-    fi
-
-    local run_failed=0
-    for run in $(seq 1 $remaining); do
-        local run_display=$((existing_runs + run))
-        echo "    Run $run_display/$runs..."
-        if ! run_test "$model" "$dataset" "$num_prompts" "$cores" "$@"; then
-            echo -e "${RED}    FAILED: Run $run_display/$runs${NC}"
-            run_failed=1
-        fi
-    done
-    return $run_failed
 }
 
 # Run Ansible playbook with timeout and retry
@@ -1045,14 +973,16 @@ use_case_sweep() {
             return 1
             ;;
     esac
-    echo "Parameters: $num_prompts prompts"
+    local capped_prompts
+    capped_prompts="$(cap_prompts "$num_prompts")"
+    echo "Parameters: $capped_prompts prompts"
     echo
 
     # Run tests for each model and core count
     for model in "${MODELS[@]}"; do
         echo -e "${GREEN}Model: $model${NC}"
         for cores in "${CORES[@]}"; do
-            if ! run_with_resume "$model" "$ansible_use_case" "$dataset" "$num_prompts" \
+            if ! run_with_resume "$model" "$ansible_use_case" "$dataset" "$capped_prompts" \
                     "$cores" "$runs" $extra_args; then
                 failed_tests+=("$use_case_name - $model - $cores cores")
             fi

--- a/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
+++ b/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
@@ -191,6 +191,28 @@ calculate_timeout() {
     echo $timeout
 }
 
+# Count completed results for a model/use_case/cores combination
+count_existing_results() {
+    local model="$1"
+    local ansible_use_case="$2"
+    local cores="$3"
+    local sanitized_model="${model//\//__}"
+    local results_base="${REPO_ROOT}/results/llm/${sanitized_model}"
+
+    if [[ ! -d "$results_base" ]]; then
+        echo 0
+        return
+    fi
+
+    local file_list
+    file_list=$(find "$results_base" -path "*/${cores}cores-*" -name "results.json" 2>/dev/null)
+    if [[ -z "$file_list" ]]; then
+        echo 0
+        return
+    fi
+    echo "$file_list" | xargs grep -l "\"use_case\": \"${ansible_use_case}\"" 2>/dev/null | wc -l | tr -d ' '
+}
+
 # Run Ansible playbook with timeout and retry
 run_ansible_with_timeout() {
     local timeout_seconds=$1
@@ -955,15 +977,31 @@ use_case_sweep() {
     echo "Parameters: $num_prompts prompts"
     echo
 
+    # Extract the ansible use_case value from extra_args for result counting
+    local ansible_use_case
+    ansible_use_case=$(echo "$extra_args" | grep -o 'use_case=[^ ]*' | cut -d= -f2)
+
     # Run tests for each model and core count
     for model in "${MODELS[@]}"; do
         echo -e "${GREEN}Model: $model${NC}"
         for cores in "${CORES[@]}"; do
-            echo "  Cores: $cores"
-            for run in $(seq 1 $runs); do
-                echo "    Run $run/$runs..."
+            local existing_runs
+            existing_runs=$(count_existing_results "$model" "$ansible_use_case" "$cores")
+            local remaining=$((runs - existing_runs))
+            if [[ $remaining -le 0 ]]; then
+                echo "  Cores: $cores — SKIP ($existing_runs/$runs runs already complete)"
+                continue
+            fi
+            if [[ $existing_runs -gt 0 ]]; then
+                echo "  Cores: $cores ($existing_runs/$runs done, running $remaining more)"
+            else
+                echo "  Cores: $cores"
+            fi
+            for run in $(seq 1 $remaining); do
+                local run_display=$((existing_runs + run))
+                echo "    Run $run_display/$runs..."
                 if ! run_test "$model" "$dataset" "$num_prompts" "$cores" $extra_args; then
-                    failed_tests+=("$use_case_name - $model - $cores cores - Run $run")
+                    failed_tests+=("$use_case_name - $model - $cores cores - Run $run_display")
                 fi
             done
         done

--- a/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
+++ b/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
@@ -77,6 +77,20 @@ TIMEOUT_PER_PROMPT="${OFFLINE_BATCH_TIMEOUT_PER_PROMPT:-$DEFAULT_TIMEOUT_PER_PRO
 MAX_RETRIES="${OFFLINE_BATCH_MAX_RETRIES:-1}"  # Retry once on timeout/failure
 RETRY_DELAY=30  # Seconds to wait between retries
 
+# Cap prompt count per benchmark run (mirrors the 10-min online time limit).
+# Set OFFLINE_BATCH_MAX_PROMPTS=0 or unset to use each use case's natural count.
+OFFLINE_BATCH_MAX_PROMPTS="${OFFLINE_BATCH_MAX_PROMPTS:-100}"
+
+# cap_prompts N — return N capped at OFFLINE_BATCH_MAX_PROMPTS (0 = no cap)
+cap_prompts() {
+    local n=$1
+    if [[ "${OFFLINE_BATCH_MAX_PROMPTS:-0}" -gt 0 && "$n" -gt "$OFFLINE_BATCH_MAX_PROMPTS" ]]; then
+        echo "$OFFLINE_BATCH_MAX_PROMPTS"
+    else
+        echo "$n"
+    fi
+}
+
 # Detect timeout command (GNU timeout on Linux, gtimeout from coreutils on macOS)
 TIMEOUT_CMD=""
 if command -v timeout &> /dev/null; then
@@ -446,7 +460,7 @@ use_cases_suite() {
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        if ! run_with_resume "$model" "summarization" "sharegpt" 1000 16 "$runs" \
+        if ! run_with_resume "$model" "summarization" "sharegpt" "$(cap_prompts 1000)" 16 "$runs" \
                 -e "use_case=summarization"; then
             failed_tests+=("Document Processing - $model")
         fi
@@ -461,7 +475,7 @@ use_cases_suite() {
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        if ! run_with_resume "$model" "classification" "sharegpt" 1000 16 "$runs" \
+        if ! run_with_resume "$model" "classification" "sharegpt" "$(cap_prompts 1000)" 16 "$runs" \
                 -e "output_len=64" -e "use_case=classification"; then
             failed_tests+=("Classification - $model")
         fi
@@ -476,7 +490,7 @@ use_cases_suite() {
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        if ! run_with_resume "$model" "translation" "sharegpt" 500 16 "$runs" \
+        if ! run_with_resume "$model" "translation" "sharegpt" "$(cap_prompts 500)" 16 "$runs" \
                 -e "output_len=1024" -e "use_case=translation"; then
             failed_tests+=("Translation - $model")
         fi
@@ -491,7 +505,7 @@ use_cases_suite() {
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        if ! run_with_resume "$model" "entity_extraction" "sharegpt" 1000 16 "$runs" \
+        if ! run_with_resume "$model" "entity_extraction" "sharegpt" "$(cap_prompts 1000)" 16 "$runs" \
                 -e "output_len=128" -e "use_case=entity_extraction"; then
             failed_tests+=("Entity Extraction - $model")
         fi
@@ -506,7 +520,7 @@ use_cases_suite() {
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        if ! run_with_resume "$model" "dataset_generation" "random" 5000 32 "$runs" \
+        if ! run_with_resume "$model" "dataset_generation" "random" "$(cap_prompts 5000)" 32 "$runs" \
                 -e "input_len=256" -e "output_len=256" -e "use_case=dataset_generation"; then
             failed_tests+=("Dataset Generation - $model")
         fi
@@ -522,7 +536,7 @@ use_cases_suite() {
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
         for cores in 8 16 24 32; do
-            if ! run_with_resume "$model" "etl" "sonnet" 500 "$cores" "$runs" \
+            if ! run_with_resume "$model" "etl" "sonnet" "$(cap_prompts 500)" "$cores" "$runs" \
                     -e "use_case=etl"; then
                 failed_tests+=("ETL ($cores cores) - $model")
             fi
@@ -538,7 +552,7 @@ use_cases_suite() {
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        if ! run_with_resume "$model" "code_generation" "random" 500 16 "$runs" \
+        if ! run_with_resume "$model" "code_generation" "random" "$(cap_prompts 500)" 16 "$runs" \
                 -e "input_len=512" -e "output_len=512" -e "use_case=code_generation"; then
             failed_tests+=("Code Generation - $model")
         fi
@@ -553,7 +567,7 @@ use_cases_suite() {
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        if ! run_with_resume "$model" "long_summarization" "random" 500 16 "$runs" \
+        if ! run_with_resume "$model" "long_summarization" "random" "$(cap_prompts 500)" 16 "$runs" \
                 -e "input_len=4096" -e "output_len=256" -e "use_case=long_summarization"; then
             failed_tests+=("Long-Document Summarization - $model")
         fi
@@ -568,7 +582,7 @@ use_cases_suite() {
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        if ! run_with_resume "$model" "rag_batch" "random" 500 16 "$runs" \
+        if ! run_with_resume "$model" "rag_batch" "random" "$(cap_prompts 500)" 16 "$runs" \
                 -e "input_len=2048" -e "output_len=128" -e "use_case=rag_batch"; then
             failed_tests+=("RAG Batch - $model")
         fi
@@ -583,7 +597,7 @@ use_cases_suite() {
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        if ! run_with_resume "$model" "shared_prefix" "random" 1000 16 "$runs" \
+        if ! run_with_resume "$model" "shared_prefix" "random" "$(cap_prompts 1000)" 16 "$runs" \
                 -e "input_len=1024" -e "output_len=64" -e "use_case=shared_prefix"; then
             failed_tests+=("Shared-Prefix - $model")
         fi
@@ -598,7 +612,7 @@ use_cases_suite() {
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        if ! run_with_resume "$model" "short_labeling" "sharegpt" 2000 16 "$runs" \
+        if ! run_with_resume "$model" "short_labeling" "sharegpt" "$(cap_prompts 2000)" 16 "$runs" \
                 -e "output_len=16" -e "use_case=short_labeling"; then
             failed_tests+=("Ultra-Short Labeling - $model")
         fi

--- a/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
+++ b/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
@@ -121,7 +121,7 @@ MODES:
       - Ultra-short labeling (output 16 tokens)
 
       Models: Single model or comma-separated list. Use 'all' for the 3 production RedHatAI models
-               (w8a8, w4a16 Llama, Qwen3 w4a16). TinyLlama is smoke-test only — pass explicitly.
+               (w8a8, w4a16 Llama, Qwen3 w4a16). TinyLlama is smoke-test only - pass explicitly.
 
       Resume: Skips configs that already have the requested number of completed results.
               Partial configs resume from where they left off. Use --force to override.
@@ -227,7 +227,9 @@ count_existing_results() {
         echo 0
         return
     fi
-    echo "$file_list" | xargs grep -l "\"use_case\": \"${ansible_use_case}\"" 2>/dev/null | wc -l | tr -d ' '
+    local count
+    count=$(echo "$file_list" | xargs grep -l "\"use_case\": \"${ansible_use_case}\"" 2>/dev/null | wc -l | tr -d ' ') || true
+    echo "${count:-0}"
 }
 
 # Run a single config with skip/resume logic.
@@ -263,6 +265,7 @@ run_with_resume() {
         local run_display=$((existing_runs + run))
         echo "    Run $run_display/$runs..."
         if ! run_test "$model" "$dataset" "$num_prompts" "$cores" "$@"; then
+            echo -e "${RED}    FAILED: Run $run_display/$runs${NC}"
             run_failed=1
         fi
     done

--- a/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
+++ b/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
@@ -84,16 +84,6 @@ RETRY_DELAY=30  # Seconds to wait between retries
 # Set OFFLINE_BATCH_MAX_PROMPTS=0 or unset to use each use case's natural count.
 OFFLINE_BATCH_MAX_PROMPTS="${OFFLINE_BATCH_MAX_PROMPTS:-100}"
 
-# cap_prompts N — return N capped at OFFLINE_BATCH_MAX_PROMPTS (0 = no cap)
-cap_prompts() {
-    local n=$1
-    if [[ "${OFFLINE_BATCH_MAX_PROMPTS:-0}" -gt 0 && "$n" -gt "$OFFLINE_BATCH_MAX_PROMPTS" ]]; then
-        echo "$OFFLINE_BATCH_MAX_PROMPTS"
-    else
-        echo "$n"
-    fi
-}
-
 # Detect timeout command (GNU timeout on Linux, gtimeout from coreutils on macOS)
 TIMEOUT_CMD=""
 if command -v timeout &> /dev/null; then
@@ -135,6 +125,8 @@ MODES:
 
       Resume: Skips configs that already have the requested number of completed results.
               Partial configs resume from where they left off. Use --force to override.
+              Note: resume is keyed on the effective (capped) prompt count; results from
+              runs with a different cap (or no cap) will not be detected as completed.
 
     use-case-sweep <use-case> [models] [cores] [runs]
       Run a specific use case with core sweep
@@ -147,6 +139,8 @@ MODES:
 
       Resume: Skips model+use-case+cores+dataset+num_prompts configs that already have
               the requested number of results. Use --force to override.
+              Note: resume is keyed on the effective (capped) prompt count; results from
+              runs with a different cap (or no cap) will not be detected as completed.
 
   Technical Benchmarks (Performance analysis):
     baseline [cores] [prompts]       Baseline throughput across all 4 RedHatAI models (includes TinyLlama)
@@ -183,10 +177,14 @@ EXAMPLES:
   ./run-offline-batch-suite.sh all meta-llama/Llama-3.2-1B-Instruct 32
 
 ENVIRONMENT VARIABLES:
-  VLLM_CONTAINER_IMAGE      Override vLLM container image
-                            Default: docker.io/vllm/vllm-openai-cpu:v0.25.1
-                            RHAIIS: export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
-  OFFLINE_BATCH_FORCE=1     Same as --force; bypass skip/resume for all configs
+  VLLM_CONTAINER_IMAGE         Override vLLM container image
+                               Default: docker.io/vllm/vllm-openai-cpu:v0.25.1
+                               RHAIIS: export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
+  OFFLINE_BATCH_FORCE=1        Same as --force; bypass skip/resume for all configs
+  OFFLINE_BATCH_MAX_PROMPTS=N  Cap prompt count per benchmark run (default: 100).
+                               Set to 0 to use each use case's full natural prompt count.
+                               Resume keys include the capped count, so prior results
+                               from runs with a different cap are not reused.
 
 REDHATAI MODELS (Intel Xeon Compatible):
   RedHatAI/TinyLlama-1.1B-Chat-v1.0-pruned2.4
@@ -384,7 +382,7 @@ use_cases_suite() {
     # 1. BULK DOCUMENT PROCESSING
     echo -e "${GREEN}📄 [1/11] Bulk Document Processing (Summarization)${NC}"
     echo "Use case: Summarize 10,000 support tickets overnight"
-    echo "Parameters: 1000 prompts, sharegpt dataset (conversations), 16 cores"
+    echo "Parameters: $(cap_prompts 1000) prompts, sharegpt dataset (conversations), 16 cores"
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
@@ -399,7 +397,7 @@ use_cases_suite() {
     # 2. CLASSIFICATION / TAGGING
     echo -e "${GREEN}🏷️ [2/11] Classification/Tagging${NC}"
     echo "Use case: Classify 50,000 articles for tagging"
-    echo "Parameters: 1000 prompts, sharegpt dataset (real conversations), 16 cores, output=64 tokens"
+    echo "Parameters: $(cap_prompts 1000) prompts, sharegpt dataset (real conversations), 16 cores, output=64 tokens"
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
@@ -414,7 +412,7 @@ use_cases_suite() {
     # 3. TRANSLATION
     echo -e "${GREEN}🌐 [3/11] Translation${NC}"
     echo "Use case: Translate documentation corpus"
-    echo "Parameters: 500 prompts, sharegpt dataset (real text), output=1024 tokens"
+    echo "Parameters: $(cap_prompts 500) prompts, sharegpt dataset (real text), output=1024 tokens"
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
@@ -429,7 +427,7 @@ use_cases_suite() {
     # 4. ENTITY EXTRACTION
     echo -e "${GREEN}🧬 [4/11] Entity Extraction${NC}"
     echo "Use case: Extract entities from document batches"
-    echo "Parameters: 1000 prompts, sharegpt dataset (conversations with real entities), output=128 tokens"
+    echo "Parameters: $(cap_prompts 1000) prompts, sharegpt dataset (conversations with real entities), output=128 tokens"
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
@@ -444,7 +442,7 @@ use_cases_suite() {
     # 5. DATASET GENERATION
     echo -e "${GREEN}🎲 [5/11] Dataset Generation${NC}"
     echo "Use case: Generate 100k synthetic training examples"
-    echo "Parameters: 5000 prompts, 256->256 tokens, 32 cores"
+    echo "Parameters: $(cap_prompts 5000) prompts, 256->256 tokens, 32 cores"
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
@@ -459,7 +457,7 @@ use_cases_suite() {
     # 6. ETL PIPELINES (Core Scaling)
     echo -e "${GREEN}🔄 [6/11] ETL Pipelines (Core Scaling)${NC}"
     echo "Use case: Batch inference in data workflows"
-    echo "Parameters: 500 prompts, sonnet, 8/16/24/32 cores"
+    echo "Parameters: $(cap_prompts 500) prompts, sonnet, 8/16/24/32 cores"
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
@@ -476,7 +474,7 @@ use_cases_suite() {
     # 7. CODE GENERATION
     echo -e "${GREEN}💻 [7/11] Code Generation${NC}"
     echo "Use case: Generate tests for 1,000 functions"
-    echo "Parameters: 500 prompts, 512->512 tokens, 16 cores"
+    echo "Parameters: $(cap_prompts 500) prompts, 512->512 tokens, 16 cores"
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
@@ -491,7 +489,7 @@ use_cases_suite() {
     # 8. LONG-DOCUMENT SUMMARIZATION
     echo -e "${GREEN}📜 [8/11] Long-Document Summarization${NC}"
     echo "Use case: Summarize long documents (reports, articles, legal docs)"
-    echo "Parameters: 500 prompts, random 4096->256 tokens, 16 cores"
+    echo "Parameters: $(cap_prompts 500) prompts, random 4096->256 tokens, 16 cores"
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
@@ -506,7 +504,7 @@ use_cases_suite() {
     # 9. BATCH RAG / GROUNDED Q&A
     echo -e "${GREEN}🔍 [9/11] Batch RAG / Grounded Q&A${NC}"
     echo "Use case: Process RAG queries with retrieved context + short answers"
-    echo "Parameters: 500 prompts, random 2048->128 tokens, 16 cores"
+    echo "Parameters: $(cap_prompts 500) prompts, random 2048->128 tokens, 16 cores"
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
@@ -521,7 +519,7 @@ use_cases_suite() {
     # 10. SHARED-PREFIX / TEMPLATE BATCH
     echo -e "${GREEN}📋 [10/11] Shared-Prefix / Template Batch${NC}"
     echo "Use case: Short-output template-shaped throughput (1024->64 tokens)"
-    echo "Parameters: 1000 prompts, random 1024->64 tokens, 16 cores"
+    echo "Parameters: $(cap_prompts 1000) prompts, random 1024->64 tokens, 16 cores"
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
@@ -536,7 +534,7 @@ use_cases_suite() {
     # 11. ULTRA-SHORT LABELING
     echo -e "${GREEN}⚡ [11/11] Ultra-Short Labeling${NC}"
     echo "Use case: Sentiment/moderation/yes-no labeling at high volume"
-    echo "Parameters: 2000 prompts, sharegpt, output=16 tokens, 16 cores"
+    echo "Parameters: $(cap_prompts 2000) prompts, sharegpt, output=16 tokens, 16 cores"
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"

--- a/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
+++ b/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
@@ -32,7 +32,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 
 # Shared helpers: count_existing_results, run_with_resume, color vars
-source "${SCRIPT_DIR}/lib/offline-batch-helpers.sh"
+source "${SCRIPT_DIR}/helpers/offline-batch-helpers.sh"
 
 # Ensure we're in the repo root
 cd "${REPO_ROOT}"

--- a/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
+++ b/automation/test-execution/scripts/bash/run-offline-batch-suite.sh
@@ -5,7 +5,7 @@
 # Uses Ansible playbook: llm-benchmark-offline-batch.yml
 #
 # Usage:
-#   ./run-offline-batch-suite.sh <mode> [args...]
+#   ./run-offline-batch-suite.sh <mode> [--force] [args...]
 #
 # Modes:
 #   use-cases [runs]                 - Run all 11 real-world use cases (default: 5 runs each)
@@ -98,7 +98,11 @@ usage() {
 vLLM Offline Batch Benchmark Suite
 
 USAGE:
-  ./run-offline-batch-suite.sh <mode> [args...]
+  ./run-offline-batch-suite.sh <mode> [--force] [args...]
+
+FLAGS:
+  --force    Bypass resume/skip logic and run the full requested iteration count
+             even when results already exist. Also settable via OFFLINE_BATCH_FORCE=1.
 
 MODES:
 
@@ -119,6 +123,9 @@ MODES:
       Models: Single model or comma-separated list. Use 'all' for the 3 production RedHatAI models
                (w8a8, w4a16 Llama, Qwen3 w4a16). TinyLlama is smoke-test only — pass explicitly.
 
+      Resume: Skips configs that already have the requested number of completed results.
+              Partial configs resume from where they left off. Use --force to override.
+
     use-case-sweep <use-case> [models] [cores] [runs]
       Run a specific use case with core sweep
       Use cases: summarization, classification, translation, entity-extraction,
@@ -127,6 +134,9 @@ MODES:
       Models: 'all' or comma-separated list (default: all)
       Cores: comma-separated list (default: 8,16,24,32)
       Runs: number of iterations (default: 3)
+
+      Resume: Skips model+use-case+cores+dataset+num_prompts configs that already have
+              the requested number of results. Use --force to override.
 
   Technical Benchmarks (Performance analysis):
     baseline [cores] [prompts]       Baseline throughput across all 4 RedHatAI models (includes TinyLlama)
@@ -146,6 +156,7 @@ EXAMPLES:
   ./run-offline-batch-suite.sh use-cases 3 "$MODEL_TINY_PRUNED"  # 3 runs, TinyLlama smoke only
   ./run-offline-batch-suite.sh use-cases 5 all                # 5 runs, 3 production RedHatAI models
   ./run-offline-batch-suite.sh use-cases 1 "$MODEL_LLAMA_W8A8,$MODEL_QWEN_W4A16"  # Specific models
+  ./run-offline-batch-suite.sh use-cases 3 all --force        # Force re-run all, ignore existing
 
   # Focused use case testing
   ./run-offline-batch-suite.sh use-case-sweep summarization all 8,16,24,32 3
@@ -154,6 +165,7 @@ EXAMPLES:
   ./run-offline-batch-suite.sh use-case-sweep long-summarization all 16,32 3
   ./run-offline-batch-suite.sh use-case-sweep rag all
   ./run-offline-batch-suite.sh use-case-sweep short-labeling all 8,16,24,32
+  ./run-offline-batch-suite.sh use-case-sweep summarization all 8,16 3 --force
 
   # Technical benchmarks
   ./run-offline-batch-suite.sh baseline 32 100
@@ -161,9 +173,10 @@ EXAMPLES:
   ./run-offline-batch-suite.sh all meta-llama/Llama-3.2-1B-Instruct 32
 
 ENVIRONMENT VARIABLES:
-  VLLM_CONTAINER_IMAGE    Override vLLM container image
-                          Default: docker.io/vllm/vllm-openai-cpu:v0.25.1
-                          RHAIIS: export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
+  VLLM_CONTAINER_IMAGE      Override vLLM container image
+                            Default: docker.io/vllm/vllm-openai-cpu:v0.25.1
+                            RHAIIS: export VLLM_CONTAINER_IMAGE=registry.redhat.io/rhaii/vllm-cpu-rhel9:3.4.0
+  OFFLINE_BATCH_FORCE=1     Same as --force; bypass skip/resume for all configs
 
 REDHATAI MODELS (Intel Xeon Compatible):
   RedHatAI/TinyLlama-1.1B-Chat-v1.0-pruned2.4
@@ -191,11 +204,14 @@ calculate_timeout() {
     echo $timeout
 }
 
-# Count completed results for a model/use_case/cores combination
+# Count completed results for a model/use_case/cores/dataset/num_prompts combination.
+# Only existing results.json files count; failed or partial runs are excluded.
 count_existing_results() {
     local model="$1"
     local ansible_use_case="$2"
     local cores="$3"
+    local dataset="$4"
+    local num_prompts="$5"
     local sanitized_model="${model//\//__}"
     local results_base="${REPO_ROOT}/results/llm/${sanitized_model}"
 
@@ -205,12 +221,52 @@ count_existing_results() {
     fi
 
     local file_list
-    file_list=$(find "$results_base" -path "*/${cores}cores-*" -name "results.json" 2>/dev/null)
+    file_list=$(find "$results_base" \
+        -path "*/${cores}cores-${dataset}-${num_prompts}prompts/results.json" 2>/dev/null)
     if [[ -z "$file_list" ]]; then
         echo 0
         return
     fi
     echo "$file_list" | xargs grep -l "\"use_case\": \"${ansible_use_case}\"" 2>/dev/null | wc -l | tr -d ' '
+}
+
+# Run a single config with skip/resume logic.
+# Skips if existing results >= runs (unless OFFLINE_BATCH_FORCE=1).
+# Resumes partial runs, preserving correct run_display numbering.
+# Returns 0 if all runs succeeded or were skipped, 1 if any run failed.
+# Args: model ansible_use_case dataset num_prompts cores runs [extra_args...]
+run_with_resume() {
+    local model="$1" ansible_use_case="$2" dataset="$3" num_prompts="$4"
+    local cores="$5" runs="$6"
+    shift 6
+
+    local existing_runs=0 remaining=$runs
+
+    if [[ "${OFFLINE_BATCH_FORCE:-0}" != "1" ]]; then
+        existing_runs=$(count_existing_results "$model" "$ansible_use_case" "$cores" "$dataset" "$num_prompts")
+        remaining=$((runs - existing_runs))
+        if [[ $remaining -le 0 ]]; then
+            echo "  Cores: $cores - SKIP ($existing_runs/$runs runs already complete)"
+            return 0
+        fi
+        if [[ $existing_runs -gt 0 ]]; then
+            echo "  Cores: $cores ($existing_runs/$runs done, running $remaining more)"
+        else
+            echo "  Cores: $cores"
+        fi
+    else
+        echo "  Cores: $cores (force: running all $runs)"
+    fi
+
+    local run_failed=0
+    for run in $(seq 1 $remaining); do
+        local run_display=$((existing_runs + run))
+        echo "    Run $run_display/$runs..."
+        if ! run_test "$model" "$dataset" "$num_prompts" "$cores" "$@"; then
+            run_failed=1
+        fi
+    done
+    return $run_failed
 }
 
 # Run Ansible playbook with timeout and retry
@@ -370,6 +426,11 @@ use_cases_suite() {
     for model in "${MODELS[@]}"; do
         echo -e "  - $model"
     done
+    if [[ "${OFFLINE_BATCH_FORCE:-0}" == "1" ]]; then
+        echo -e "  Resume: disabled (--force)"
+    else
+        echo -e "  Resume: enabled (skip completed configs, resume partial)"
+    fi
     echo -e "${BLUE}========================================${NC}"
     echo
 
@@ -382,12 +443,10 @@ use_cases_suite() {
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        for run in $(seq 1 $runs); do
-            echo "    Run $run/$runs..."
-            if ! run_test "$model" "sharegpt" 1000 16 -e "use_case=summarization"; then
-                failed_tests+=("Document Processing - $model - Run $run")
-            fi
-        done
+        if ! run_with_resume "$model" "summarization" "sharegpt" 1000 16 "$runs" \
+                -e "use_case=summarization"; then
+            failed_tests+=("Document Processing - $model")
+        fi
     done
     echo -e "${GREEN}✓ Complete${NC}"
     echo
@@ -399,12 +458,10 @@ use_cases_suite() {
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        for run in $(seq 1 $runs); do
-            echo "    Run $run/$runs..."
-            if ! run_test "$model" "sharegpt" 1000 16 -e "output_len=64" -e "use_case=classification"; then
-                failed_tests+=("Classification - $model - Run $run")
-            fi
-        done
+        if ! run_with_resume "$model" "classification" "sharegpt" 1000 16 "$runs" \
+                -e "output_len=64" -e "use_case=classification"; then
+            failed_tests+=("Classification - $model")
+        fi
     done
     echo -e "${GREEN}✓ Complete${NC}"
     echo
@@ -416,12 +473,10 @@ use_cases_suite() {
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        for run in $(seq 1 $runs); do
-            echo "    Run $run/$runs..."
-            if ! run_test "$model" "sharegpt" 500 16 -e "output_len=1024" -e "use_case=translation"; then
-                failed_tests+=("Translation - $model - Run $run")
-            fi
-        done
+        if ! run_with_resume "$model" "translation" "sharegpt" 500 16 "$runs" \
+                -e "output_len=1024" -e "use_case=translation"; then
+            failed_tests+=("Translation - $model")
+        fi
     done
     echo -e "${GREEN}✓ Complete${NC}"
     echo
@@ -433,12 +488,10 @@ use_cases_suite() {
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        for run in $(seq 1 $runs); do
-            echo "    Run $run/$runs..."
-            if ! run_test "$model" "sharegpt" 1000 16 -e "output_len=128" -e "use_case=entity_extraction"; then
-                failed_tests+=("Entity Extraction - $model - Run $run")
-            fi
-        done
+        if ! run_with_resume "$model" "entity_extraction" "sharegpt" 1000 16 "$runs" \
+                -e "output_len=128" -e "use_case=entity_extraction"; then
+            failed_tests+=("Entity Extraction - $model")
+        fi
     done
     echo -e "${GREEN}✓ Complete${NC}"
     echo
@@ -446,16 +499,14 @@ use_cases_suite() {
     # 5. DATASET GENERATION
     echo -e "${GREEN}🎲 [5/11] Dataset Generation${NC}"
     echo "Use case: Generate 100k synthetic training examples"
-    echo "Parameters: 5000 prompts, 256→256 tokens, 32 cores"
+    echo "Parameters: 5000 prompts, 256->256 tokens, 32 cores"
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        for run in $(seq 1 $runs); do
-            echo "    Run $run/$runs..."
-            if ! run_test "$model" "random" 5000 32 -e "input_len=256" -e "output_len=256" -e "use_case=dataset_generation"; then
-                failed_tests+=("Dataset Generation - $model - Run $run")
-            fi
-        done
+        if ! run_with_resume "$model" "dataset_generation" "random" 5000 32 "$runs" \
+                -e "input_len=256" -e "output_len=256" -e "use_case=dataset_generation"; then
+            failed_tests+=("Dataset Generation - $model")
+        fi
     done
     echo -e "${GREEN}✓ Complete${NC}"
     echo
@@ -468,13 +519,10 @@ use_cases_suite() {
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
         for cores in 8 16 24 32; do
-            echo "    Testing with $cores cores..."
-            for run in $(seq 1 $runs); do
-                echo "      Run $run/$runs..."
-                if ! run_test "$model" "sonnet" 500 $cores -e "use_case=etl"; then
-                    failed_tests+=("ETL ($cores cores) - $model - Run $run")
-                fi
-            done
+            if ! run_with_resume "$model" "etl" "sonnet" 500 "$cores" "$runs" \
+                    -e "use_case=etl"; then
+                failed_tests+=("ETL ($cores cores) - $model")
+            fi
         done
     done
     echo -e "${GREEN}✓ Complete${NC}"
@@ -483,16 +531,14 @@ use_cases_suite() {
     # 7. CODE GENERATION
     echo -e "${GREEN}💻 [7/11] Code Generation${NC}"
     echo "Use case: Generate tests for 1,000 functions"
-    echo "Parameters: 500 prompts, 512→512 tokens, 16 cores"
+    echo "Parameters: 500 prompts, 512->512 tokens, 16 cores"
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        for run in $(seq 1 $runs); do
-            echo "    Run $run/$runs..."
-            if ! run_test "$model" "random" 500 16 -e "input_len=512" -e "output_len=512" -e "use_case=code_generation"; then
-                failed_tests+=("Code Generation - $model - Run $run")
-            fi
-        done
+        if ! run_with_resume "$model" "code_generation" "random" 500 16 "$runs" \
+                -e "input_len=512" -e "output_len=512" -e "use_case=code_generation"; then
+            failed_tests+=("Code Generation - $model")
+        fi
     done
     echo -e "${GREEN}✓ Complete${NC}"
     echo
@@ -500,16 +546,14 @@ use_cases_suite() {
     # 8. LONG-DOCUMENT SUMMARIZATION
     echo -e "${GREEN}📜 [8/11] Long-Document Summarization${NC}"
     echo "Use case: Summarize long documents (reports, articles, legal docs)"
-    echo "Parameters: 500 prompts, random 4096→256 tokens, 16 cores"
+    echo "Parameters: 500 prompts, random 4096->256 tokens, 16 cores"
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        for run in $(seq 1 $runs); do
-            echo "    Run $run/$runs..."
-            if ! run_test "$model" "random" 500 16 -e "input_len=4096" -e "output_len=256" -e "use_case=long_summarization"; then
-                failed_tests+=("Long-Document Summarization - $model - Run $run")
-            fi
-        done
+        if ! run_with_resume "$model" "long_summarization" "random" 500 16 "$runs" \
+                -e "input_len=4096" -e "output_len=256" -e "use_case=long_summarization"; then
+            failed_tests+=("Long-Document Summarization - $model")
+        fi
     done
     echo -e "${GREEN}✓ Complete${NC}"
     echo
@@ -517,33 +561,29 @@ use_cases_suite() {
     # 9. BATCH RAG / GROUNDED Q&A
     echo -e "${GREEN}🔍 [9/11] Batch RAG / Grounded Q&A${NC}"
     echo "Use case: Process RAG queries with retrieved context + short answers"
-    echo "Parameters: 500 prompts, random 2048→128 tokens, 16 cores"
+    echo "Parameters: 500 prompts, random 2048->128 tokens, 16 cores"
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        for run in $(seq 1 $runs); do
-            echo "    Run $run/$runs..."
-            if ! run_test "$model" "random" 500 16 -e "input_len=2048" -e "output_len=128" -e "use_case=rag_batch"; then
-                failed_tests+=("RAG Batch - $model - Run $run")
-            fi
-        done
+        if ! run_with_resume "$model" "rag_batch" "random" 500 16 "$runs" \
+                -e "input_len=2048" -e "output_len=128" -e "use_case=rag_batch"; then
+            failed_tests+=("RAG Batch - $model")
+        fi
     done
     echo -e "${GREEN}✓ Complete${NC}"
     echo
 
     # 10. SHARED-PREFIX / TEMPLATE BATCH
     echo -e "${GREEN}📋 [10/11] Shared-Prefix / Template Batch${NC}"
-    echo "Use case: Short-output template-shaped throughput (1024→64 tokens)"
-    echo "Parameters: 1000 prompts, random 1024→64 tokens, 16 cores"
+    echo "Use case: Short-output template-shaped throughput (1024->64 tokens)"
+    echo "Parameters: 1000 prompts, random 1024->64 tokens, 16 cores"
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        for run in $(seq 1 $runs); do
-            echo "    Run $run/$runs..."
-            if ! run_test "$model" "random" 1000 16 -e "input_len=1024" -e "output_len=64" -e "use_case=shared_prefix"; then
-                failed_tests+=("Shared-Prefix - $model - Run $run")
-            fi
-        done
+        if ! run_with_resume "$model" "shared_prefix" "random" 1000 16 "$runs" \
+                -e "input_len=1024" -e "output_len=64" -e "use_case=shared_prefix"; then
+            failed_tests+=("Shared-Prefix - $model")
+        fi
     done
     echo -e "${GREEN}✓ Complete${NC}"
     echo
@@ -555,12 +595,10 @@ use_cases_suite() {
     echo
     for model in "${MODELS[@]}"; do
         echo "  Model: $model"
-        for run in $(seq 1 $runs); do
-            echo "    Run $run/$runs..."
-            if ! run_test "$model" "sharegpt" 2000 16 -e "output_len=16" -e "use_case=short_labeling"; then
-                failed_tests+=("Ultra-Short Labeling - $model - Run $run")
-            fi
-        done
+        if ! run_with_resume "$model" "short_labeling" "sharegpt" 2000 16 "$runs" \
+                -e "output_len=16" -e "use_case=short_labeling"; then
+            failed_tests+=("Ultra-Short Labeling - $model")
+        fi
     done
     echo -e "${GREEN}✓ Complete${NC}"
     echo
@@ -632,7 +670,7 @@ test_batch_scaling() {
     echo -e "${GREEN}Test: Batch Size Scaling${NC}"
     echo -e "${GREEN}========================================${NC}"
     echo "Model: $model"
-    echo "Dataset: random (512 → 256 tokens)"
+    echo "Dataset: random (512 -> 256 tokens)"
     echo "Cores: $cores"
     echo "Batch sizes: ${sizes[*]}"
     echo -e "${GREEN}========================================${NC}"
@@ -791,7 +829,7 @@ test_kv_capacity() {
     echo -e "${GREEN}Test: KV-Cache Capacity Sweep${NC}"
     echo -e "${GREEN}========================================${NC}"
     echo "Model: $model"
-    echo "Dataset: random (512 → 256 tokens)"
+    echo "Dataset: random (512 -> 256 tokens)"
     echo "Cores: $cores"
     echo "Batch sizes: ${sizes[*]}"
     echo "Question: How large a batch fits before KV cache saturates?"
@@ -870,18 +908,24 @@ use_case_sweep() {
     done
     echo -e "Core counts: ${CORES[*]}"
     echo -e "Runs per config: $runs"
+    if [[ "${OFFLINE_BATCH_FORCE:-0}" == "1" ]]; then
+        echo -e "Resume: disabled (--force)"
+    else
+        echo -e "Resume: enabled (skip completed configs, resume partial)"
+    fi
     echo -e "${BLUE}========================================${NC}"
     echo
 
     local failed_tests=()
 
-    # Define use case parameters
-    local dataset num_prompts extra_args use_case_name
+    # Define use case parameters; ansible_use_case is the value written to results.json
+    local dataset num_prompts extra_args ansible_use_case use_case_name
     case "$use_case" in
         summarization|summary|sum)
             use_case_name="📝 Summarization"
             dataset="sharegpt"
             num_prompts=1000
+            ansible_use_case="summarization"
             extra_args="-e use_case=summarization"
             echo "Use case: Summarize 10,000 support tickets overnight"
             echo "Dataset: sharegpt (conversations)"
@@ -890,6 +934,7 @@ use_case_sweep() {
             use_case_name="🏷️ Classification/Tagging"
             dataset="sharegpt"
             num_prompts=1000
+            ansible_use_case="classification"
             extra_args="-e output_len=64 -e use_case=classification"
             echo "Use case: Classify 50,000 articles for tagging"
             echo "Dataset: sharegpt (real conversations)"
@@ -898,6 +943,7 @@ use_case_sweep() {
             use_case_name="🌐 Translation"
             dataset="sharegpt"
             num_prompts=500
+            ansible_use_case="translation"
             extra_args="-e output_len=1024 -e use_case=translation"
             echo "Use case: Translate documentation corpus"
             echo "Dataset: sharegpt (real text)"
@@ -906,6 +952,7 @@ use_case_sweep() {
             use_case_name="🧬 Entity Extraction"
             dataset="sharegpt"
             num_prompts=1000
+            ansible_use_case="entity_extraction"
             extra_args="-e output_len=128 -e use_case=entity_extraction"
             echo "Use case: Extract entities from document batches"
             echo "Dataset: sharegpt (conversations with real entities)"
@@ -914,6 +961,7 @@ use_case_sweep() {
             use_case_name="🎲 Dataset Generation"
             dataset="random"
             num_prompts=5000
+            ansible_use_case="dataset_generation"
             extra_args="-e input_len=256 -e output_len=256 -e use_case=dataset_generation"
             echo "Use case: Generate 100k synthetic training examples"
             echo "Dataset: random (synthetic data)"
@@ -922,6 +970,7 @@ use_case_sweep() {
             use_case_name="💻 Code Generation"
             dataset="random"
             num_prompts=500
+            ansible_use_case="code_generation"
             extra_args="-e input_len=512 -e output_len=512 -e use_case=code_generation"
             echo "Use case: Generate tests for 1,000 functions"
             echo "Dataset: random (no code-specific dataset available)"
@@ -930,6 +979,7 @@ use_case_sweep() {
             use_case_name="🔄 ETL Pipelines"
             dataset="sonnet"
             num_prompts=500
+            ansible_use_case="etl"
             extra_args="-e use_case=etl"
             echo "Use case: Batch inference in data workflows"
             echo "Dataset: sonnet (baseline)"
@@ -938,6 +988,7 @@ use_case_sweep() {
             use_case_name="📜 Long-Document Summarization"
             dataset="random"
             num_prompts=500
+            ansible_use_case="long_summarization"
             extra_args="-e input_len=4096 -e output_len=256 -e use_case=long_summarization"
             echo "Use case: Summarize long documents (reports, articles, legal)"
             echo "Dataset: random (controlled long input)"
@@ -946,6 +997,7 @@ use_case_sweep() {
             use_case_name="🔍 Batch RAG / Grounded Q&A"
             dataset="random"
             num_prompts=500
+            ansible_use_case="rag_batch"
             extra_args="-e input_len=2048 -e output_len=128 -e use_case=rag_batch"
             echo "Use case: RAG queries with retrieved context + short answers"
             echo "Dataset: random (simulating retrieved chunks)"
@@ -954,14 +1006,16 @@ use_case_sweep() {
             use_case_name="📋 Shared-Prefix / Template Batch"
             dataset="random"
             num_prompts=1000
+            ansible_use_case="shared_prefix"
             extra_args="-e input_len=1024 -e output_len=64 -e use_case=shared_prefix"
-            echo "Use case: Short-output template-shaped throughput (1024→64 tokens)"
+            echo "Use case: Short-output template-shaped throughput (1024->64 tokens)"
             echo "Dataset: random (controlled I/O shape)"
             ;;
         short-labeling|short-label|labeling|sentiment)
             use_case_name="⚡ Ultra-Short Labeling"
             dataset="sharegpt"
             num_prompts=2000
+            ansible_use_case="short_labeling"
             extra_args="-e output_len=16 -e use_case=short_labeling"
             echo "Use case: Sentiment/moderation/yes-no labeling at high volume"
             echo "Dataset: sharegpt (real text, ultra-short output)"
@@ -977,33 +1031,14 @@ use_case_sweep() {
     echo "Parameters: $num_prompts prompts"
     echo
 
-    # Extract the ansible use_case value from extra_args for result counting
-    local ansible_use_case
-    ansible_use_case=$(echo "$extra_args" | grep -o 'use_case=[^ ]*' | cut -d= -f2)
-
     # Run tests for each model and core count
     for model in "${MODELS[@]}"; do
         echo -e "${GREEN}Model: $model${NC}"
         for cores in "${CORES[@]}"; do
-            local existing_runs
-            existing_runs=$(count_existing_results "$model" "$ansible_use_case" "$cores")
-            local remaining=$((runs - existing_runs))
-            if [[ $remaining -le 0 ]]; then
-                echo "  Cores: $cores — SKIP ($existing_runs/$runs runs already complete)"
-                continue
+            if ! run_with_resume "$model" "$ansible_use_case" "$dataset" "$num_prompts" \
+                    "$cores" "$runs" $extra_args; then
+                failed_tests+=("$use_case_name - $model - $cores cores")
             fi
-            if [[ $existing_runs -gt 0 ]]; then
-                echo "  Cores: $cores ($existing_runs/$runs done, running $remaining more)"
-            else
-                echo "  Cores: $cores"
-            fi
-            for run in $(seq 1 $remaining); do
-                local run_display=$((existing_runs + run))
-                echo "    Run $run_display/$runs..."
-                if ! run_test "$model" "$dataset" "$num_prompts" "$cores" $extra_args; then
-                    failed_tests+=("$use_case_name - $model - $cores cores - Run $run_display")
-                fi
-            done
         done
         echo
     done
@@ -1094,6 +1129,23 @@ test_all() {
 # ==============================================================================
 
 main() {
+    if [ $# -lt 1 ]; then
+        usage
+    fi
+
+    # Parse --force flag from any position in the argument list
+    OFFLINE_BATCH_FORCE="${OFFLINE_BATCH_FORCE:-0}"
+    local -a filtered_args=()
+    for arg in "$@"; do
+        if [[ "$arg" == "--force" ]]; then
+            OFFLINE_BATCH_FORCE=1
+        else
+            filtered_args+=("$arg")
+        fi
+    done
+    export OFFLINE_BATCH_FORCE
+    set -- "${filtered_args[@]}"
+
     if [ $# -lt 1 ]; then
         usage
     fi

--- a/automation/test-execution/tests/dashboard/test_offline_batch_page.py
+++ b/automation/test-execution/tests/dashboard/test_offline_batch_page.py
@@ -50,6 +50,22 @@ is_technical_use_case = _ns["is_technical_use_case"]
 format_duration = _ns["format_duration"]
 normalize_version = _ns["normalize_vllm_version"]
 USE_CASE_REFERENCE = _ns["USE_CASE_REFERENCE"]
+build_config_fingerprint = _ns["build_config_fingerprint"]
+is_capped_run = _ns["is_capped_run"]
+capped_run_note = _ns["capped_run_note"]
+apply_run_aggregation = _ns["apply_run_aggregation"]
+build_coverage_pivot = _ns["build_coverage_pivot"]
+build_best_configs_table = _ns["build_best_configs_table"]
+format_run_stats = _ns["format_run_stats"]
+parse_streaming_metrics_from_log = _ns["parse_streaming_metrics_from_log"]
+use_case_cli_name = _ns["use_case_cli_name"]
+compute_coefficient_of_variation = _ns["compute_coefficient_of_variation"]
+IMPORT_CSV_COLUMN_MAP = _ns["IMPORT_CSV_COLUMN_MAP"]
+normalize_imported_offline_batch_df = _ns["normalize_imported_offline_batch_df"]
+PREFILL_COL = _ns["PREFILL_COL"]
+DECODE_COL = _ns["DECODE_COL"]
+METRIC_RPS = _ns["METRIC_RPS"]
+METRIC_TOK_S = _ns["METRIC_TOK_S"]
 
 
 class TestComputeItemsPerHour:
@@ -676,6 +692,80 @@ class TestUseCaseInference:
             }
         }
         assert infer_use_case(metadata) == "⚙️ General"
+
+
+class TestConfigFingerprint:
+    def test_basic_fingerprint(self):
+        row = {
+            'cores': 16,
+            'dataset': 'sharegpt',
+            'num_prompts': 100,
+            'config_input_len': None,
+            'config_output_len': 64,
+        }
+        fp = build_config_fingerprint(row)
+        assert '16c' in fp
+        assert 'sharegpt' in fp
+        assert '100 prompts' in fp
+        assert 'out=64' in fp
+
+
+class TestCappedRuns:
+    def test_capped_detection(self):
+        assert is_capped_run('summarization', 100) is True
+        assert is_capped_run('summarization', 1000) is False
+        assert is_capped_run('', 100) is False
+
+    def test_capped_note(self):
+        note = capped_run_note('summarization', 100)
+        assert 'Capped run' in note
+        assert capped_run_note('summarization', 1000) == ''
+
+
+class TestStreamingMetricsParsing:
+    SAMPLE_LOG = """
+Throughput: 1.23 requests/s, 456.78 total tokens/s
+Engine 000: Avg prompt throughput: 100.5 tokens/s, Avg generation throughput: 45.2 tokens/s, Running: 1 reqs
+Engine 000: Avg prompt throughput: 110.0 tokens/s, Avg generation throughput: 50.0 tokens/s, Running: 0 reqs
+Engine 000: CPU KV cache usage: 12.5%, Prefix cache hit rate: 33.3%
+"""
+
+    def test_parse_prefill_decode_averages(self):
+        metrics = parse_streaming_metrics_from_log(self.SAMPLE_LOG)
+        assert metrics[PREFILL_COL] == 105.25
+        assert metrics[DECODE_COL] == 47.6
+
+    def test_parse_kv_and_prefix(self):
+        metrics = parse_streaming_metrics_from_log(self.SAMPLE_LOG)
+        assert metrics['metric_max_kv_cache_usage_percent'] == 12.5
+        assert metrics['metric_avg_prefix_cache_hit_rate_percent'] == 33.3
+
+    def test_empty_log(self):
+        metrics = parse_streaming_metrics_from_log('')
+        assert metrics[PREFILL_COL] == 0.0
+        assert metrics[DECODE_COL] == 0.0
+
+
+class TestUseCaseCliName:
+    def test_from_slug(self):
+        assert use_case_cli_name('ignored', 'long_summarization') == 'long-summarization'
+
+    def test_from_display(self):
+        assert use_case_cli_name('📝 Summarization') == 'summarization'
+
+
+class TestCoefficientOfVariation:
+    def test_basic(self):
+        assert compute_coefficient_of_variation(10.0, 1.0) == 0.1
+
+    def test_zero_mean(self):
+        assert compute_coefficient_of_variation(0.0, 1.0) == 0.0
+
+
+class TestCsvImportMap:
+    def test_export_headers_mapped(self):
+        assert IMPORT_CSV_COLUMN_MAP['Req/sec'] == METRIC_RPS
+        assert IMPORT_CSV_COLUMN_MAP['Use Case'] == 'use_case'
 
 
 if __name__ == "__main__":

--- a/automation/test-execution/tests/scripts/test_run_offline_batch_suite.sh
+++ b/automation/test-execution/tests/scripts/test_run_offline_batch_suite.sh
@@ -162,6 +162,107 @@ test_all_keyword_expansion() {
     assert_equals "3" "${#MODELS[@]}" "'all' expands to 3 production models"
 }
 
+# ── count_existing_results fixture tests ─────────────────────────────────────
+# This function mirrors count_existing_results() in run-offline-batch-suite.sh.
+# If the find/grep logic changes in the script, update this definition too.
+_count_existing_results() {
+    local model="$1" ansible_use_case="$2" cores="$3" dataset="$4" num_prompts="$5"
+    local sanitized_model="${model//\//__}"
+    local results_base="${REPO_ROOT}/results/llm/${sanitized_model}"
+    [[ ! -d "$results_base" ]] && { echo 0; return; }
+    local file_list
+    file_list=$(find "$results_base" \
+        -path "*/${cores}cores-${dataset}-${num_prompts}prompts/results.json" 2>/dev/null)
+    [[ -z "$file_list" ]] && { echo 0; return; }
+    local count
+    count=$(echo "$file_list" | xargs grep -l "\"use_case\": \"${ansible_use_case}\"" 2>/dev/null | wc -l | tr -d ' ') || true
+    echo "${count:-0}"
+}
+
+# Write a minimal results.json with the given use_case into the given directory
+_make_result() {
+    local dir="$1" use_case="$2"
+    mkdir -p "$dir"
+    printf '{"use_case": "%s", "throughput": 1.0}\n' "$use_case" > "$dir/results.json"
+}
+
+# Test 9: returns 0 when the model results directory does not exist
+test_count_no_results_dir() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' RETURN
+    local REPO_ROOT="$tmpdir"
+    local result
+    result=$(_count_existing_results "model/foo" "summarization" 16 "sharegpt" 1000)
+    assert_equals "0" "$result" "count returns 0 when no results dir exists"
+}
+
+# Test 10: full skip - all 3 runs already complete
+test_count_full_skip() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' RETURN
+    local REPO_ROOT="$tmpdir"
+    _make_result "$tmpdir/results/llm/model__foo/run1/16cores-sharegpt-1000prompts" "summarization"
+    _make_result "$tmpdir/results/llm/model__foo/run2/16cores-sharegpt-1000prompts" "summarization"
+    _make_result "$tmpdir/results/llm/model__foo/run3/16cores-sharegpt-1000prompts" "summarization"
+    local result
+    result=$(_count_existing_results "model/foo" "summarization" 16 "sharegpt" 1000)
+    assert_equals "3" "$result" "count returns 3 when 3 runs are complete (full skip)"
+}
+
+# Test 11: partial resume - 2 of 3 runs complete
+test_count_partial_resume() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' RETURN
+    local REPO_ROOT="$tmpdir"
+    _make_result "$tmpdir/results/llm/model__foo/run1/16cores-sharegpt-1000prompts" "summarization"
+    _make_result "$tmpdir/results/llm/model__foo/run2/16cores-sharegpt-1000prompts" "summarization"
+    local result
+    result=$(_count_existing_results "model/foo" "summarization" 16 "sharegpt" 1000)
+    assert_equals "2" "$result" "count returns 2 when 2 of 3 runs are complete (partial resume)"
+}
+
+# Test 12: no false match across use cases (same dataset/prompts/cores, different use_case)
+test_count_no_false_match_use_case() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' RETURN
+    local REPO_ROOT="$tmpdir"
+    _make_result "$tmpdir/results/llm/model__foo/run1/16cores-sharegpt-1000prompts" "summarization"
+    _make_result "$tmpdir/results/llm/model__foo/run2/16cores-sharegpt-1000prompts" "summarization"
+    local result
+    result=$(_count_existing_results "model/foo" "classification" 16 "sharegpt" 1000)
+    assert_equals "0" "$result" "summarization results do not count toward classification sweep"
+}
+
+# Test 13: prompt count isolation (500-prompt results must not count toward 1000-prompt sweep)
+test_count_prompt_isolation() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' RETURN
+    local REPO_ROOT="$tmpdir"
+    _make_result "$tmpdir/results/llm/model__foo/run1/16cores-sharegpt-500prompts" "summarization"
+    _make_result "$tmpdir/results/llm/model__foo/run2/16cores-sharegpt-500prompts" "summarization"
+    local result
+    result=$(_count_existing_results "model/foo" "summarization" 16 "sharegpt" 1000)
+    assert_equals "0" "$result" "500-prompt results do not count toward 1000-prompt sweep"
+}
+
+# Test 14: dataset name isolation (sonnet results must not count toward sharegpt sweep)
+test_count_dataset_isolation() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' RETURN
+    local REPO_ROOT="$tmpdir"
+    _make_result "$tmpdir/results/llm/model__foo/run1/16cores-sonnet-500prompts" "etl"
+    _make_result "$tmpdir/results/llm/model__foo/run2/16cores-sonnet-500prompts" "etl"
+    local result
+    result=$(_count_existing_results "model/foo" "etl" 16 "sharegpt" 500)
+    assert_equals "0" "$result" "sonnet results do not count toward sharegpt sweep"
+}
+
 # Main test execution
 echo "=========================================="
 echo "run-offline-batch-suite.sh Unit Tests"
@@ -176,6 +277,12 @@ test_default_container_image
 test_usage_message
 test_comma_separated_models
 test_all_keyword_expansion
+test_count_no_results_dir
+test_count_full_skip
+test_count_partial_resume
+test_count_no_false_match_use_case
+test_count_prompt_isolation
+test_count_dataset_isolation
 
 echo
 echo "=========================================="

--- a/automation/test-execution/tests/scripts/test_run_offline_batch_suite.sh
+++ b/automation/test-execution/tests/scripts/test_run_offline_batch_suite.sh
@@ -376,6 +376,23 @@ test_resume_failure_propagation() {
     run_test() { return 0; }
 }
 
+# ── cap_prompts tests ─────────────────────────────────────────────────────────
+# cap_prompts is sourced from offline-batch-helpers.sh via HELPERS_LIB above.
+
+# Test 19: cap active — input above cap returns the cap value
+test_cap_prompts_capped() {
+    local result
+    result=$(OFFLINE_BATCH_MAX_PROMPTS=100 cap_prompts 1000)
+    assert_equals "100" "$result" "cap_prompts: 1000 capped to 100 when MAX_PROMPTS=100"
+}
+
+# Test 20: cap disabled — OFFLINE_BATCH_MAX_PROMPTS=0 returns the original value
+test_cap_prompts_disabled() {
+    local result
+    result=$(OFFLINE_BATCH_MAX_PROMPTS=0 cap_prompts 1000)
+    assert_equals "1000" "$result" "cap_prompts: 1000 unchanged when MAX_PROMPTS=0 (cap disabled)"
+}
+
 # Main test execution
 echo "=========================================="
 echo "run-offline-batch-suite.sh Unit Tests"
@@ -400,6 +417,8 @@ test_resume_full_skip
 test_resume_partial
 test_resume_force_bypass
 test_resume_failure_propagation
+test_cap_prompts_capped
+test_cap_prompts_disabled
 
 echo
 echo "=========================================="

--- a/automation/test-execution/tests/scripts/test_run_offline_batch_suite.sh
+++ b/automation/test-execution/tests/scripts/test_run_offline_batch_suite.sh
@@ -179,11 +179,13 @@ _count_existing_results() {
     echo "${count:-0}"
 }
 
-# Write a minimal results.json with the given use_case into the given directory
+# Write a minimal results.json matching the real schema into the given directory.
+# use_case lives under dataset_config, which is what the grep in count_existing_results targets.
 _make_result() {
     local dir="$1" use_case="$2"
     mkdir -p "$dir"
-    printf '{"use_case": "%s", "throughput": 1.0}\n' "$use_case" > "$dir/results.json"
+    printf '{"test_type": "offline-batch", "dataset_config": {"use_case": "%s"}}\n' \
+        "$use_case" > "$dir/results.json"
 }
 
 # Test 9: returns 0 when the model results directory does not exist

--- a/automation/test-execution/tests/scripts/test_run_offline_batch_suite.sh
+++ b/automation/test-execution/tests/scripts/test_run_offline_batch_suite.sh
@@ -4,17 +4,21 @@
 # Tests bash script functionality:
 # - Model list parsing ("all", comma-separated, single)
 # - Parameter validation
-# - Command construction
+# - count_existing_results: path/use-case/dataset/prompt isolation
+# - run_with_resume: skip, partial resume, --force bypass, failure propagation
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SUITE_SCRIPT="$SCRIPT_DIR/../../scripts/bash/run-offline-batch-suite.sh"
+HELPERS_LIB="$SCRIPT_DIR/../../scripts/bash/helpers/offline-batch-helpers.sh"
 
-# Colors for test output
-GREEN='\033[0;32m'
-RED='\033[0;31m'
-NC='\033[0m'
+# Source shared helpers so count_existing_results and run_with_resume are available
+# directly — no duplication of the function logic in this file.
+source "$HELPERS_LIB"
+
+# Colors for test output (already defined by helpers lib, kept here for clarity)
+# GREEN / RED / NC come from HELPERS_LIB
 
 # Test counters
 TESTS_RUN=0
@@ -58,10 +62,26 @@ assert_contains() {
     fi
 }
 
-# Source the script functions (without executing main)
+assert_not_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local test_name="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [[ "$haystack" != *"$needle"* ]]; then
+        echo -e "${GREEN}✓${NC} $test_name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo -e "${RED}✗${NC} $test_name"
+        echo "  Expected NOT to contain: $needle"
+        echo "  Actual: $haystack"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# Source the script variables (without executing main)
 source_script_functions() {
-    # Extract just the function definitions, not the main execution
-    # This is a bit hacky but works for testing
     export MODEL_TINY_PRUNED="RedHatAI/TinyLlama-1.1B-Chat-v1.0-pruned2.4"
     export MODEL_LLAMA_W8A8="RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8"
     export MODEL_LLAMA_W4A16="RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16"
@@ -69,6 +89,20 @@ source_script_functions() {
     export ALL_MODELS="$MODEL_LLAMA_W8A8,$MODEL_LLAMA_W4A16,$MODEL_QWEN_W4A16"
     export VLLM_CONTAINER_IMAGE="vllm/vllm-openai:latest"
 }
+
+# Write a minimal results.json matching the real schema into the given directory.
+# use_case lives under dataset_config, matching the grep pattern in count_existing_results.
+_make_result() {
+    local dir="$1" use_case="$2"
+    mkdir -p "$dir"
+    printf '{"test_type": "offline-batch", "dataset_config": {"use_case": "%s"}}\n' \
+        "$use_case" > "$dir/results.json"
+}
+
+# Default no-op run_test stub — overridden per test as needed.
+run_test() { return 0; }
+
+# ── Script smoke tests ────────────────────────────────────────────────────────
 
 # Test 1: Check if script exists
 test_script_exists() {
@@ -163,30 +197,8 @@ test_all_keyword_expansion() {
 }
 
 # ── count_existing_results fixture tests ─────────────────────────────────────
-# This function mirrors count_existing_results() in run-offline-batch-suite.sh.
-# If the find/grep logic changes in the script, update this definition too.
-_count_existing_results() {
-    local model="$1" ansible_use_case="$2" cores="$3" dataset="$4" num_prompts="$5"
-    local sanitized_model="${model//\//__}"
-    local results_base="${REPO_ROOT}/results/llm/${sanitized_model}"
-    [[ ! -d "$results_base" ]] && { echo 0; return; }
-    local file_list
-    file_list=$(find "$results_base" \
-        -path "*/${cores}cores-${dataset}-${num_prompts}prompts/results.json" 2>/dev/null)
-    [[ -z "$file_list" ]] && { echo 0; return; }
-    local count
-    count=$(echo "$file_list" | xargs grep -l "\"use_case\": \"${ansible_use_case}\"" 2>/dev/null | wc -l | tr -d ' ') || true
-    echo "${count:-0}"
-}
-
-# Write a minimal results.json matching the real schema into the given directory.
-# use_case lives under dataset_config, which is what the grep in count_existing_results targets.
-_make_result() {
-    local dir="$1" use_case="$2"
-    mkdir -p "$dir"
-    printf '{"test_type": "offline-batch", "dataset_config": {"use_case": "%s"}}\n' \
-        "$use_case" > "$dir/results.json"
-}
+# These tests use count_existing_results directly from offline-batch-helpers.sh
+# (no inline copy needed).
 
 # Test 9: returns 0 when the model results directory does not exist
 test_count_no_results_dir() {
@@ -195,7 +207,7 @@ test_count_no_results_dir() {
     trap 'rm -rf "$tmpdir"' RETURN
     local REPO_ROOT="$tmpdir"
     local result
-    result=$(_count_existing_results "model/foo" "summarization" 16 "sharegpt" 1000)
+    result=$(count_existing_results "model/foo" "summarization" 16 "sharegpt" 1000)
     assert_equals "0" "$result" "count returns 0 when no results dir exists"
 }
 
@@ -209,7 +221,7 @@ test_count_full_skip() {
     _make_result "$tmpdir/results/llm/model__foo/run2/16cores-sharegpt-1000prompts" "summarization"
     _make_result "$tmpdir/results/llm/model__foo/run3/16cores-sharegpt-1000prompts" "summarization"
     local result
-    result=$(_count_existing_results "model/foo" "summarization" 16 "sharegpt" 1000)
+    result=$(count_existing_results "model/foo" "summarization" 16 "sharegpt" 1000)
     assert_equals "3" "$result" "count returns 3 when 3 runs are complete (full skip)"
 }
 
@@ -222,7 +234,7 @@ test_count_partial_resume() {
     _make_result "$tmpdir/results/llm/model__foo/run1/16cores-sharegpt-1000prompts" "summarization"
     _make_result "$tmpdir/results/llm/model__foo/run2/16cores-sharegpt-1000prompts" "summarization"
     local result
-    result=$(_count_existing_results "model/foo" "summarization" 16 "sharegpt" 1000)
+    result=$(count_existing_results "model/foo" "summarization" 16 "sharegpt" 1000)
     assert_equals "2" "$result" "count returns 2 when 2 of 3 runs are complete (partial resume)"
 }
 
@@ -235,7 +247,7 @@ test_count_no_false_match_use_case() {
     _make_result "$tmpdir/results/llm/model__foo/run1/16cores-sharegpt-1000prompts" "summarization"
     _make_result "$tmpdir/results/llm/model__foo/run2/16cores-sharegpt-1000prompts" "summarization"
     local result
-    result=$(_count_existing_results "model/foo" "classification" 16 "sharegpt" 1000)
+    result=$(count_existing_results "model/foo" "classification" 16 "sharegpt" 1000)
     assert_equals "0" "$result" "summarization results do not count toward classification sweep"
 }
 
@@ -248,7 +260,7 @@ test_count_prompt_isolation() {
     _make_result "$tmpdir/results/llm/model__foo/run1/16cores-sharegpt-500prompts" "summarization"
     _make_result "$tmpdir/results/llm/model__foo/run2/16cores-sharegpt-500prompts" "summarization"
     local result
-    result=$(_count_existing_results "model/foo" "summarization" 16 "sharegpt" 1000)
+    result=$(count_existing_results "model/foo" "summarization" 16 "sharegpt" 1000)
     assert_equals "0" "$result" "500-prompt results do not count toward 1000-prompt sweep"
 }
 
@@ -261,8 +273,107 @@ test_count_dataset_isolation() {
     _make_result "$tmpdir/results/llm/model__foo/run1/16cores-sonnet-500prompts" "etl"
     _make_result "$tmpdir/results/llm/model__foo/run2/16cores-sonnet-500prompts" "etl"
     local result
-    result=$(_count_existing_results "model/foo" "etl" 16 "sharegpt" 500)
+    result=$(count_existing_results "model/foo" "etl" 16 "sharegpt" 500)
     assert_equals "0" "$result" "sonnet results do not count toward sharegpt sweep"
+}
+
+# ── run_with_resume tests ─────────────────────────────────────────────────────
+# run_test is stubbed per test. Stubs write to a calls file so we can verify
+# call count from the parent after the subshell exits.
+
+# Test 15: full skip — run_test must not be called when all runs exist
+test_resume_full_skip() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' RETURN
+    local REPO_ROOT="$tmpdir"
+    _make_result "$tmpdir/results/llm/model__foo/run1/16cores-sharegpt-1000prompts" "summarization"
+    _make_result "$tmpdir/results/llm/model__foo/run2/16cores-sharegpt-1000prompts" "summarization"
+    _make_result "$tmpdir/results/llm/model__foo/run3/16cores-sharegpt-1000prompts" "summarization"
+
+    local calls_file="$tmpdir/calls.log"
+    run_test() { echo "called" >> "$calls_file"; return 0; }
+
+    local output
+    output=$(OFFLINE_BATCH_FORCE=0 run_with_resume \
+        "model/foo" "summarization" "sharegpt" 1000 16 3 -e "use_case=summarization" 2>&1)
+
+    assert_contains "$output" "SKIP" "full skip: SKIP message shown"
+    local call_count=0
+    [[ -f "$calls_file" ]] && call_count=$(wc -l < "$calls_file" | tr -d ' ')
+    assert_equals "0" "$call_count" "full skip: run_test not called"
+
+    # Restore default stub
+    run_test() { return 0; }
+}
+
+# Test 16: partial resume — correct run number shown, run_test called once for the missing run
+test_resume_partial() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' RETURN
+    local REPO_ROOT="$tmpdir"
+    _make_result "$tmpdir/results/llm/model__foo/run1/16cores-sharegpt-1000prompts" "summarization"
+    _make_result "$tmpdir/results/llm/model__foo/run2/16cores-sharegpt-1000prompts" "summarization"
+
+    local calls_file="$tmpdir/calls.log"
+    run_test() { echo "called" >> "$calls_file"; return 0; }
+
+    local output
+    output=$(OFFLINE_BATCH_FORCE=0 run_with_resume \
+        "model/foo" "summarization" "sharegpt" 1000 16 3 -e "use_case=summarization" 2>&1)
+
+    assert_contains "$output" "Run 3/3" "partial resume: run display shows Run 3/3"
+    local call_count=0
+    [[ -f "$calls_file" ]] && call_count=$(wc -l < "$calls_file" | tr -d ' ')
+    assert_equals "1" "$call_count" "partial resume: run_test called exactly once"
+
+    run_test() { return 0; }
+}
+
+# Test 17: --force bypass — run_test called for all runs even when results exist
+test_resume_force_bypass() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' RETURN
+    local REPO_ROOT="$tmpdir"
+    _make_result "$tmpdir/results/llm/model__foo/run1/16cores-sharegpt-1000prompts" "summarization"
+    _make_result "$tmpdir/results/llm/model__foo/run2/16cores-sharegpt-1000prompts" "summarization"
+    _make_result "$tmpdir/results/llm/model__foo/run3/16cores-sharegpt-1000prompts" "summarization"
+
+    local calls_file="$tmpdir/calls.log"
+    run_test() { echo "called" >> "$calls_file"; return 0; }
+
+    local output
+    output=$(OFFLINE_BATCH_FORCE=1 run_with_resume \
+        "model/foo" "summarization" "sharegpt" 1000 16 3 -e "use_case=summarization" 2>&1)
+
+    assert_not_contains "$output" "SKIP" "force: no SKIP message shown"
+    assert_contains "$output" "force" "force: force message shown"
+    local call_count=0
+    [[ -f "$calls_file" ]] && call_count=$(wc -l < "$calls_file" | tr -d ' ')
+    assert_equals "3" "$call_count" "force: run_test called 3 times"
+
+    run_test() { return 0; }
+}
+
+# Test 18: failure propagation — run_with_resume returns 1 when run_test fails
+test_resume_failure_propagation() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' RETURN
+    local REPO_ROOT="$tmpdir"
+
+    run_test() { return 1; }
+
+    local result="pass"
+    OFFLINE_BATCH_FORCE=0 run_with_resume \
+        "model/foo" "summarization" "sharegpt" 1000 16 1 -e "use_case=summarization" \
+        >/dev/null 2>&1 && result="pass" || result="fail"
+
+    assert_equals "fail" "$result" "failure propagation: run_with_resume returns 1 when run_test fails"
+
+    run_test() { return 0; }
 }
 
 # Main test execution
@@ -285,6 +396,10 @@ test_count_partial_resume
 test_count_no_false_match_use_case
 test_count_prompt_isolation
 test_count_dataset_isolation
+test_resume_full_skip
+test_resume_partial
+test_resume_force_bypass
+test_resume_failure_propagation
 
 echo
 echo "=========================================="


### PR DESCRIPTION
## Summary

Adds skip/resume logic to both `use-cases` and `use-case-sweep` modes so re-running after interruption does not redo already-completed tests.

### What changed

**Resume / skip logic (`run-offline-batch-suite.sh`)**
- New `run_with_resume()` helper encapsulates all skip/partial-resume logic; both `use_cases_suite()` and `use_case_sweep()` call it so behaviour is identical across both entry points
- Counting is per **model × use-case × cores × dataset × num_prompts** — a 500-prompt summarization result never satisfies a 1000-prompt sweep, and summarization results cannot satisfy a classification counter
- Partial runs resume from the correct run number (`Run 3/3` after 2 existing, not `Run 1/3`)
- `failed_tests` summary stays at config-level; per-run failures print a coloured `FAILED: Run X/Y` line in the log for debuggability

**`--force` flag**
- `--force` (or `OFFLINE_BATCH_FORCE=1`) bypasses skip/resume and always runs the full requested iteration count
- Parsed in `main()` before mode dispatch — works with both `use-cases` and `use-case-sweep`
- Documented in `usage()` under FLAGS and in both mode descriptions

**Result counting (`count_existing_results`)**
- Accepts `dataset` and `num_prompts` in addition to `model`, `ansible_use_case`, and `cores`
- `find` path narrowed to `*/${cores}cores-${dataset}-${num_prompts}prompts/results.json`
- `ansible_use_case` is now set explicitly in each `case` branch of `use_case_sweep()` — removed the fragile `grep -o 'use_case=...' | cut -d= -f2` parsing
- Guarded the grep pipeline with `|| true` to prevent `set -o pipefail` from exiting the script when files match the path but not the use_case (latent bug)

**Ansible cache race fix (`llm-benchmark-offline-batch.yml`)**
- Model cache check now tests for `snapshots/` subdir rather than the base model dir; the base dir is created early in the download so the old check gave false hits during parallel runs on a fresh DUT

**`ALL_MODELS` / TinyLlama**
- `ALL_MODELS` (used by `use-cases all` and `use-case-sweep … all`) contains the 3 production RedHatAI models: Llama w8a8, Llama w4a16, Qwen w4a16
- TinyLlama is excluded because its 2048-token context cannot handle RAG (2048-token input) or long-summarization (4096-token input) use cases
- **User-visible**: anyone relying on `use-cases 5 all` to benchmark TinyLlama should pass it explicitly: `use-cases 5 RedHatAI/TinyLlama-1.1B-Chat-v1.0-pruned2.4`
- `usage()` documents this clearly

**Unit tests (`test_run_offline_batch_suite.sh`)**
- 6 new fixture-based tests for `count_existing_results`: no-dir (→ 0), full-skip (3/3), partial-resume (2/3), cross-use-case isolation, prompt-count isolation, dataset-name isolation
- Fixtures now use the real `results.json` schema (`use_case` nested under `dataset_config`)

## Test plan

- [ ] Manually verify full skip: 3 existing results for a config → prints SKIP, runs 0
- [ ] Manually verify partial resume: 2/3 complete → runs 1 more, displays `Run 3/3`
- [ ] Manually verify use-case isolation: summarization results must not count toward classification sweep
- [ ] Manually verify `--force`: with existing results, still runs all requested iterations
- [ ] Run unit tests: `bash automation/test-execution/tests/scripts/test_run_offline_batch_suite.sh`

## Known follow-ups (non-blocking)

- `count_existing_results` is duplicated between the script and test file with a sync comment — longer-term, extract to a sourced helper or test against the script directly
- `run_with_resume()` and `--force` bypass are not covered by unit tests; integration behaviour would require a fuller test harness
- Ansible cache check: if `snapshots/` exists but contains no hash subdirs, parallel runners could still both attempt download; a stricter check (require a non-empty hash dir) is a future improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)