### PR TITLE
fix(embedding-dashboard): fix empty Concurrent Load tab

### DIFF
--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/3_📊_Embedding_Metrics.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/3_📊_Embedding_Metrics.py
@@ -109,7 +109,7 @@ def load_embedding_data(results_dir: str) -> pd.DataFrame:
 
                         # Extract test_name from test_run_id (format: test_name-YYYYMMDD-HHMMSS or just YYYYMMDD-HHMMSS)
                         test_run_id = metadata.get('test_run_id', 'unknown')
-                        test_name = None
+                        test_name = ''
                         if test_run_id != 'unknown' and '-' in test_run_id:
                             parts = test_run_id.split('-')
                             # If more than 2 parts (date-time), first part(s) are test_name
@@ -1560,10 +1560,21 @@ def main():
         with col6:
             # Scenario filter - remove empty strings and deduplicate
             scenarios = sorted(set([s for s in df['scenario'].unique() if s and s.strip()]))
+            # Auto-select newly available scenarios: Streamlit preserves widget state across
+            # reruns, so if the session started when only 'baseline' existed, 'latency' and
+            # 'all' would silently stay deselected after data is added. Fix: whenever the
+            # available scenario set grows, merge the new scenarios into the selection.
+            _scenario_key = '_embedding_scenario_filter'
+            _scenario_opts_key = '_embedding_scenario_opts'
+            if st.session_state.get(_scenario_opts_key) != scenarios:
+                prev_selection = set(st.session_state.get(_scenario_key, scenarios))
+                st.session_state[_scenario_key] = sorted(prev_selection | set(scenarios))
+                st.session_state[_scenario_opts_key] = scenarios
             selected_scenarios = st.multiselect(
                 "Scenario",
                 options=scenarios,
                 default=scenarios,
+                key=_scenario_key,
                 help="Test scenario: baseline, latency, or all"
             )
 

--- a/automation/test-execution/dashboard-examples/vllm_dashboard/pages/3_📊_Embedding_Metrics.py
+++ b/automation/test-execution/dashboard-examples/vllm_dashboard/pages/3_📊_Embedding_Metrics.py
@@ -1560,15 +1560,19 @@ def main():
         with col6:
             # Scenario filter - remove empty strings and deduplicate
             scenarios = sorted(set([s for s in df['scenario'].unique() if s and s.strip()]))
-            # Auto-select newly available scenarios: Streamlit preserves widget state across
-            # reruns, so if the session started when only 'baseline' existed, 'latency' and
-            # 'all' would silently stay deselected after data is added. Fix: whenever the
-            # available scenario set grows, merge the new scenarios into the selection.
+            # Preserve deselections while auto-selecting newly available scenarios:
+            # intersect prev_selection with current scenarios (drops gone options and
+            # respects user deselections), then union only the net-new scenarios so
+            # they are selected by default when they first appear.
             _scenario_key = '_embedding_scenario_filter'
             _scenario_opts_key = '_embedding_scenario_opts'
             if st.session_state.get(_scenario_opts_key) != scenarios:
+                prev_opts = set(st.session_state.get(_scenario_opts_key, []))
                 prev_selection = set(st.session_state.get(_scenario_key, scenarios))
-                st.session_state[_scenario_key] = sorted(prev_selection | set(scenarios))
+                new_scenarios = set(scenarios) - prev_opts
+                st.session_state[_scenario_key] = sorted(
+                    (prev_selection & set(scenarios)) | new_scenarios
+                )
                 st.session_state[_scenario_opts_key] = scenarios
             selected_scenarios = st.multiselect(
                 "Scenario",


### PR DESCRIPTION
## Summary

Two bugs caused the Concurrent Load tab (first tab on the Embedding Metrics dashboard) to always render blank despite latency result files being present on disk.

### Bug 1 — `test_name=None` silently drops all rows from groupby

`load_embedding_data` set `test_name = None` for all standard runs whose `test_run_id` is a plain `YYYYMMDD-HHMMSS` timestamp (exactly 2 dash-separated parts, so the `len(parts) > 2` guard never triggered). When that `None` reaches a pandas `groupby`, pandas drops every row where any key is `NaN` by default — leaving 0 groups and no chart traces, even though 60 concurrent rows were loaded.

**Fix:** default `test_name` to `''` so the groupby retains all rows; the existing `if test_name and test_name.strip()` label check continues to handle the empty-string case correctly.

### Bug 2 — Scenario filter widget state stuck on `['baseline']`

Streamlit preserves multiselect widget state across reruns within a session. If the dashboard was first opened when only July 31 baseline-only runs existed, the Scenario filter defaulted to `['baseline']` and that was locked into session state. After Aug 4 latency/all scenario data was added and the cache refreshed, Streamlit kept `['baseline']` selected (still a valid option) — silently filtering out all concurrent rows, which exclusively carry `scenario='latency'` or `scenario='all'`.

**Fix:** track the available scenario set in `st.session_state`; whenever new scenarios appear that aren't in the current selection, merge them in automatically.

## Test plan
- [ ] Open Embedding Metrics page with a fresh session — Concurrent Load tab shows data
- [ ] Open with a session that had only baseline scenario selected — tab now shows concurrent data after reload
- [ ] Saturation Analysis and Core Scaling tabs unaffected