### PR TITLE
feat(cpueval): add install command for system deps and Ansible collec…

### DIFF
--- a/.github/workflows/cpueval-tests.yml
+++ b/.github/workflows/cpueval-tests.yml
@@ -65,6 +65,33 @@ jobs:
           python -m cpueval --suite rhaiis-sweep --dry-run
           python -m cpueval run --suite rhaiis-sweep --dry-run
 
+  container-smoke:
+    name: CLI container (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubi9
+            image: registry.access.redhat.com/ubi9/ubi:latest
+          - name: fedora
+            image: fedora:latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Smoke launcher and install in ${{ matrix.name }}
+        run: |
+          docker run --rm \
+            --user 0 \
+            -e HOME=/tmp/cpueval-home \
+            -v "$PWD:/src" \
+            -w /src \
+            "${{ matrix.image }}" \
+            bash /src/automation/cli/tests/container-smoke.sh
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cpueval-tests.yml
+++ b/.github/workflows/cpueval-tests.yml
@@ -5,10 +5,12 @@ name: cpueval CLI Tests
     branches: [main]
     paths:
       - "automation/cli/**"
+      - "cpueval"
       - ".github/workflows/cpueval-tests.yml"
   pull_request:
     paths:
       - "automation/cli/**"
+      - "cpueval"
       - ".github/workflows/cpueval-tests.yml"
 
 permissions:

--- a/automation/cli/README.md
+++ b/automation/cli/README.md
@@ -124,7 +124,7 @@ done
 
 ### install - Install prerequisites
 ```bash
-# Full install: system packages (dnf) + Ansible collections + shell completion
+# Full install: system packages + Ansible collections + shell completion
 ./cpueval install
 
 # Skip system packages if already installed
@@ -137,10 +137,12 @@ done
 ./cpueval install --dry-run
 ```
 
-On RHEL/Fedora this installs `ansible-core`, `python3-pip`, `git` via `dnf` and
-the required Ansible Galaxy collections. On macOS/Ubuntu the dnf step is
-soft-skipped with a `brew`/`apt` one-liner hint; install Ansible manually then
-re-run `./cpueval install --skip-system-deps`.
+On RHEL/Fedora this installs `python3-pip` and `git` via `dnf`, then
+`ansible-core` from dnf when the RPM exists. UBI 9 (and other hosts without
+that RPM) fall back to `pip install ansible-core` in the cpueval venv so
+`ansible-galaxy` is available for the collections step. If pip cannot install
+Ansible, the error includes a `brew`/`apt` one-liner; install Ansible manually
+then re-run `./cpueval install --skip-system-deps`.
 
 Shell completion is installed for bash/zsh and registered for both `cpueval`
 and `./cpueval`. Restart the shell (`exec bash` or `exec zsh`) once, then

--- a/automation/cli/README.md
+++ b/automation/cli/README.md
@@ -120,6 +120,23 @@ done
 ./cpueval show audio
 ```
 
+### install - Install prerequisites
+```bash
+# Full install: system packages (dnf) + Ansible collections
+./cpueval install
+
+# Skip system packages if already installed
+./cpueval install --skip-system-deps
+
+# Preview without executing
+./cpueval install --dry-run
+```
+
+On RHEL/Fedora this installs `ansible-core`, `python3-pip`, `git` via `dnf` and
+the required Ansible Galaxy collections. On macOS/Ubuntu the dnf step is
+soft-skipped with a `brew`/`apt` one-liner hint; install Ansible manually then
+re-run `./cpueval install --skip-system-deps`.
+
 ### doctor - Health checks
 ```bash
 # Full check (including host ping)
@@ -441,7 +458,7 @@ rm -rf automation/cli/.venv
 
 **Ansible collection missing:**
 ```bash
-ansible-galaxy collection install containers.podman
+./cpueval install --skip-system-deps
 ```
 
 ## Development

--- a/automation/cli/README.md
+++ b/automation/cli/README.md
@@ -31,7 +31,9 @@ Thin CLI wrapper for running full test matrices with easy overrides.
 
 ## Installation
 
-The `./cpueval` launcher automatically creates a virtual environment and installs dependencies on first run.
+The `./cpueval` launcher automatically creates a virtual environment and installs
+dependencies on first run. It requires Python 3.10+; on RHEL 9 / UBI 9 it will
+install `python3.12` via dnf if `python3` is 3.9.
 
 For manual installation:
 ```bash

--- a/automation/cli/README.md
+++ b/automation/cli/README.md
@@ -122,11 +122,14 @@ done
 
 ### install - Install prerequisites
 ```bash
-# Full install: system packages (dnf) + Ansible collections
+# Full install: system packages (dnf) + Ansible collections + shell completion
 ./cpueval install
 
 # Skip system packages if already installed
 ./cpueval install --skip-system-deps
+
+# Skip tab-completion setup
+./cpueval install --skip-completion
 
 # Preview without executing
 ./cpueval install --dry-run
@@ -136,6 +139,10 @@ On RHEL/Fedora this installs `ansible-core`, `python3-pip`, `git` via `dnf` and
 the required Ansible Galaxy collections. On macOS/Ubuntu the dnf step is
 soft-skipped with a `brew`/`apt` one-liner hint; install Ansible manually then
 re-run `./cpueval install --skip-system-deps`.
+
+Shell completion is installed for bash/zsh and registered for both `cpueval`
+and `./cpueval`. Restart the shell (`exec bash` or `exec zsh`) once, then
+`./cpueval <TAB>` completes commands. Use `--skip-completion` to opt out.
 
 ### doctor - Health checks
 ```bash

--- a/automation/cli/src/cpueval/cli.py
+++ b/automation/cli/src/cpueval/cli.py
@@ -793,7 +793,7 @@ def profiles():
 @app.command()
 def install(
     skip_system_deps: bool = typer.Option(
-        False, "--skip-system-deps", help="Skip system package installation (dnf)"
+        False, "--skip-system-deps", help="Skip system package installation (dnf/pip)"
     ),
     skip_collections: bool = typer.Option(
         False, "--skip-collections", help="Skip Ansible collection installation"

--- a/automation/cli/src/cpueval/cli.py
+++ b/automation/cli/src/cpueval/cli.py
@@ -798,12 +798,16 @@ def install(
     skip_collections: bool = typer.Option(
         False, "--skip-collections", help="Skip Ansible collection installation"
     ),
+    skip_completion: bool = typer.Option(
+        False, "--skip-completion", help="Skip shell tab-completion setup"
+    ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Print commands without running them"),
 ):
-    """Install prerequisites: system packages (dnf) and Ansible collections."""
+    """Install prerequisites: system packages, Ansible collections, and shell completion."""
     exit_code = run_install(
         skip_system_deps=skip_system_deps,
         skip_collections=skip_collections,
+        skip_completion=skip_completion,
         dry_run=dry_run,
     )
     raise typer.Exit(exit_code)

--- a/automation/cli/src/cpueval/cli.py
+++ b/automation/cli/src/cpueval/cli.py
@@ -24,6 +24,7 @@ from cpueval.results import (
     find_latest_result,
     find_latest_embedding_result,
 )
+from cpueval.install import run_install
 from cpueval.offline_batch import build_offline_batch_args
 from cpueval.runners import (
     load_profile,
@@ -787,6 +788,25 @@ def profiles():
         "[dim]Use with:[/dim] cpueval --suite <suite> --profile <name>"
     )
     console.print()
+
+
+@app.command()
+def install(
+    skip_system_deps: bool = typer.Option(
+        False, "--skip-system-deps", help="Skip system package installation (dnf)"
+    ),
+    skip_collections: bool = typer.Option(
+        False, "--skip-collections", help="Skip Ansible collection installation"
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Print commands without running them"),
+):
+    """Install prerequisites: system packages (dnf) and Ansible collections."""
+    exit_code = run_install(
+        skip_system_deps=skip_system_deps,
+        skip_collections=skip_collections,
+        dry_run=dry_run,
+    )
+    raise typer.Exit(exit_code)
 
 
 @app.command()

--- a/automation/cli/src/cpueval/doctor.py
+++ b/automation/cli/src/cpueval/doctor.py
@@ -177,7 +177,9 @@ def run_doctor(no_ping: bool = False) -> int:
         return 0
     else:
         console.print("\n[red]✗ Some checks failed[/red]\n")
-        console.print("[yellow]Tip:[/yellow] Set required environment variables:")
+        console.print("[yellow]Tip:[/yellow] Missing Ansible or collections? Run:")
+        console.print("  ./cpueval install")
+        console.print("\n[yellow]Tip:[/yellow] Set required environment variables:")
         console.print("  export DUT_HOSTNAME=<dut-host>")
         console.print("  export LOADGEN_HOSTNAME=<loadgen-host>")
         console.print("  export HF_TOKEN=<token>  # for gated models")

--- a/automation/cli/src/cpueval/install.py
+++ b/automation/cli/src/cpueval/install.py
@@ -1,5 +1,6 @@
 """Dependency installation helpers for cpueval."""
 
+import os
 import re
 import shutil
 import subprocess
@@ -19,6 +20,20 @@ _StepResult = Tuple[Optional[bool], str]
 
 def _requirements_path():
     return get_ansible_dir() / "requirements.yml"
+
+
+def _is_root() -> bool:
+    """Return True when running as root (containers / UBI images)."""
+    geteuid = getattr(os, "geteuid", None)
+    return geteuid is not None and geteuid() == 0
+
+
+def _dnf_install_cmd() -> List[str]:
+    """Build the dnf install command; skip sudo when already root."""
+    cmd = ["dnf", "install", "-y", *SYSTEM_PACKAGES]
+    if not _is_root() and shutil.which("sudo"):
+        cmd = ["sudo", *cmd]
+    return cmd
 
 
 def _run_streaming(cmd: List[str], timeout: int) -> Tuple[bool, str]:
@@ -48,7 +63,7 @@ def install_system_deps(dry_run: bool = False) -> _StepResult:
             "         On Ubuntu/Debian: sudo apt install -y ansible-core python3-pip git"
         )
 
-    cmd = ["sudo", "dnf", "install", "-y"] + SYSTEM_PACKAGES
+    cmd = _dnf_install_cmd()
     if dry_run:
         return True, f"[dry-run] would run: {' '.join(cmd)}"
 

--- a/automation/cli/src/cpueval/install.py
+++ b/automation/cli/src/cpueval/install.py
@@ -2,8 +2,7 @@
 
 import shutil
 import subprocess
-from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from rich.console import Console
 from rich.table import Table
@@ -12,53 +11,75 @@ from cpueval.paths import get_ansible_dir
 
 SYSTEM_PACKAGES = ["ansible-core", "python3-pip", "git"]
 
+# Status values: True = pass (green ✓), None = skipped (yellow ~), False = fail (red ✗)
+_StepResult = Tuple[Optional[bool], str]
 
-def _requirements_path() -> Path:
+
+def _requirements_path():
     return get_ansible_dir() / "requirements.yml"
 
 
-def install_system_deps(dry_run: bool = False) -> Tuple[bool, str]:
-    """Install system packages via dnf (RHEL/Fedora only)."""
+def _run_streaming(cmd: List[str], timeout: int) -> Tuple[bool, str]:
+    """Print cmd, stream stdout/stderr to the terminal, return (ok, detail)."""
+    console = Console()
+    console.print(f"[dim]Running:[/dim] {' '.join(cmd)}")
+    try:
+        result = subprocess.run(cmd, timeout=timeout)
+        if result.returncode == 0:
+            return True, "done"
+        return False, f"exited {result.returncode} — see output above"
+    except subprocess.TimeoutExpired:
+        return False, f"timed out after {timeout}s"
+    except Exception as e:
+        return False, str(e)
+
+
+def install_system_deps(dry_run: bool = False) -> _StepResult:
+    """Install system packages via dnf (RHEL/Fedora only).
+
+    Returns True on success, None when dnf is absent (soft-skip), False on error.
+    """
     if not shutil.which("dnf"):
-        return True, "dnf not found — skipping (not a RHEL/Fedora system)"
+        return None, (
+            "dnf not found — skipping (not a RHEL/Fedora system).\n"
+            "         On macOS: brew install ansible\n"
+            "         On Ubuntu/Debian: sudo apt install -y ansible-core python3-pip git"
+        )
 
     cmd = ["sudo", "dnf", "install", "-y"] + SYSTEM_PACKAGES
     if dry_run:
         return True, f"[dry-run] would run: {' '.join(cmd)}"
 
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
-        if result.returncode == 0:
-            return True, f"installed: {', '.join(SYSTEM_PACKAGES)}"
-        return False, result.stderr.strip() or result.stdout.strip() or "dnf failed"
-    except subprocess.TimeoutExpired:
-        return False, "dnf timed out"
-    except Exception as e:
-        return False, str(e)
+    ok, detail = _run_streaming(cmd, timeout=300)
+    if ok:
+        return True, f"installed: {', '.join(SYSTEM_PACKAGES)}"
+    return False, detail
 
 
-def install_ansible_collections(dry_run: bool = False) -> Tuple[bool, str]:
-    """Install Ansible collections from requirements.yml."""
+def install_ansible_collections(dry_run: bool = False) -> _StepResult:
+    """Install Ansible collections from requirements.yml.
+
+    Returns True on success, False on error.
+    """
     req = _requirements_path()
     if not req.exists():
         return False, f"requirements.yml not found: {req}"
 
     if not shutil.which("ansible-galaxy"):
-        return False, "ansible-galaxy not found in PATH"
+        return False, (
+            "ansible-galaxy not found in PATH — "
+            "install ansible-core first (cpueval install --skip-collections, "
+            "then re-run without the flag)"
+        )
 
     cmd = ["ansible-galaxy", "collection", "install", "-r", str(req)]
     if dry_run:
         return True, f"[dry-run] would run: {' '.join(cmd)}"
 
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
-        if result.returncode == 0:
-            return True, "collections installed"
-        return False, result.stderr.strip() or result.stdout.strip() or "ansible-galaxy failed"
-    except subprocess.TimeoutExpired:
-        return False, "ansible-galaxy timed out"
-    except Exception as e:
-        return False, str(e)
+    ok, detail = _run_streaming(cmd, timeout=300)
+    if ok:
+        return True, "collections installed"
+    return False, detail
 
 
 def run_install(
@@ -69,7 +90,7 @@ def run_install(
     """Run the full install sequence.
 
     Returns:
-        Exit code (0 = all enabled steps succeeded)
+        Exit code (0 = all enabled steps succeeded or soft-skipped)
     """
     console = Console()
     prefix = "[dim][dry-run][/dim] " if dry_run else ""
@@ -90,25 +111,29 @@ def run_install(
     table.add_column("Status", width=12)
     table.add_column("Details")
 
-    all_passed = True
+    rows = []
+    any_failed = False
     for step_name, step_fn in steps:
-        passed, details = step_fn()
-        all_passed = all_passed and passed
-        status_symbol = "✓" if passed else "✗"
-        status_color = "green" if passed else "red"
-        table.add_row(
-            step_name,
-            f"[{status_color}]{status_symbol}[/{status_color}]",
-            details,
-        )
+        ok, details = step_fn()
+        if ok is False:
+            any_failed = True
+            symbol, color = "✗", "red"
+        elif ok is None:
+            symbol, color = "~", "yellow"
+        else:
+            symbol, color = "✓", "green"
+        rows.append((step_name, f"[{color}]{symbol}[/{color}]", details))
 
+    console.print()  # blank line after streamed subprocess output
+    for row in rows:
+        table.add_row(*row)
     console.print(table)
 
-    if all_passed:
+    if not any_failed:
         console.print("\n[green]✓ Install complete[/green]\n")
         if not dry_run:
             console.print("Next step: verify with [bold]cpueval doctor[/bold]\n")
         return 0
 
-    console.print("\n[red]✗ Some steps failed[/red]\n")
+    console.print("\n[red]✗ Some steps failed — see output above for details[/red]\n")
     return 1

--- a/automation/cli/src/cpueval/install.py
+++ b/automation/cli/src/cpueval/install.py
@@ -1,0 +1,114 @@
+"""Dependency installation helpers for cpueval."""
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List, Tuple
+
+from rich.console import Console
+from rich.table import Table
+
+from cpueval.paths import get_ansible_dir
+
+SYSTEM_PACKAGES = ["ansible-core", "python3-pip", "git"]
+
+
+def _requirements_path() -> Path:
+    return get_ansible_dir() / "requirements.yml"
+
+
+def install_system_deps(dry_run: bool = False) -> Tuple[bool, str]:
+    """Install system packages via dnf (RHEL/Fedora only)."""
+    if not shutil.which("dnf"):
+        return True, "dnf not found — skipping (not a RHEL/Fedora system)"
+
+    cmd = ["sudo", "dnf", "install", "-y"] + SYSTEM_PACKAGES
+    if dry_run:
+        return True, f"[dry-run] would run: {' '.join(cmd)}"
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+        if result.returncode == 0:
+            return True, f"installed: {', '.join(SYSTEM_PACKAGES)}"
+        return False, result.stderr.strip() or result.stdout.strip() or "dnf failed"
+    except subprocess.TimeoutExpired:
+        return False, "dnf timed out"
+    except Exception as e:
+        return False, str(e)
+
+
+def install_ansible_collections(dry_run: bool = False) -> Tuple[bool, str]:
+    """Install Ansible collections from requirements.yml."""
+    req = _requirements_path()
+    if not req.exists():
+        return False, f"requirements.yml not found: {req}"
+
+    if not shutil.which("ansible-galaxy"):
+        return False, "ansible-galaxy not found in PATH"
+
+    cmd = ["ansible-galaxy", "collection", "install", "-r", str(req)]
+    if dry_run:
+        return True, f"[dry-run] would run: {' '.join(cmd)}"
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        if result.returncode == 0:
+            return True, "collections installed"
+        return False, result.stderr.strip() or result.stdout.strip() or "ansible-galaxy failed"
+    except subprocess.TimeoutExpired:
+        return False, "ansible-galaxy timed out"
+    except Exception as e:
+        return False, str(e)
+
+
+def run_install(
+    skip_system_deps: bool = False,
+    skip_collections: bool = False,
+    dry_run: bool = False,
+) -> int:
+    """Run the full install sequence.
+
+    Returns:
+        Exit code (0 = all enabled steps succeeded)
+    """
+    console = Console()
+    prefix = "[dim][dry-run][/dim] " if dry_run else ""
+    console.print(f"\n[bold cyan]{prefix}cpueval install[/bold cyan]\n")
+
+    steps: List[Tuple[str, object]] = []
+    if not skip_system_deps:
+        steps.append(("System packages (dnf)", lambda: install_system_deps(dry_run)))
+    if not skip_collections:
+        steps.append(("Ansible collections", lambda: install_ansible_collections(dry_run)))
+
+    if not steps:
+        console.print("[yellow]Nothing to install (all steps skipped).[/yellow]\n")
+        return 0
+
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Step", style="dim", width=28)
+    table.add_column("Status", width=12)
+    table.add_column("Details")
+
+    all_passed = True
+    for step_name, step_fn in steps:
+        passed, details = step_fn()
+        all_passed = all_passed and passed
+        status_symbol = "✓" if passed else "✗"
+        status_color = "green" if passed else "red"
+        table.add_row(
+            step_name,
+            f"[{status_color}]{status_symbol}[/{status_color}]",
+            details,
+        )
+
+    console.print(table)
+
+    if all_passed:
+        console.print("\n[green]✓ Install complete[/green]\n")
+        if not dry_run:
+            console.print("Next step: verify with [bold]cpueval doctor[/bold]\n")
+        return 0
+
+    console.print("\n[red]✗ Some steps failed[/red]\n")
+    return 1

--- a/automation/cli/src/cpueval/install.py
+++ b/automation/cli/src/cpueval/install.py
@@ -1,7 +1,9 @@
 """Dependency installation helpers for cpueval."""
 
+import re
 import shutil
 import subprocess
+from pathlib import Path
 from typing import List, Optional, Tuple
 
 from rich.console import Console
@@ -82,9 +84,90 @@ def install_ansible_collections(dry_run: bool = False) -> _StepResult:
     return False, detail
 
 
+def _enable_dot_slash_completion(path: Path, prog_name: str) -> None:
+    """Register ./prog_name so tab-complete works without putting the repo on PATH.
+
+    Typer's installer only registers the bare command name. Bash already invokes
+    $1 (the command being completed); zsh hardcodes prog_name, so we point it
+    at ${words[1]} as well.
+    """
+    text = path.read_text()
+    dot = f"./{prog_name}"
+    if dot not in text:
+        text = re.sub(
+            rf"(complete\b[^\n]*\s)({re.escape(prog_name)})(\s*)$",
+            rf"\1\2 {dot}\3",
+            text,
+            count=1,
+            flags=re.M,
+        )
+        text = re.sub(
+            rf"^(#compdef\s+)({re.escape(prog_name)})(\s*)$",
+            rf"\1\2 {dot}\3",
+            text,
+            count=1,
+            flags=re.M,
+        )
+        text = re.sub(
+            rf"(^compdef\s+\S+\s+)({re.escape(prog_name)})(\s*)$",
+            rf"\1\2 {dot}\3",
+            text,
+            count=1,
+            flags=re.M,
+        )
+    # zsh script invokes the hardcoded binary; use the command being completed
+    # so ./cpueval works even when cpueval is not on PATH.
+    text = text.replace(
+        f"=complete_zsh {prog_name}",
+        '=complete_zsh "${words[1]}"',
+    )
+    path.write_text(text)
+
+
+def install_shell_completion(dry_run: bool = False) -> _StepResult:
+    """Install bash/zsh tab completion for cpueval and ./cpueval.
+
+    Uses the same helper as ``cpueval --install-completion``, then registers
+    ``./cpueval`` so completion works from the repo launcher without PATH.
+    Unknown shells and detection failures are a soft-skip (do not fail install).
+    """
+    try:
+        import shellingham
+        from typer._completion_shared import install as typer_install
+    except ImportError as e:
+        return False, f"completion helpers not available: {e}"
+
+    try:
+        shell, _ = shellingham.detect_shell()
+    except Exception:
+        return None, (
+            "could not detect shell — "
+            "run ./cpueval --install-completion from bash/zsh"
+        )
+
+    if shell not in ("bash", "zsh"):
+        return None, f"{shell} is not supported (bash/zsh only) — skipped"
+
+    if dry_run:
+        return True, (
+            f"[dry-run] would install {shell} completion for cpueval and ./cpueval"
+        )
+
+    try:
+        installed_shell, path = typer_install(shell=shell, prog_name="cpueval")
+        _enable_dot_slash_completion(path, "cpueval")
+        return True, (
+            f"{installed_shell} completion at {path} "
+            f"(includes ./cpueval) — restart shell: exec {installed_shell}"
+        )
+    except Exception as e:
+        return False, str(e)
+
+
 def run_install(
     skip_system_deps: bool = False,
     skip_collections: bool = False,
+    skip_completion: bool = False,
     dry_run: bool = False,
 ) -> int:
     """Run the full install sequence.
@@ -101,6 +184,8 @@ def run_install(
         steps.append(("System packages (dnf)", lambda: install_system_deps(dry_run)))
     if not skip_collections:
         steps.append(("Ansible collections", lambda: install_ansible_collections(dry_run)))
+    if not skip_completion:
+        steps.append(("Shell completion", lambda: install_shell_completion(dry_run)))
 
     if not steps:
         console.print("[yellow]Nothing to install (all steps skipped).[/yellow]\n")
@@ -113,6 +198,7 @@ def run_install(
 
     rows = []
     any_failed = False
+    completion_ready = False
     for step_name, step_fn in steps:
         ok, details = step_fn()
         if ok is False:
@@ -122,6 +208,8 @@ def run_install(
             symbol, color = "~", "yellow"
         else:
             symbol, color = "✓", "green"
+            if step_name == "Shell completion":
+                completion_ready = True
         rows.append((step_name, f"[{color}]{symbol}[/{color}]", details))
 
     console.print()  # blank line after streamed subprocess output
@@ -132,7 +220,14 @@ def run_install(
     if not any_failed:
         console.print("\n[green]✓ Install complete[/green]\n")
         if not dry_run:
-            console.print("Next step: verify with [bold]cpueval doctor[/bold]\n")
+            console.print("Next step: verify with [bold]cpueval doctor[/bold]")
+            if completion_ready:
+                console.print(
+                    "Enable tab completion in this shell with "
+                    "[bold]exec bash[/bold] or [bold]exec zsh[/bold], "
+                    "then try [bold]./cpueval <TAB>[/bold]"
+                )
+            console.print()
         return 0
 
     console.print("\n[red]✗ Some steps failed — see output above for details[/red]\n")

--- a/automation/cli/src/cpueval/install.py
+++ b/automation/cli/src/cpueval/install.py
@@ -65,16 +65,16 @@ def install_ansible_collections(dry_run: bool = False) -> _StepResult:
     if not req.exists():
         return False, f"requirements.yml not found: {req}"
 
+    cmd = ["ansible-galaxy", "collection", "install", "-r", str(req)]
+    if dry_run:
+        return True, f"[dry-run] would run: {' '.join(cmd)}"
+
     if not shutil.which("ansible-galaxy"):
         return False, (
             "ansible-galaxy not found in PATH — "
             "install ansible-core first (brew/apt/dnf), "
             "then re-run: ./cpueval install --skip-system-deps"
         )
-
-    cmd = ["ansible-galaxy", "collection", "install", "-r", str(req)]
-    if dry_run:
-        return True, f"[dry-run] would run: {' '.join(cmd)}"
 
     ok, detail = _run_streaming(cmd, timeout=300)
     if ok:

--- a/automation/cli/src/cpueval/install.py
+++ b/automation/cli/src/cpueval/install.py
@@ -4,6 +4,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -12,7 +13,12 @@ from rich.table import Table
 
 from cpueval.paths import get_ansible_dir
 
-SYSTEM_PACKAGES = ["ansible-core", "python3-pip", "git"]
+# python3-pip and git are in UBI/RHEL base repos. ansible-core is not in UBI
+# (needs a subscribed RHEL AppStream), so install_system_deps falls back to pip.
+DNF_BASE_PACKAGES = ["python3-pip", "git"]
+ANSIBLE_PACKAGE = "ansible-core"
+SYSTEM_PACKAGES = [*DNF_BASE_PACKAGES, ANSIBLE_PACKAGE]
+PIP_ANSIBLE_SPEC = "ansible-core>=2.14"
 
 # Status values: True = pass (green ✓), None = skipped (yellow ~), False = fail (red ✗)
 _StepResult = Tuple[Optional[bool], str]
@@ -28,12 +34,25 @@ def _is_root() -> bool:
     return geteuid is not None and geteuid() == 0
 
 
-def _dnf_install_cmd() -> List[str]:
-    """Build the dnf install command; skip sudo when already root."""
-    cmd = ["dnf", "install", "-y", *SYSTEM_PACKAGES]
+def _dnf_install_cmd(packages: List[str]) -> List[str]:
+    """Build a dnf install command; skip sudo when already root or sudo is absent."""
+    cmd = ["dnf", "install", "-y", *packages]
     if not _is_root() and shutil.which("sudo"):
         cmd = ["sudo", *cmd]
     return cmd
+
+
+def _venv_bin(name: str) -> Optional[str]:
+    """Return a venv executable next to sys.executable, if it exists."""
+    path = Path(sys.executable).resolve().parent / name
+    if path.is_file() and os.access(path, os.X_OK):
+        return str(path)
+    return None
+
+
+def _ansible_executable(name: str) -> Optional[str]:
+    """Find an Ansible binary on PATH or in the active venv."""
+    return shutil.which(name) or _venv_bin(name)
 
 
 def _run_streaming(cmd: List[str], timeout: int) -> Tuple[bool, str]:
@@ -52,25 +71,51 @@ def _run_streaming(cmd: List[str], timeout: int) -> Tuple[bool, str]:
 
 
 def install_system_deps(dry_run: bool = False) -> _StepResult:
-    """Install system packages via dnf (RHEL/Fedora only).
+    """Install git/pip via dnf when available, and ansible-core via dnf or pip.
 
-    Returns True on success, None when dnf is absent (soft-skip), False on error.
+    UBI 9 does not ship ansible-core. After a failed dnf install, fall back to
+    ``pip install ansible-core`` into the active interpreter (the cpueval venv).
     """
-    if not shutil.which("dnf"):
-        return None, (
-            "dnf not found — skipping (not a RHEL/Fedora system).\n"
-            "         On macOS: brew install ansible\n"
-            "         On Ubuntu/Debian: sudo apt install -y ansible-core python3-pip git"
-        )
-
-    cmd = _dnf_install_cmd()
+    has_dnf = shutil.which("dnf") is not None
     if dry_run:
-        return True, f"[dry-run] would run: {' '.join(cmd)}"
+        parts = []
+        if has_dnf:
+            parts.append(" ".join(_dnf_install_cmd(DNF_BASE_PACKAGES)))
+            parts.append(" ".join(_dnf_install_cmd([ANSIBLE_PACKAGE])))
+        parts.append(f"{sys.executable} -m pip install {PIP_ANSIBLE_SPEC} (if ansible-core is missing)")
+        return True, f"[dry-run] would run: {'; '.join(parts)}"
 
-    ok, detail = _run_streaming(cmd, timeout=300)
-    if ok:
-        return True, f"installed: {', '.join(SYSTEM_PACKAGES)}"
-    return False, detail
+    notes: List[str] = []
+    if has_dnf:
+        ok, detail = _run_streaming(_dnf_install_cmd(DNF_BASE_PACKAGES), timeout=300)
+        if ok:
+            notes.append(f"dnf: {', '.join(DNF_BASE_PACKAGES)}")
+        else:
+            notes.append(f"dnf {', '.join(DNF_BASE_PACKAGES)}: {detail}")
+
+        if not _ansible_executable("ansible-galaxy"):
+            ok, detail = _run_streaming(_dnf_install_cmd([ANSIBLE_PACKAGE]), timeout=300)
+            if ok:
+                notes.append("dnf: ansible-core")
+            else:
+                notes.append("dnf: ansible-core not in repos")
+
+    if not _ansible_executable("ansible-galaxy"):
+        pip_cmd = [sys.executable, "-m", "pip", "install", PIP_ANSIBLE_SPEC]
+        ok, detail = _run_streaming(pip_cmd, timeout=300)
+        if not ok:
+            hint = (
+                "could not install ansible-core via dnf or pip — "
+                "on macOS: brew install ansible; "
+                "on Ubuntu: sudo apt install -y ansible-core"
+            )
+            return False, f"{detail}; {hint}"
+        notes.append(f"pip: {PIP_ANSIBLE_SPEC}")
+
+    if not _ansible_executable("ansible-galaxy"):
+        return False, "ansible-galaxy still not found after dnf/pip install"
+
+    return True, "; ".join(notes) if notes else "ansible-core already installed"
 
 
 def install_ansible_collections(dry_run: bool = False) -> _StepResult:
@@ -82,14 +127,15 @@ def install_ansible_collections(dry_run: bool = False) -> _StepResult:
     if not req.exists():
         return False, f"requirements.yml not found: {req}"
 
-    cmd = ["ansible-galaxy", "collection", "install", "-r", str(req)]
+    galaxy = _ansible_executable("ansible-galaxy")
+    cmd = [galaxy or "ansible-galaxy", "collection", "install", "-r", str(req)]
     if dry_run:
         return True, f"[dry-run] would run: {' '.join(cmd)}"
 
-    if not shutil.which("ansible-galaxy"):
+    if not galaxy:
         return False, (
             "ansible-galaxy not found in PATH — "
-            "install ansible-core first (brew/apt/dnf), "
+            "install ansible-core first (brew/apt/dnf or pip), "
             "then re-run: ./cpueval install --skip-system-deps"
         )
 
@@ -196,7 +242,7 @@ def run_install(
 
     steps: List[Tuple[str, object]] = []
     if not skip_system_deps:
-        steps.append(("System packages (dnf)", lambda: install_system_deps(dry_run)))
+        steps.append(("System packages", lambda: install_system_deps(dry_run)))
     if not skip_collections:
         steps.append(("Ansible collections", lambda: install_ansible_collections(dry_run)))
     if not skip_completion:

--- a/automation/cli/src/cpueval/install.py
+++ b/automation/cli/src/cpueval/install.py
@@ -68,8 +68,8 @@ def install_ansible_collections(dry_run: bool = False) -> _StepResult:
     if not shutil.which("ansible-galaxy"):
         return False, (
             "ansible-galaxy not found in PATH — "
-            "install ansible-core first (cpueval install --skip-collections, "
-            "then re-run without the flag)"
+            "install ansible-core first (brew/apt/dnf), "
+            "then re-run: ./cpueval install --skip-system-deps"
         )
 
     cmd = ["ansible-galaxy", "collection", "install", "-r", str(req)]

--- a/automation/cli/tests/container-smoke.sh
+++ b/automation/cli/tests/container-smoke.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Smoke-test the repo-root ./cpueval launcher and common commands.
+# Intended to run inside a RHEL/Fedora container (UBI 9, Fedora, …).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+if [[ ! -x ./cpueval ]]; then
+    echo "error: ./cpueval is missing or not executable" >&2
+    exit 1
+fi
+
+echo "==> ./cpueval list"
+./cpueval list
+
+echo "==> ./cpueval show rhaiis-sweep"
+./cpueval show rhaiis-sweep
+
+echo "==> ./cpueval install --help"
+./cpueval install --help
+
+echo "==> ./cpueval install --dry-run"
+./cpueval install --dry-run
+
+echo "==> ./cpueval install --skip-completion"
+./cpueval install --skip-completion
+
+echo "==> ./cpueval --suite rhaiis-sweep --dry-run"
+./cpueval --suite rhaiis-sweep --dry-run
+
+echo "==> ./cpueval doctor --no-ping (env vars unset is expected)"
+set +e
+doctor_out="$(./cpueval doctor --no-ping 2>&1)"
+doctor_rc=$?
+set -e
+printf '%s\n' "$doctor_out"
+if ! printf '%s\n' "$doctor_out" | grep -q "ansible-playbook"; then
+    echo "error: doctor output did not mention ansible-playbook" >&2
+    exit 1
+fi
+if [[ "$doctor_rc" -eq 0 ]]; then
+    echo "warning: doctor succeeded without DUT_HOSTNAME (unexpected in CI)" >&2
+fi
+
+echo "==> container smoke passed"

--- a/automation/cli/tests/test_install.py
+++ b/automation/cli/tests/test_install.py
@@ -250,3 +250,13 @@ def test_run_install_dry_run_passes_flag():
         run_install(dry_run=True)
     mock_sys.assert_called_once_with(True)
     mock_col.assert_called_once_with(True)
+
+
+def test_run_install_dry_run_succeeds_without_ansible_galaxy(tmp_path, monkeypatch):
+    """dry_run=True completes the full install preview even when ansible-galaxy is absent."""
+    req = tmp_path / "requirements.yml"
+    req.write_text("collections: []\n")
+    monkeypatch.setattr("cpueval.install._requirements_path", lambda: req)
+    monkeypatch.setattr("shutil.which", lambda _: None)
+    code = run_install(dry_run=True)
+    assert code == 0

--- a/automation/cli/tests/test_install.py
+++ b/automation/cli/tests/test_install.py
@@ -65,6 +65,7 @@ def test_install_system_deps_success(monkeypatch):
 def test_install_system_deps_calls_sudo_dnf(monkeypatch):
     """Verifies subprocess is called with the expected sudo dnf command."""
     monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/dnf")
+    monkeypatch.setattr("os.geteuid", lambda: 1000)
     mock_result = MagicMock(returncode=0)
     with patch("subprocess.run", return_value=mock_result) as mock_run:
         install_system_deps()
@@ -72,6 +73,36 @@ def test_install_system_deps_calls_sudo_dnf(monkeypatch):
     assert cmd[:4] == ["sudo", "dnf", "install", "-y"]
     for pkg in SYSTEM_PACKAGES:
         assert pkg in cmd
+
+
+def test_install_system_deps_root_omits_sudo(monkeypatch):
+    """Containers running as root must not require sudo."""
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/dnf")
+    monkeypatch.setattr("os.geteuid", lambda: 0)
+    mock_result = MagicMock(returncode=0)
+    with patch("subprocess.run", return_value=mock_result) as mock_run:
+        install_system_deps()
+    cmd = mock_run.call_args[0][0]
+    assert cmd[:3] == ["dnf", "install", "-y"]
+    assert "sudo" not in cmd
+
+
+def test_install_system_deps_no_sudo_binary_omits_sudo(monkeypatch):
+    """If sudo is not installed, run dnf directly (root UBI images)."""
+    monkeypatch.setattr("os.geteuid", lambda: 1000)
+
+    def which(name):
+        if name == "dnf":
+            return "/usr/bin/dnf"
+        return None
+
+    monkeypatch.setattr("shutil.which", which)
+    mock_result = MagicMock(returncode=0)
+    with patch("subprocess.run", return_value=mock_result) as mock_run:
+        install_system_deps()
+    cmd = mock_run.call_args[0][0]
+    assert cmd[:3] == ["dnf", "install", "-y"]
+    assert "sudo" not in cmd
 
 
 def test_install_system_deps_failure(monkeypatch):

--- a/automation/cli/tests/test_install.py
+++ b/automation/cli/tests/test_install.py
@@ -128,13 +128,14 @@ def test_install_ansible_collections_no_ansible_galaxy(tmp_path, monkeypatch):
 
 
 def test_install_ansible_collections_no_galaxy_hints_install(tmp_path, monkeypatch):
-    """Missing ansible-galaxy message mentions how to fix it."""
+    """Missing ansible-galaxy message mentions the correct recovery flag."""
     req = tmp_path / "requirements.yml"
     req.write_text("collections: []\n")
     monkeypatch.setattr("cpueval.install._requirements_path", lambda: req)
     monkeypatch.setattr("shutil.which", lambda _: None)
     _, msg = install_ansible_collections()
     assert "ansible-core" in msg
+    assert "--skip-system-deps" in msg
 
 
 def test_install_ansible_collections_success(tmp_path, monkeypatch):

--- a/automation/cli/tests/test_install.py
+++ b/automation/cli/tests/test_install.py
@@ -1,0 +1,200 @@
+"""Unit tests for cpueval install module."""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from cpueval.install import (
+    SYSTEM_PACKAGES,
+    install_ansible_collections,
+    install_system_deps,
+    run_install,
+)
+
+
+# ---------------------------------------------------------------------------
+# install_system_deps
+# ---------------------------------------------------------------------------
+
+def test_install_system_deps_dry_run_no_subprocess(monkeypatch):
+    """Dry-run returns True without running any subprocess."""
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/dnf")
+    with patch("subprocess.run") as mock_run:
+        ok, msg = install_system_deps(dry_run=True)
+    assert ok is True
+    assert "dry-run" in msg
+    mock_run.assert_not_called()
+
+
+def test_install_system_deps_dry_run_includes_packages(monkeypatch):
+    """Dry-run message lists all expected packages."""
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/dnf")
+    _, msg = install_system_deps(dry_run=True)
+    for pkg in SYSTEM_PACKAGES:
+        assert pkg in msg
+
+
+def test_install_system_deps_no_dnf_skips(monkeypatch):
+    """Returns True (soft-skip) with a helpful message when dnf is absent."""
+    monkeypatch.setattr("shutil.which", lambda _: None)
+    ok, msg = install_system_deps()
+    assert ok is True
+    assert "dnf not found" in msg
+    assert "skipping" in msg
+
+
+def test_install_system_deps_success(monkeypatch):
+    """Returns True when dnf exits 0."""
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/dnf")
+    mock_result = MagicMock(returncode=0, stderr="", stdout="")
+    with patch("subprocess.run", return_value=mock_result):
+        ok, msg = install_system_deps()
+    assert ok is True
+    assert "installed" in msg
+
+
+def test_install_system_deps_failure(monkeypatch):
+    """Returns False with stderr when dnf exits non-zero."""
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/dnf")
+    mock_result = MagicMock(returncode=1, stderr="Error: something went wrong", stdout="")
+    with patch("subprocess.run", return_value=mock_result):
+        ok, msg = install_system_deps()
+    assert ok is False
+    assert "Error: something went wrong" in msg
+
+
+def test_install_system_deps_timeout(monkeypatch):
+    """Returns False when dnf times out."""
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/dnf")
+    with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="dnf", timeout=300)):
+        ok, msg = install_system_deps()
+    assert ok is False
+    assert "timed out" in msg
+
+
+# ---------------------------------------------------------------------------
+# install_ansible_collections
+# ---------------------------------------------------------------------------
+
+def test_install_ansible_collections_dry_run_no_subprocess(tmp_path, monkeypatch):
+    """Dry-run returns True without running any subprocess."""
+    req = tmp_path / "requirements.yml"
+    req.write_text("collections: []\n")
+    monkeypatch.setattr("cpueval.install._requirements_path", lambda: req)
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ansible-galaxy")
+    with patch("subprocess.run") as mock_run:
+        ok, msg = install_ansible_collections(dry_run=True)
+    assert ok is True
+    assert "dry-run" in msg
+    mock_run.assert_not_called()
+
+
+def test_install_ansible_collections_missing_requirements(monkeypatch, tmp_path):
+    """Returns False when requirements.yml does not exist."""
+    monkeypatch.setattr("cpueval.install._requirements_path", lambda: tmp_path / "missing.yml")
+    ok, msg = install_ansible_collections()
+    assert ok is False
+    assert "not found" in msg
+
+
+def test_install_ansible_collections_no_ansible_galaxy(tmp_path, monkeypatch):
+    """Returns False when ansible-galaxy is not in PATH."""
+    req = tmp_path / "requirements.yml"
+    req.write_text("collections: []\n")
+    monkeypatch.setattr("cpueval.install._requirements_path", lambda: req)
+    monkeypatch.setattr("shutil.which", lambda _: None)
+    ok, msg = install_ansible_collections()
+    assert ok is False
+    assert "ansible-galaxy not found" in msg
+
+
+def test_install_ansible_collections_success(tmp_path, monkeypatch):
+    """Returns True when ansible-galaxy exits 0."""
+    req = tmp_path / "requirements.yml"
+    req.write_text("collections: []\n")
+    monkeypatch.setattr("cpueval.install._requirements_path", lambda: req)
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ansible-galaxy")
+    mock_result = MagicMock(returncode=0, stderr="", stdout="")
+    with patch("subprocess.run", return_value=mock_result):
+        ok, msg = install_ansible_collections()
+    assert ok is True
+    assert "installed" in msg
+
+
+def test_install_ansible_collections_failure(tmp_path, monkeypatch):
+    """Returns False with error details when ansible-galaxy exits non-zero."""
+    req = tmp_path / "requirements.yml"
+    req.write_text("collections: []\n")
+    monkeypatch.setattr("cpueval.install._requirements_path", lambda: req)
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ansible-galaxy")
+    mock_result = MagicMock(returncode=1, stderr="ERROR! collection not found", stdout="")
+    with patch("subprocess.run", return_value=mock_result):
+        ok, msg = install_ansible_collections()
+    assert ok is False
+    assert "collection not found" in msg
+
+
+def test_install_ansible_collections_timeout(tmp_path, monkeypatch):
+    """Returns False when ansible-galaxy times out."""
+    req = tmp_path / "requirements.yml"
+    req.write_text("collections: []\n")
+    monkeypatch.setattr("cpueval.install._requirements_path", lambda: req)
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ansible-galaxy")
+    with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="ansible-galaxy", timeout=120)):
+        ok, msg = install_ansible_collections()
+    assert ok is False
+    assert "timed out" in msg
+
+
+# ---------------------------------------------------------------------------
+# run_install
+# ---------------------------------------------------------------------------
+
+def test_run_install_skip_all_returns_zero():
+    """Skipping all steps returns exit code 0 without calling anything."""
+    with patch("cpueval.install.install_system_deps") as mock_sys, \
+         patch("cpueval.install.install_ansible_collections") as mock_col:
+        code = run_install(skip_system_deps=True, skip_collections=True)
+    assert code == 0
+    mock_sys.assert_not_called()
+    mock_col.assert_not_called()
+
+
+def test_run_install_all_pass_returns_zero(monkeypatch):
+    """All steps succeeding returns exit code 0."""
+    with patch("cpueval.install.install_system_deps", return_value=(True, "ok")), \
+         patch("cpueval.install.install_ansible_collections", return_value=(True, "ok")):
+        code = run_install()
+    assert code == 0
+
+
+def test_run_install_one_failure_returns_one(monkeypatch):
+    """Any failing step returns exit code 1."""
+    with patch("cpueval.install.install_system_deps", return_value=(False, "dnf error")), \
+         patch("cpueval.install.install_ansible_collections", return_value=(True, "ok")):
+        code = run_install()
+    assert code == 1
+
+
+def test_run_install_skip_system_deps_only_calls_collections():
+    """--skip-system-deps skips dnf but still installs collections."""
+    with patch("cpueval.install.install_system_deps") as mock_sys, \
+         patch("cpueval.install.install_ansible_collections", return_value=(True, "ok")):
+        run_install(skip_system_deps=True)
+    mock_sys.assert_not_called()
+
+
+def test_run_install_skip_collections_only_calls_system_deps():
+    """--skip-collections skips galaxy but still installs system packages."""
+    with patch("cpueval.install.install_system_deps", return_value=(True, "ok")), \
+         patch("cpueval.install.install_ansible_collections") as mock_col:
+        run_install(skip_collections=True)
+    mock_col.assert_not_called()
+
+
+def test_run_install_dry_run_passes_flag():
+    """dry_run=True propagates to individual install functions."""
+    with patch("cpueval.install.install_system_deps", return_value=(True, "[dry-run] ...")) as mock_sys, \
+         patch("cpueval.install.install_ansible_collections", return_value=(True, "[dry-run] ...")) as mock_col:
+        run_install(dry_run=True)
+    mock_sys.assert_called_once_with(True)
+    mock_col.assert_called_once_with(True)

--- a/automation/cli/tests/test_install.py
+++ b/automation/cli/tests/test_install.py
@@ -34,32 +34,52 @@ def test_install_system_deps_dry_run_includes_packages(monkeypatch):
 
 
 def test_install_system_deps_no_dnf_skips(monkeypatch):
-    """Returns True (soft-skip) with a helpful message when dnf is absent."""
+    """Returns None (soft-skip) with alternative install hints when dnf is absent."""
     monkeypatch.setattr("shutil.which", lambda _: None)
     ok, msg = install_system_deps()
-    assert ok is True
+    assert ok is None
     assert "dnf not found" in msg
     assert "skipping" in msg
+
+
+def test_install_system_deps_no_dnf_hints_brew_and_apt(monkeypatch):
+    """Soft-skip message includes macOS and Ubuntu install one-liners."""
+    monkeypatch.setattr("shutil.which", lambda _: None)
+    _, msg = install_system_deps()
+    assert "brew" in msg
+    assert "apt" in msg
 
 
 def test_install_system_deps_success(monkeypatch):
     """Returns True when dnf exits 0."""
     monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/dnf")
-    mock_result = MagicMock(returncode=0, stderr="", stdout="")
+    mock_result = MagicMock(returncode=0)
     with patch("subprocess.run", return_value=mock_result):
         ok, msg = install_system_deps()
     assert ok is True
     assert "installed" in msg
 
 
-def test_install_system_deps_failure(monkeypatch):
-    """Returns False with stderr when dnf exits non-zero."""
+def test_install_system_deps_calls_sudo_dnf(monkeypatch):
+    """Verifies subprocess is called with the expected sudo dnf command."""
     monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/dnf")
-    mock_result = MagicMock(returncode=1, stderr="Error: something went wrong", stdout="")
+    mock_result = MagicMock(returncode=0)
+    with patch("subprocess.run", return_value=mock_result) as mock_run:
+        install_system_deps()
+    cmd = mock_run.call_args[0][0]
+    assert cmd[:4] == ["sudo", "dnf", "install", "-y"]
+    for pkg in SYSTEM_PACKAGES:
+        assert pkg in cmd
+
+
+def test_install_system_deps_failure(monkeypatch):
+    """Returns False when dnf exits non-zero."""
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/dnf")
+    mock_result = MagicMock(returncode=1)
     with patch("subprocess.run", return_value=mock_result):
         ok, msg = install_system_deps()
     assert ok is False
-    assert "Error: something went wrong" in msg
+    assert "exited 1" in msg
 
 
 def test_install_system_deps_timeout(monkeypatch):
@@ -107,13 +127,23 @@ def test_install_ansible_collections_no_ansible_galaxy(tmp_path, monkeypatch):
     assert "ansible-galaxy not found" in msg
 
 
+def test_install_ansible_collections_no_galaxy_hints_install(tmp_path, monkeypatch):
+    """Missing ansible-galaxy message mentions how to fix it."""
+    req = tmp_path / "requirements.yml"
+    req.write_text("collections: []\n")
+    monkeypatch.setattr("cpueval.install._requirements_path", lambda: req)
+    monkeypatch.setattr("shutil.which", lambda _: None)
+    _, msg = install_ansible_collections()
+    assert "ansible-core" in msg
+
+
 def test_install_ansible_collections_success(tmp_path, monkeypatch):
     """Returns True when ansible-galaxy exits 0."""
     req = tmp_path / "requirements.yml"
     req.write_text("collections: []\n")
     monkeypatch.setattr("cpueval.install._requirements_path", lambda: req)
     monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ansible-galaxy")
-    mock_result = MagicMock(returncode=0, stderr="", stdout="")
+    mock_result = MagicMock(returncode=0)
     with patch("subprocess.run", return_value=mock_result):
         ok, msg = install_ansible_collections()
     assert ok is True
@@ -121,16 +151,16 @@ def test_install_ansible_collections_success(tmp_path, monkeypatch):
 
 
 def test_install_ansible_collections_failure(tmp_path, monkeypatch):
-    """Returns False with error details when ansible-galaxy exits non-zero."""
+    """Returns False when ansible-galaxy exits non-zero."""
     req = tmp_path / "requirements.yml"
     req.write_text("collections: []\n")
     monkeypatch.setattr("cpueval.install._requirements_path", lambda: req)
     monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ansible-galaxy")
-    mock_result = MagicMock(returncode=1, stderr="ERROR! collection not found", stdout="")
+    mock_result = MagicMock(returncode=1)
     with patch("subprocess.run", return_value=mock_result):
         ok, msg = install_ansible_collections()
     assert ok is False
-    assert "collection not found" in msg
+    assert "exited 1" in msg
 
 
 def test_install_ansible_collections_timeout(tmp_path, monkeypatch):
@@ -139,10 +169,23 @@ def test_install_ansible_collections_timeout(tmp_path, monkeypatch):
     req.write_text("collections: []\n")
     monkeypatch.setattr("cpueval.install._requirements_path", lambda: req)
     monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ansible-galaxy")
-    with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="ansible-galaxy", timeout=120)):
+    with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="ansible-galaxy", timeout=300)):
         ok, msg = install_ansible_collections()
     assert ok is False
     assert "timed out" in msg
+
+
+def test_install_ansible_collections_uses_300s_timeout(tmp_path, monkeypatch):
+    """ansible-galaxy uses a 300s timeout to handle slow networks."""
+    req = tmp_path / "requirements.yml"
+    req.write_text("collections: []\n")
+    monkeypatch.setattr("cpueval.install._requirements_path", lambda: req)
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/ansible-galaxy")
+    mock_result = MagicMock(returncode=0)
+    with patch("subprocess.run", return_value=mock_result) as mock_run:
+        install_ansible_collections()
+    _, kwargs = mock_run.call_args
+    assert kwargs.get("timeout") == 300
 
 
 # ---------------------------------------------------------------------------
@@ -159,7 +202,7 @@ def test_run_install_skip_all_returns_zero():
     mock_col.assert_not_called()
 
 
-def test_run_install_all_pass_returns_zero(monkeypatch):
+def test_run_install_all_pass_returns_zero():
     """All steps succeeding returns exit code 0."""
     with patch("cpueval.install.install_system_deps", return_value=(True, "ok")), \
          patch("cpueval.install.install_ansible_collections", return_value=(True, "ok")):
@@ -167,7 +210,15 @@ def test_run_install_all_pass_returns_zero(monkeypatch):
     assert code == 0
 
 
-def test_run_install_one_failure_returns_one(monkeypatch):
+def test_run_install_skipped_step_returns_zero():
+    """A skipped (None) step does not cause a non-zero exit."""
+    with patch("cpueval.install.install_system_deps", return_value=(None, "skipping")), \
+         patch("cpueval.install.install_ansible_collections", return_value=(True, "ok")):
+        code = run_install()
+    assert code == 0
+
+
+def test_run_install_one_failure_returns_one():
     """Any failing step returns exit code 1."""
     with patch("cpueval.install.install_system_deps", return_value=(False, "dnf error")), \
          patch("cpueval.install.install_ansible_collections", return_value=(True, "ok")):

--- a/automation/cli/tests/test_install.py
+++ b/automation/cli/tests/test_install.py
@@ -1,9 +1,13 @@
 """Unit tests for cpueval install module."""
 
 import subprocess
+import sys
 from unittest.mock import MagicMock, patch
 
 from cpueval.install import (
+    ANSIBLE_PACKAGE,
+    DNF_BASE_PACKAGES,
+    PIP_ANSIBLE_SPEC,
     SYSTEM_PACKAGES,
     _enable_dot_slash_completion,
     install_ansible_collections,
@@ -13,13 +17,60 @@ from cpueval.install import (
 )
 
 
+def _disable_venv_ansible(monkeypatch):
+    """Keep tests from picking up a real ansible-galaxy next to sys.executable."""
+    monkeypatch.setattr("cpueval.install._venv_bin", lambda name: None)
+
+
+def _patch_which(monkeypatch, *, dnf=True, sudo=True):
+    """PATH stub that reveals ansible-galaxy after a successful ansible-core install."""
+    state = {"galaxy": False}
+
+    def which(name):
+        if name in {"ansible-galaxy", "ansible-playbook"}:
+            return f"/usr/bin/{name}" if state["galaxy"] else None
+        if name == "dnf" and dnf:
+            return "/usr/bin/dnf"
+        if name == "sudo" and sudo:
+            return "/usr/bin/sudo"
+        return None
+
+    monkeypatch.setattr("shutil.which", which)
+    _disable_venv_ansible(monkeypatch)
+    return state
+
+
+def _run_installing_ansible(
+    state, *, dnf_base_rc=0, dnf_ansible_rc=0, pip_rc=0, timeout=False
+):
+    """subprocess.run stub: mark galaxy installed after a successful dnf/pip ansible-core."""
+
+    def run(cmd, **kwargs):
+        if timeout:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=300)
+        result = MagicMock()
+        is_pip = "pip" in cmd
+        is_dnf_ansible = (not is_pip) and ANSIBLE_PACKAGE in cmd
+        if is_pip:
+            result.returncode = pip_rc
+        elif is_dnf_ansible:
+            result.returncode = dnf_ansible_rc
+        else:
+            result.returncode = dnf_base_rc
+        if result.returncode == 0 and (is_pip or is_dnf_ansible):
+            state["galaxy"] = True
+        return result
+
+    return run
+
+
 # ---------------------------------------------------------------------------
 # install_system_deps
 # ---------------------------------------------------------------------------
 
 def test_install_system_deps_dry_run_no_subprocess(monkeypatch):
     """Dry-run returns True without running any subprocess."""
-    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/dnf")
+    _patch_which(monkeypatch)
     with patch("subprocess.run") as mock_run:
         ok, msg = install_system_deps(dry_run=True)
     assert ok is True
@@ -28,97 +79,117 @@ def test_install_system_deps_dry_run_no_subprocess(monkeypatch):
 
 
 def test_install_system_deps_dry_run_includes_packages(monkeypatch):
-    """Dry-run message lists all expected packages."""
-    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/dnf")
+    """Dry-run message lists dnf packages and the pip ansible-core fallback."""
+    _patch_which(monkeypatch)
     _, msg = install_system_deps(dry_run=True)
     for pkg in SYSTEM_PACKAGES:
         assert pkg in msg
+    assert "pip install" in msg
+    assert PIP_ANSIBLE_SPEC in msg
 
 
-def test_install_system_deps_no_dnf_skips(monkeypatch):
-    """Returns None (soft-skip) with alternative install hints when dnf is absent."""
-    monkeypatch.setattr("shutil.which", lambda _: None)
-    ok, msg = install_system_deps()
-    assert ok is None
-    assert "dnf not found" in msg
-    assert "skipping" in msg
+def test_install_system_deps_no_dnf_uses_pip(monkeypatch):
+    """Without dnf, ansible-core is installed via pip into the venv."""
+    state = _patch_which(monkeypatch, dnf=False)
+    with patch(
+        "subprocess.run", side_effect=_run_installing_ansible(state)
+    ) as mock_run:
+        ok, msg = install_system_deps()
+    assert ok is True
+    assert "pip" in msg
+    pip_cmd = mock_run.call_args[0][0]
+    assert pip_cmd == [sys.executable, "-m", "pip", "install", PIP_ANSIBLE_SPEC]
 
 
-def test_install_system_deps_no_dnf_hints_brew_and_apt(monkeypatch):
-    """Soft-skip message includes macOS and Ubuntu install one-liners."""
-    monkeypatch.setattr("shutil.which", lambda _: None)
-    _, msg = install_system_deps()
+def test_install_system_deps_no_dnf_pip_failure_hints_brew_apt(monkeypatch):
+    """If pip cannot install ansible-core, the error mentions brew/apt."""
+    state = _patch_which(monkeypatch, dnf=False)
+    with patch("subprocess.run", side_effect=_run_installing_ansible(state, pip_rc=1)):
+        ok, msg = install_system_deps()
+    assert ok is False
     assert "brew" in msg
     assert "apt" in msg
 
 
 def test_install_system_deps_success(monkeypatch):
-    """Returns True when dnf exits 0."""
-    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/dnf")
-    mock_result = MagicMock(returncode=0)
-    with patch("subprocess.run", return_value=mock_result):
+    """Returns True when dnf ansible-core succeeds (no pip fallback)."""
+    state = _patch_which(monkeypatch)
+    with patch("subprocess.run", side_effect=_run_installing_ansible(state)) as mock_run:
         ok, msg = install_system_deps()
     assert ok is True
-    assert "installed" in msg
+    assert "dnf: ansible-core" in msg
+    pip_cmds = [c[0][0] for c in mock_run.call_args_list if "pip" in c[0][0]]
+    assert not pip_cmds
 
 
 def test_install_system_deps_calls_sudo_dnf(monkeypatch):
     """Verifies subprocess is called with the expected sudo dnf command."""
-    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/dnf")
+    state = _patch_which(monkeypatch, sudo=True)
     monkeypatch.setattr("os.geteuid", lambda: 1000)
-    mock_result = MagicMock(returncode=0)
-    with patch("subprocess.run", return_value=mock_result) as mock_run:
+    with patch("subprocess.run", side_effect=_run_installing_ansible(state)) as mock_run:
         install_system_deps()
-    cmd = mock_run.call_args[0][0]
+    cmd = mock_run.call_args_list[0][0][0]
     assert cmd[:4] == ["sudo", "dnf", "install", "-y"]
-    for pkg in SYSTEM_PACKAGES:
+    for pkg in DNF_BASE_PACKAGES:
         assert pkg in cmd
 
 
 def test_install_system_deps_root_omits_sudo(monkeypatch):
     """Containers running as root must not require sudo."""
-    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/dnf")
+    state = _patch_which(monkeypatch)
     monkeypatch.setattr("os.geteuid", lambda: 0)
-    mock_result = MagicMock(returncode=0)
-    with patch("subprocess.run", return_value=mock_result) as mock_run:
+    with patch("subprocess.run", side_effect=_run_installing_ansible(state)) as mock_run:
         install_system_deps()
-    cmd = mock_run.call_args[0][0]
+    cmd = mock_run.call_args_list[0][0][0]
     assert cmd[:3] == ["dnf", "install", "-y"]
     assert "sudo" not in cmd
 
 
 def test_install_system_deps_no_sudo_binary_omits_sudo(monkeypatch):
     """If sudo is not installed, run dnf directly (root UBI images)."""
+    state = _patch_which(monkeypatch, sudo=False)
     monkeypatch.setattr("os.geteuid", lambda: 1000)
-
-    def which(name):
-        if name == "dnf":
-            return "/usr/bin/dnf"
-        return None
-
-    monkeypatch.setattr("shutil.which", which)
-    mock_result = MagicMock(returncode=0)
-    with patch("subprocess.run", return_value=mock_result) as mock_run:
+    with patch("subprocess.run", side_effect=_run_installing_ansible(state)) as mock_run:
         install_system_deps()
-    cmd = mock_run.call_args[0][0]
+    cmd = mock_run.call_args_list[0][0][0]
     assert cmd[:3] == ["dnf", "install", "-y"]
     assert "sudo" not in cmd
 
 
+def test_install_system_deps_dnf_ansible_missing_falls_back_to_pip(monkeypatch):
+    """UBI 9: dnf has no ansible-core, so pip install into the venv."""
+    state = _patch_which(monkeypatch)
+    monkeypatch.setattr("os.geteuid", lambda: 0)
+    with patch(
+        "subprocess.run",
+        side_effect=_run_installing_ansible(state, dnf_ansible_rc=1),
+    ) as mock_run:
+        ok, msg = install_system_deps()
+    assert ok is True
+    assert "pip" in msg
+    pip_cmds = [c[0][0] for c in mock_run.call_args_list if "pip" in c[0][0]]
+    assert pip_cmds
+    assert pip_cmds[0] == [sys.executable, "-m", "pip", "install", PIP_ANSIBLE_SPEC]
+
+
 def test_install_system_deps_failure(monkeypatch):
-    """Returns False when dnf exits non-zero."""
-    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/dnf")
-    mock_result = MagicMock(returncode=1)
-    with patch("subprocess.run", return_value=mock_result):
+    """Returns False when dnf and pip both fail."""
+    state = _patch_which(monkeypatch)
+    with patch(
+        "subprocess.run",
+        side_effect=_run_installing_ansible(state, dnf_base_rc=1, dnf_ansible_rc=1, pip_rc=1),
+    ):
         ok, msg = install_system_deps()
     assert ok is False
-    assert "exited 1" in msg
 
 
 def test_install_system_deps_timeout(monkeypatch):
     """Returns False when dnf times out."""
-    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/dnf")
-    with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="dnf", timeout=300)):
+    _patch_which(monkeypatch)
+    with patch(
+        "subprocess.run",
+        side_effect=_run_installing_ansible({"galaxy": False}, timeout=True),
+    ):
         ok, msg = install_system_deps()
     assert ok is False
     assert "timed out" in msg
@@ -155,6 +226,7 @@ def test_install_ansible_collections_no_ansible_galaxy(tmp_path, monkeypatch):
     req.write_text("collections: []\n")
     monkeypatch.setattr("cpueval.install._requirements_path", lambda: req)
     monkeypatch.setattr("shutil.which", lambda _: None)
+    _disable_venv_ansible(monkeypatch)
     ok, msg = install_ansible_collections()
     assert ok is False
     assert "ansible-galaxy not found" in msg
@@ -166,9 +238,27 @@ def test_install_ansible_collections_no_galaxy_hints_install(tmp_path, monkeypat
     req.write_text("collections: []\n")
     monkeypatch.setattr("cpueval.install._requirements_path", lambda: req)
     monkeypatch.setattr("shutil.which", lambda _: None)
+    _disable_venv_ansible(monkeypatch)
     _, msg = install_ansible_collections()
     assert "ansible-core" in msg
     assert "--skip-system-deps" in msg
+
+
+def test_install_ansible_collections_uses_venv_galaxy(tmp_path, monkeypatch):
+    """ansible-galaxy from the cpueval venv is used when it is not on PATH."""
+    req = tmp_path / "requirements.yml"
+    req.write_text("collections: []\n")
+    monkeypatch.setattr("cpueval.install._requirements_path", lambda: req)
+    monkeypatch.setattr("shutil.which", lambda _: None)
+    monkeypatch.setattr(
+        "cpueval.install._venv_bin",
+        lambda name: f"/venv/bin/{name}" if name == "ansible-galaxy" else None,
+    )
+    mock_result = MagicMock(returncode=0)
+    with patch("subprocess.run", return_value=mock_result) as mock_run:
+        ok, msg = install_ansible_collections()
+    assert ok is True
+    assert mock_run.call_args[0][0][0] == "/venv/bin/ansible-galaxy"
 
 
 def test_install_ansible_collections_success(tmp_path, monkeypatch):
@@ -323,6 +413,7 @@ def test_run_install_dry_run_succeeds_without_ansible_galaxy(tmp_path, monkeypat
     req.write_text("collections: []\n")
     monkeypatch.setattr("cpueval.install._requirements_path", lambda: req)
     monkeypatch.setattr("shutil.which", lambda _: None)
+    _disable_venv_ansible(monkeypatch)
     with patch("cpueval.install.install_shell_completion", return_value=(True, "[dry-run] ...")):
         code = run_install(dry_run=True)
     assert code == 0

--- a/automation/cli/tests/test_install.py
+++ b/automation/cli/tests/test_install.py
@@ -5,7 +5,9 @@ from unittest.mock import MagicMock, patch
 
 from cpueval.install import (
     SYSTEM_PACKAGES,
+    _enable_dot_slash_completion,
     install_ansible_collections,
+    install_shell_completion,
     install_system_deps,
     run_install,
 )
@@ -196,17 +198,22 @@ def test_install_ansible_collections_uses_300s_timeout(tmp_path, monkeypatch):
 def test_run_install_skip_all_returns_zero():
     """Skipping all steps returns exit code 0 without calling anything."""
     with patch("cpueval.install.install_system_deps") as mock_sys, \
-         patch("cpueval.install.install_ansible_collections") as mock_col:
-        code = run_install(skip_system_deps=True, skip_collections=True)
+         patch("cpueval.install.install_ansible_collections") as mock_col, \
+         patch("cpueval.install.install_shell_completion") as mock_comp:
+        code = run_install(
+            skip_system_deps=True, skip_collections=True, skip_completion=True
+        )
     assert code == 0
     mock_sys.assert_not_called()
     mock_col.assert_not_called()
+    mock_comp.assert_not_called()
 
 
 def test_run_install_all_pass_returns_zero():
     """All steps succeeding returns exit code 0."""
     with patch("cpueval.install.install_system_deps", return_value=(True, "ok")), \
-         patch("cpueval.install.install_ansible_collections", return_value=(True, "ok")):
+         patch("cpueval.install.install_ansible_collections", return_value=(True, "ok")), \
+         patch("cpueval.install.install_shell_completion", return_value=(True, "ok")):
         code = run_install()
     assert code == 0
 
@@ -214,7 +221,8 @@ def test_run_install_all_pass_returns_zero():
 def test_run_install_skipped_step_returns_zero():
     """A skipped (None) step does not cause a non-zero exit."""
     with patch("cpueval.install.install_system_deps", return_value=(None, "skipping")), \
-         patch("cpueval.install.install_ansible_collections", return_value=(True, "ok")):
+         patch("cpueval.install.install_ansible_collections", return_value=(True, "ok")), \
+         patch("cpueval.install.install_shell_completion", return_value=(True, "ok")):
         code = run_install()
     assert code == 0
 
@@ -222,7 +230,8 @@ def test_run_install_skipped_step_returns_zero():
 def test_run_install_one_failure_returns_one():
     """Any failing step returns exit code 1."""
     with patch("cpueval.install.install_system_deps", return_value=(False, "dnf error")), \
-         patch("cpueval.install.install_ansible_collections", return_value=(True, "ok")):
+         patch("cpueval.install.install_ansible_collections", return_value=(True, "ok")), \
+         patch("cpueval.install.install_shell_completion", return_value=(True, "ok")):
         code = run_install()
     assert code == 1
 
@@ -230,7 +239,8 @@ def test_run_install_one_failure_returns_one():
 def test_run_install_skip_system_deps_only_calls_collections():
     """--skip-system-deps skips dnf but still installs collections."""
     with patch("cpueval.install.install_system_deps") as mock_sys, \
-         patch("cpueval.install.install_ansible_collections", return_value=(True, "ok")):
+         patch("cpueval.install.install_ansible_collections", return_value=(True, "ok")), \
+         patch("cpueval.install.install_shell_completion", return_value=(True, "ok")):
         run_install(skip_system_deps=True)
     mock_sys.assert_not_called()
 
@@ -238,18 +248,42 @@ def test_run_install_skip_system_deps_only_calls_collections():
 def test_run_install_skip_collections_only_calls_system_deps():
     """--skip-collections skips galaxy but still installs system packages."""
     with patch("cpueval.install.install_system_deps", return_value=(True, "ok")), \
-         patch("cpueval.install.install_ansible_collections") as mock_col:
+         patch("cpueval.install.install_ansible_collections") as mock_col, \
+         patch("cpueval.install.install_shell_completion", return_value=(True, "ok")):
         run_install(skip_collections=True)
     mock_col.assert_not_called()
+
+
+def test_run_install_skip_completion_does_not_call_completion():
+    """--skip-completion skips shell completion setup."""
+    with patch("cpueval.install.install_system_deps", return_value=(True, "ok")), \
+         patch("cpueval.install.install_ansible_collections", return_value=(True, "ok")), \
+         patch("cpueval.install.install_shell_completion") as mock_comp:
+        run_install(skip_completion=True)
+    mock_comp.assert_not_called()
+
+
+def test_run_install_skip_deps_still_installs_completion():
+    """Skipping dnf and galaxy still sets up tab completion."""
+    with patch("cpueval.install.install_system_deps") as mock_sys, \
+         patch("cpueval.install.install_ansible_collections") as mock_col, \
+         patch("cpueval.install.install_shell_completion", return_value=(True, "ok")) as mock_comp:
+        code = run_install(skip_system_deps=True, skip_collections=True)
+    assert code == 0
+    mock_sys.assert_not_called()
+    mock_col.assert_not_called()
+    mock_comp.assert_called_once_with(False)
 
 
 def test_run_install_dry_run_passes_flag():
     """dry_run=True propagates to individual install functions."""
     with patch("cpueval.install.install_system_deps", return_value=(True, "[dry-run] ...")) as mock_sys, \
-         patch("cpueval.install.install_ansible_collections", return_value=(True, "[dry-run] ...")) as mock_col:
+         patch("cpueval.install.install_ansible_collections", return_value=(True, "[dry-run] ...")) as mock_col, \
+         patch("cpueval.install.install_shell_completion", return_value=(True, "[dry-run] ...")) as mock_comp:
         run_install(dry_run=True)
     mock_sys.assert_called_once_with(True)
     mock_col.assert_called_once_with(True)
+    mock_comp.assert_called_once_with(True)
 
 
 def test_run_install_dry_run_succeeds_without_ansible_galaxy(tmp_path, monkeypatch):
@@ -258,5 +292,116 @@ def test_run_install_dry_run_succeeds_without_ansible_galaxy(tmp_path, monkeypat
     req.write_text("collections: []\n")
     monkeypatch.setattr("cpueval.install._requirements_path", lambda: req)
     monkeypatch.setattr("shutil.which", lambda _: None)
-    code = run_install(dry_run=True)
+    with patch("cpueval.install.install_shell_completion", return_value=(True, "[dry-run] ...")):
+        code = run_install(dry_run=True)
     assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# shell completion
+# ---------------------------------------------------------------------------
+
+_BASH_SCRIPT = """\
+_cpueval_completion() {
+    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \\
+                   COMP_CWORD=$COMP_CWORD \\
+                   _CPUEVAL_COMPLETE=complete_bash $1 ) )
+    return 0
+}
+
+complete -o default -F _cpueval_completion cpueval
+"""
+
+_ZSH_SCRIPT = """\
+#compdef cpueval
+
+_cpueval_completion() {
+    eval $(env _TYPER_COMPLETE_ARGS="${words[1,$CURRENT]}" _CPUEVAL_COMPLETE=complete_zsh cpueval)
+}
+
+compdef _cpueval_completion cpueval
+"""
+
+
+def test_enable_dot_slash_completion_bash(tmp_path):
+    """Bash complete line also registers ./cpueval."""
+    path = tmp_path / "cpueval.sh"
+    path.write_text(_BASH_SCRIPT)
+    _enable_dot_slash_completion(path, "cpueval")
+    text = path.read_text()
+    assert "complete -o default -F _cpueval_completion cpueval ./cpueval" in text
+
+
+def test_enable_dot_slash_completion_bash_idempotent(tmp_path):
+    """Running the patch twice does not duplicate ./cpueval."""
+    path = tmp_path / "cpueval.sh"
+    path.write_text(_BASH_SCRIPT)
+    _enable_dot_slash_completion(path, "cpueval")
+    _enable_dot_slash_completion(path, "cpueval")
+    assert path.read_text().count("./cpueval") == 1
+
+
+def test_enable_dot_slash_completion_zsh(tmp_path):
+    """Zsh registers ./cpueval and invokes the command being completed."""
+    path = tmp_path / "_cpueval"
+    path.write_text(_ZSH_SCRIPT)
+    _enable_dot_slash_completion(path, "cpueval")
+    text = path.read_text()
+    assert "#compdef cpueval ./cpueval" in text
+    assert "compdef _cpueval_completion cpueval ./cpueval" in text
+    assert "${words[1]}" in text
+    assert "=complete_zsh cpueval" not in text
+
+
+def test_install_shell_completion_dry_run_no_write(monkeypatch):
+    """Dry-run reports the plan without calling Typer's installer."""
+    monkeypatch.setattr(
+        "shellingham.detect_shell", lambda: ("bash", "/bin/bash")
+    )
+    with patch("typer._completion_shared.install") as mock_install:
+        ok, msg = install_shell_completion(dry_run=True)
+    assert ok is True
+    assert "dry-run" in msg
+    assert "./cpueval" in msg
+    mock_install.assert_not_called()
+
+
+def test_install_shell_completion_unknown_shell_skips(monkeypatch):
+    """Unsupported shells are a soft-skip, not a failure."""
+    monkeypatch.setattr(
+        "shellingham.detect_shell", lambda: ("fish", "/usr/bin/fish")
+    )
+    ok, msg = install_shell_completion()
+    assert ok is None
+    assert "fish" in msg
+
+
+def test_install_shell_completion_detect_failure_skips(monkeypatch):
+    """A detection error is a soft-skip with a recovery hint."""
+    def _raise():
+        raise RuntimeError("no shell")
+
+    monkeypatch.setattr("shellingham.detect_shell", _raise)
+    ok, msg = install_shell_completion()
+    assert ok is None
+    assert "--install-completion" in msg
+
+
+def test_install_shell_completion_success_patches_script(tmp_path, monkeypatch):
+    """Successful install writes Typer's script then registers ./cpueval."""
+    script = tmp_path / "cpueval.sh"
+    script.write_text(_BASH_SCRIPT)
+
+    monkeypatch.setattr(
+        "shellingham.detect_shell", lambda: ("bash", "/bin/bash")
+    )
+
+    def fake_install(shell=None, prog_name=None, complete_var=None):
+        return shell, script
+
+    monkeypatch.setattr("typer._completion_shared.install", fake_install)
+    ok, msg = install_shell_completion()
+    assert ok is True
+    assert "bash" in msg
+    assert "./cpueval" in script.read_text()
+    assert "exec bash" in msg

--- a/automation/cli/tests/test_launcher.py
+++ b/automation/cli/tests/test_launcher.py
@@ -1,0 +1,25 @@
+"""Regression checks for the repo-root ./cpueval launcher."""
+
+from pathlib import Path
+
+
+def _launcher() -> str:
+    # tests/ -> cli/ -> automation/ -> repo root
+    return (Path(__file__).resolve().parents[3] / "cpueval").read_text()
+
+
+def test_launcher_requires_python_310():
+    """Launcher must refuse the RHEL 9 / UBI 9 default python3 (3.9)."""
+    text = _launcher()
+    assert "3, 10" in text
+    assert "python3.12" in text
+    assert "python3.11" in text
+    assert "python3.10" in text
+
+
+def test_launcher_bootstraps_python312_via_dnf():
+    """On dnf hosts without 3.10+, first run installs python3.12."""
+    text = _launcher()
+    assert "sudo dnf install -y python3.12" in text
+    assert "microdnf install -y python3.12" in text
+    assert "UBI 9" in text

--- a/automation/cli/tests/test_launcher.py
+++ b/automation/cli/tests/test_launcher.py
@@ -20,6 +20,8 @@ def test_launcher_requires_python_310():
 def test_launcher_bootstraps_python312_via_dnf():
     """On dnf hosts without 3.10+, first run installs python3.12."""
     text = _launcher()
-    assert "sudo dnf install -y python3.12" in text
+    assert "dnf install -y python3.12" in text
     assert "microdnf install -y python3.12" in text
     assert "UBI 9" in text
+    assert "_cpueval_pkg" in text
+    assert "command -v sudo" in text

--- a/automation/cli/tests/test_launcher.py
+++ b/automation/cli/tests/test_launcher.py
@@ -25,3 +25,4 @@ def test_launcher_bootstraps_python312_via_dnf():
     assert "UBI 9" in text
     assert "_cpueval_pkg" in text
     assert "command -v sudo" in text
+    assert 'export PATH="$VENV_DIR/bin:$PATH"' in text

--- a/cpueval
+++ b/cpueval
@@ -26,19 +26,35 @@ _cpueval_find_python() {
 }
 
 _cpueval_python_hint() {
-    echo "Error: cpueval requires Python 3.10+ (python3 is $(python3 -c 'import sys; print("%d.%d.%d" % sys.version_info[:3])' 2>/dev/null || echo 'not found'))." >&2
+    local pyver
+    pyver="$(python3 -c 'import sys; print("%d.%d.%d" % sys.version_info[:3])' 2>/dev/null || echo 'not found')"
+    echo "Error: cpueval requires Python 3.10+ (python3 is ${pyver})." >&2
     echo "Install Python 3.10 or newer, then re-run:" >&2
-    echo "  RHEL 9 / UBI 9:  sudo dnf install -y python3.12" >&2
-    echo "  Fedora:          sudo dnf install -y python3.12" >&2
+    if [ "${EUID:-$(id -u 2>/dev/null || echo 1)}" -eq 0 ]; then
+        echo "  RHEL 9 / UBI 9:  dnf install -y python3.12" >&2
+        echo "  Fedora:          dnf install -y python3.12" >&2
+    else
+        echo "  RHEL 9 / UBI 9:  sudo dnf install -y python3.12" >&2
+        echo "  Fedora:          sudo dnf install -y python3.12" >&2
+    fi
     echo "  Ubuntu/Debian:   sudo apt install -y python3.12" >&2
     echo "  macOS:           brew install python@3.12" >&2
 }
 
+# Use sudo only for non-root users who have it. UBI/root containers do not.
+_cpueval_pkg() {
+    if [ "${EUID:-$(id -u 2>/dev/null || echo 1)}" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
+        sudo "$@"
+    else
+        "$@"
+    fi
+}
+
 _cpueval_dnf_install_python312() {
     if command -v dnf >/dev/null 2>&1; then
-        sudo dnf install -y python3.12
+        _cpueval_pkg dnf install -y python3.12
     elif command -v microdnf >/dev/null 2>&1; then
-        sudo microdnf install -y python3.12
+        _cpueval_pkg microdnf install -y python3.12
     else
         return 1
     fi
@@ -64,7 +80,7 @@ if [ ! -d "$VENV_DIR" ]; then
     if ! "$PYTHON" -m venv "$VENV_DIR"; then
         rm -rf "$VENV_DIR"
         echo "Error: Failed to create virtual environment with $PYTHON" >&2
-        echo "On RHEL 9 / UBI 9 you may also need: sudo dnf install -y python3.12" >&2
+        echo "On RHEL 9 / UBI 9 you may also need: dnf install -y python3.12" >&2
         exit 1
     fi
 

--- a/cpueval
+++ b/cpueval
@@ -100,4 +100,5 @@ fi
 # Run cpueval via the installed entry point so the program name is 'cpueval'
 # (using 'python -m cpueval' would make Typer name the shell completion file
 # '_python -m cpueval' instead of '_cpueval')
+export PATH="$VENV_DIR/bin:$PATH"
 exec "$VENV_DIR/bin/cpueval" "$@"

--- a/cpueval
+++ b/cpueval
@@ -8,12 +8,63 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLI_DIR="$SCRIPT_DIR/automation/cli"
 VENV_DIR="$CLI_DIR/.venv"
 
+# cpueval requires Python 3.10+ (see automation/cli/pyproject.toml).
+# RHEL 9 / UBI 9 ships python3 = 3.9; prefer a newer interpreter when present.
+_cpueval_python_ok() {
+    "$1" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' 2>/dev/null
+}
+
+_cpueval_find_python() {
+    local candidate
+    for candidate in python3.12 python3.11 python3.10 python3; do
+        if command -v "$candidate" >/dev/null 2>&1 && _cpueval_python_ok "$candidate"; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+_cpueval_python_hint() {
+    echo "Error: cpueval requires Python 3.10+ (python3 is $(python3 -c 'import sys; print("%d.%d.%d" % sys.version_info[:3])' 2>/dev/null || echo 'not found'))." >&2
+    echo "Install Python 3.10 or newer, then re-run:" >&2
+    echo "  RHEL 9 / UBI 9:  sudo dnf install -y python3.12" >&2
+    echo "  Fedora:          sudo dnf install -y python3.12" >&2
+    echo "  Ubuntu/Debian:   sudo apt install -y python3.12" >&2
+    echo "  macOS:           brew install python@3.12" >&2
+}
+
+_cpueval_dnf_install_python312() {
+    if command -v dnf >/dev/null 2>&1; then
+        sudo dnf install -y python3.12
+    elif command -v microdnf >/dev/null 2>&1; then
+        sudo microdnf install -y python3.12
+    else
+        return 1
+    fi
+}
+
 # Create venv if it doesn't exist
 if [ ! -d "$VENV_DIR" ]; then
-    echo "Creating virtual environment at $VENV_DIR..."
-    if ! python3 -m venv "$VENV_DIR"; then
+    PYTHON=""
+    if PYTHON="$(_cpueval_find_python)"; then
+        :
+    elif command -v dnf >/dev/null 2>&1 || command -v microdnf >/dev/null 2>&1; then
+        echo "Python 3.10+ is required and was not found. Installing python3.12..."
+        if ! _cpueval_dnf_install_python312 || ! PYTHON="$(_cpueval_find_python)"; then
+            _cpueval_python_hint
+            exit 1
+        fi
+    else
+        _cpueval_python_hint
+        exit 1
+    fi
+
+    echo "Creating virtual environment at $VENV_DIR (with $PYTHON)..."
+    if ! "$PYTHON" -m venv "$VENV_DIR"; then
         rm -rf "$VENV_DIR"
-        echo "Error: Failed to create virtual environment" >&2
+        echo "Error: Failed to create virtual environment with $PYTHON" >&2
+        echo "On RHEL 9 / UBI 9 you may also need: sudo dnf install -y python3.12" >&2
         exit 1
     fi
 

--- a/docs/cpueval-cli.md
+++ b/docs/cpueval-cli.md
@@ -225,6 +225,54 @@ Edit that file to change permanent defaults.
 > **Tip:** The suite YAML path is printed at the bottom of every `show` output. Edit it to
 > permanently change defaults; use CLI flags (e.g. `--cores`) to override for a single run.
 
+### install - Install prerequisites
+
+Automates the dependency setup steps required before running benchmarks.
+
+```bash
+# Full install: system packages (dnf) + Ansible collections
+./cpueval install
+
+# Skip system packages (already installed)
+./cpueval install --skip-system-deps
+
+# Skip Ansible collection install
+./cpueval install --skip-collections
+
+# Preview commands without executing
+./cpueval install --dry-run
+```
+
+Example output:
+
+```text
+cpueval install
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Step                         ┃ Status     ┃ Details                                      ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ System packages (dnf)        │ ✓          │ installed: ansible-core, python3-pip, git    │
+│ Ansible collections          │ ✓          │ collections installed                         │
+└──────────────────────────────┴────────────┴──────────────────────────────────────────────┘
+
+✓ Install complete
+
+Next step: verify with cpueval doctor
+```
+
+**What it installs:**
+
+| Step | Tool | Notes |
+|------|------|-------|
+| System packages (dnf) | `ansible-core`, `python3-pip`, `git` | RHEL/Fedora only; soft-skipped on macOS/Ubuntu with alternative install hint |
+| Ansible collections | `containers.podman`, `ansible.posix` | From `automation/test-execution/ansible/requirements.yml` |
+
+On non-RHEL systems (macOS, Ubuntu) the dnf step shows `~` (skipped) and prints the
+equivalent `brew` / `apt` one-liner. Install Ansible manually, then re-run
+`./cpueval install --skip-system-deps` to install the collections.
+
+After installing, verify everything with `./cpueval doctor`.
+
 ### doctor - Health checks
 
 ```bash

--- a/docs/cpueval-cli.md
+++ b/docs/cpueval-cli.md
@@ -241,7 +241,7 @@ Edit that file to change permanent defaults.
 Automates the dependency setup steps required before running benchmarks.
 
 ```bash
-# Full install: system packages (dnf) + Ansible collections + shell completion
+# Full install: system packages + Ansible collections + shell completion
 ./cpueval install
 
 # Skip system packages (already installed)
@@ -265,7 +265,7 @@ cpueval install
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Step                         ┃ Status     ┃ Details                                      ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ System packages (dnf)        │ ✓          │ installed: ansible-core, python3-pip, git    │
+│ System packages              │ ✓          │ dnf: python3-pip, git; pip: ansible-core>=2.14 │
 │ Ansible collections          │ ✓          │ collections installed                         │
 │ Shell completion             │ ✓          │ bash completion at ~/.bash_completions/…      │
 └──────────────────────────────┴────────────┴──────────────────────────────────────────────┘
@@ -280,12 +280,13 @@ Enable tab completion in this shell with exec bash or exec zsh, then try ./cpuev
 
 | Step | Tool | Notes |
 |------|------|-------|
-| System packages (dnf) | `ansible-core`, `python3-pip`, `git` | RHEL/Fedora only; soft-skipped on macOS/Ubuntu with alternative install hint |
+| System packages | `python3-pip`, `git`, `ansible-core` | `dnf` on RHEL/Fedora; UBI 9 has no `ansible-core` RPM so install falls back to `pip` in the cpueval venv |
 | Ansible collections | `containers.podman`, `ansible.posix` | From `automation/test-execution/ansible/requirements.yml` |
 | Shell completion | bash/zsh tab completion | Registers `cpueval` and `./cpueval`; restart the shell once (`exec bash` / `exec zsh`) |
 
-On non-RHEL systems (macOS, Ubuntu) the dnf step shows `~` (skipped) and prints the
-equivalent `brew` / `apt` one-liner. Install Ansible manually, then re-run
+On macOS/Ubuntu, `git`/`pip` are left to the OS; `ansible-core` is installed into
+the venv with pip. If pip cannot install Ansible, the step fails with a `brew` /
+`apt` one-liner — install Ansible manually, then re-run
 `./cpueval install --skip-system-deps` to install the collections.
 
 After installing, restart the shell (`exec bash` or `exec zsh`) so `./cpueval <TAB>`

--- a/docs/cpueval-cli.md
+++ b/docs/cpueval-cli.md
@@ -49,7 +49,9 @@ cpueval supports tab-completion for bash and zsh.
 **Install (one-time, auto-detects shell):**
 
 ```bash
-./cpueval --install-completion
+./cpueval install                 # includes completion for cpueval and ./cpueval
+# completion only (same ./cpueval registration):
+./cpueval install --skip-system-deps --skip-collections
 exec zsh    # or exec bash
 ```
 
@@ -64,6 +66,7 @@ exec zsh    # or exec bash
 
 | Typing… | Completes with… |
 |---------|-----------------|
+| `./cpueval <TAB>` | `doctor`, `install`, `list`, `run`, `show`, … |
 | `cpueval run --suite <TAB>` | `audio`, `chat-smoke`, `concurrent-load`, … |
 | `cpueval run --suite ch<TAB>` | `chat-smoke` |
 | `cpueval run --model <TAB>` | model names discovered from your results directories |
@@ -80,7 +83,10 @@ exec zsh    # or exec bash
 ./cpueval --show-completion
 ```
 
-**PATH requirement:** `cpueval` must be on your `PATH` for completion to work (the completion script calls `cpueval` internally). Simplest approach — add the repo root:
+**PATH requirement:** Completion is registered for both `cpueval` and `./cpueval`,
+so tab-complete works from the repo launcher after a shell restart. If you invoke
+the command as `cpueval` (no `./`), it still needs to be on your `PATH` — add the
+repo root:
 
 ```bash
 # Add to ~/.zshrc or ~/.bashrc
@@ -230,7 +236,7 @@ Edit that file to change permanent defaults.
 Automates the dependency setup steps required before running benchmarks.
 
 ```bash
-# Full install: system packages (dnf) + Ansible collections
+# Full install: system packages (dnf) + Ansible collections + shell completion
 ./cpueval install
 
 # Skip system packages (already installed)
@@ -238,6 +244,9 @@ Automates the dependency setup steps required before running benchmarks.
 
 # Skip Ansible collection install
 ./cpueval install --skip-collections
+
+# Skip tab-completion setup
+./cpueval install --skip-completion
 
 # Preview commands without executing
 ./cpueval install --dry-run
@@ -253,11 +262,13 @@ cpueval install
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
 │ System packages (dnf)        │ ✓          │ installed: ansible-core, python3-pip, git    │
 │ Ansible collections          │ ✓          │ collections installed                         │
+│ Shell completion             │ ✓          │ bash completion at ~/.bash_completions/…      │
 └──────────────────────────────┴────────────┴──────────────────────────────────────────────┘
 
 ✓ Install complete
 
 Next step: verify with cpueval doctor
+Enable tab completion in this shell with exec bash or exec zsh, then try ./cpueval <TAB>
 ```
 
 **What it installs:**
@@ -266,12 +277,16 @@ Next step: verify with cpueval doctor
 |------|------|-------|
 | System packages (dnf) | `ansible-core`, `python3-pip`, `git` | RHEL/Fedora only; soft-skipped on macOS/Ubuntu with alternative install hint |
 | Ansible collections | `containers.podman`, `ansible.posix` | From `automation/test-execution/ansible/requirements.yml` |
+| Shell completion | bash/zsh tab completion | Registers `cpueval` and `./cpueval`; restart the shell once (`exec bash` / `exec zsh`) |
 
 On non-RHEL systems (macOS, Ubuntu) the dnf step shows `~` (skipped) and prints the
 equivalent `brew` / `apt` one-liner. Install Ansible manually, then re-run
 `./cpueval install --skip-system-deps` to install the collections.
 
-After installing, verify everything with `./cpueval doctor`.
+After installing, restart the shell (`exec bash` or `exec zsh`) so `./cpueval <TAB>`
+works, then verify with `./cpueval doctor`. Use `--skip-completion` to leave
+tab-completion alone; `./cpueval --install-completion` still works as a standalone
+reinstall.
 
 ### doctor - Health checks
 

--- a/docs/cpueval-cli.md
+++ b/docs/cpueval-cli.md
@@ -33,7 +33,12 @@ Matrix-first CLI for running comprehensive CPU benchmarks. Most suites run full 
 
 ## Installation
 
-The `./cpueval` launcher automatically creates a virtual environment on first run. For manual installation:
+The `./cpueval` launcher automatically creates a virtual environment on first
+run. It requires **Python 3.10+**. On RHEL 9 / UBI 9, `python3` is 3.9; the
+launcher looks for `python3.12` / `python3.11` / `python3.10` and will install
+`python3.12` via `dnf` if needed.
+
+For manual installation:
 
 ```bash
 cd automation/cli

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -138,8 +138,16 @@ cd vllm-cpu-perf-eval
 ./cpueval install --skip-system-deps
 ```
 
-The `./cpueval` launcher also auto-creates a Python venv for the CLI itself on
-first run — no separate `pip install` step required.
+The `./cpueval` launcher auto-creates a Python venv on first run — no separate
+`pip install` step required.
+
+> **Bootstrap note:** The launcher runs `python3 -m venv` before `cpueval install`
+> can install `python3-pip`. On a minimal RHEL image where the venv module is
+> absent, the launcher will fail first. If that happens:
+> ```bash
+> sudo dnf install -y python3-pip   # unblocks venv creation
+> ./cpueval install
+> ```
 
 #### 2. Set Environment Variables
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -141,11 +141,14 @@ cd vllm-cpu-perf-eval
 The `./cpueval` launcher auto-creates a Python venv on first run — no separate
 `pip install` step required.
 
-> **Bootstrap note:** The launcher runs `python3 -m venv` before `cpueval install`
-> can install `python3-pip`. On a minimal RHEL image where the venv module is
-> absent, the launcher will fail first. If that happens:
+> **Bootstrap note:** The launcher needs **Python 3.10+** before it can create
+> the venv (`python3` on RHEL 9 / UBI 9 is 3.9). It prefers `python3.12` /
+> `python3.11` / `python3.10` when those binaries exist, and on dnf systems it
+> will `sudo dnf install -y python3.12` if nothing new enough is found.
+>
+> If venv creation still fails (missing `ensurepip` / venv module):
 > ```bash
-> sudo dnf install -y python3-pip   # unblocks venv creation
+> sudo dnf install -y python3.12 python3-pip
 > ./cpueval install
 > ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,28 +20,30 @@ The vLLM CPU Performance Evaluation framework uses **Ansible** to automate:
 The control machine is your local laptop/workstation where you run Ansible commands.
 
 **Install Ansible:**
+
+**On RHEL/Fedora** — use `cpueval install` (see [Clone and Install](#1-clone-and-install) below):
+
 ```bash
-# On macOS
+# After cloning the repo, one command installs everything:
+./cpueval install
+```
+
+**On macOS / Ubuntu/Debian** — install Ansible manually, then install collections:
+
+```bash
+# macOS
 brew install ansible
 
-# On Ubuntu/Debian
-sudo apt update && sudo apt install -y ansible
+# Ubuntu/Debian
+sudo apt update && sudo apt install -y ansible-core python3-pip git
 
-# On RHEL/Fedora
-sudo dnf install -y ansible-core python3-pip
-pip install podman-compose
+# Then install Ansible collections (works on any OS once ansible-galaxy is available)
+./cpueval install --skip-system-deps
+```
 
+```bash
 # Verify installation
 ansible --version  # Should be 2.14+
-
-# Navigate to the ansible directory
-cd automation/test-execution/ansible
-
-# Install required Ansible collections
-ansible-galaxy collection install -r requirements.yml
-
-# Or install individually
-ansible-galaxy collection install containers.podman ansible.posix
 ```
 
 ### Test Hosts (DUT and Load Generator)
@@ -128,11 +130,16 @@ The `cpueval` CLI provides a simple interface for running standard benchmarks.
 git clone https://github.com/redhat-et/vllm-cpu-perf-eval.git
 cd vllm-cpu-perf-eval
 
-# Install cpueval
-cd automation/cli
-pip install -e .
-cd ../..
+# Install prerequisites (ansible-core, python3-pip, git via dnf + Ansible collections).
+# On RHEL/Fedora this is a single command:
+./cpueval install
+
+# On macOS/Ubuntu: install Ansible first (brew/apt), then:
+./cpueval install --skip-system-deps
 ```
+
+The `./cpueval` launcher also auto-creates a Python venv for the CLI itself on
+first run — no separate `pip install` step required.
 
 #### 2. Set Environment Variables
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,14 +21,18 @@ The control machine is your local laptop/workstation where you run Ansible comma
 
 **Install Ansible:**
 
-**On RHEL/Fedora** — use `cpueval install` (see [Clone and Install](#1-clone-and-install) below):
+**On RHEL/Fedora/UBI** — use `cpueval install` (see [Clone and Install](#1-clone-and-install) below):
 
 ```bash
 # After cloning the repo, one command installs everything:
 ./cpueval install
 ```
 
-**On macOS / Ubuntu/Debian** — install Ansible manually, then install collections:
+UBI 9 does not ship an `ansible-core` RPM; `cpueval install` pip-installs
+`ansible-core` into the CLI venv and continues with Galaxy collections.
+
+**On macOS / Ubuntu/Debian** — `./cpueval install` also pip-installs `ansible-core`
+into the venv. If that fails, install Ansible from the OS then continue:
 
 ```bash
 # macOS
@@ -130,12 +134,9 @@ The `cpueval` CLI provides a simple interface for running standard benchmarks.
 git clone https://github.com/redhat-et/vllm-cpu-perf-eval.git
 cd vllm-cpu-perf-eval
 
-# Install prerequisites (ansible-core, python3-pip, git via dnf + Ansible collections).
-# On RHEL/Fedora this is a single command:
+# Install prerequisites (git/pip via dnf when present, ansible-core via dnf or
+# pip into the venv, then Ansible collections).
 ./cpueval install
-
-# On macOS/Ubuntu: install Ansible first (brew/apt), then:
-./cpueval install --skip-system-deps
 ```
 
 The `./cpueval` launcher auto-creates a Python venv on first run — no separate
@@ -144,11 +145,12 @@ The `./cpueval` launcher auto-creates a Python venv on first run — no separate
 > **Bootstrap note:** The launcher needs **Python 3.10+** before it can create
 > the venv (`python3` on RHEL 9 / UBI 9 is 3.9). It prefers `python3.12` /
 > `python3.11` / `python3.10` when those binaries exist, and on dnf systems it
-> will `sudo dnf install -y python3.12` if nothing new enough is found.
+> will `dnf install -y python3.12` if nothing new enough is found (with `sudo`
+> only when you are not already root).
 >
 > If venv creation still fails (missing `ensurepip` / venv module):
 > ```bash
-> sudo dnf install -y python3.12 python3-pip
+> dnf install -y python3.12 python3-pip   # add sudo if you are not root
 > ./cpueval install
 > ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -164,15 +164,21 @@ export ANSIBLE_PRIVATE_KEY_FILE=~/your-key.pem
 export HF_TOKEN=$(cat ~/hf-token)
 ```
 
-#### 3. Enable Shell Completion (Optional)
+#### 3. Enable Shell Completion
+
+`./cpueval install` already sets up bash/zsh tab completion for `./cpueval`.
+Restart the shell once so it takes effect:
 
 ```bash
-# One-time setup — auto-detects bash/zsh
-./cpueval --install-completion
-exec zsh  # or exec bash
+exec bash  # or: exec zsh
 ```
 
-Tab-complete suite names, model names, and profiles. See [cpueval CLI Guide](cpueval-cli.md#shell-completion) for details.
+Then `./cpueval <TAB>` completes commands. To reinstall later:
+
+```bash
+./cpueval --install-completion
+exec bash  # or exec zsh
+```
 
 #### 4. Check System Health
 


### PR DESCRIPTION
…tions

Adds `cpueval install` to automate the prerequisite setup steps:
- Installs ansible-core, python3-pip, git via `sudo dnf install` on RHEL/Fedora
- Installs Ansible Galaxy collections from automation/test-execution/ansible/requirements.yml
- Soft-skips the dnf step on non-RHEL systems (returns green ✓ with a note)
- Supports --skip-system-deps, --skip-collections, and --dry-run flags