### PR TITLE
docs: point remaining setup guides at cpueval install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ The recommended entry point is the **cpueval CLI** — it wraps Ansible playbook
 suite scripts so you can run full test matrices without hand-writing playbook commands.
 
 ```bash
+git clone https://github.com/redhat-et/vllm-cpu-perf-eval.git
+cd vllm-cpu-perf-eval
+
+# System packages, Ansible collections, and tab completion
+./cpueval install
+
 # Set up your test hosts
 export DUT_HOSTNAME=<dut-host>
 export LOADGEN_HOSTNAME=<loadgen-host>
@@ -88,7 +94,9 @@ pass `-e "allow_unsupported_tests=true"` to Ansible or set `ALLOW_UNSUPPORTED_TE
 - **OS:** Ubuntu 22.04+, RHEL 9+, or Fedora 38+
 - **Software:** Python 3.10+, Docker 24+ or Podman 4+, Ansible 2.14+, vLLM, GuideLLM
 
-See [Getting Started](docs/getting-started.md) for control-machine and DUT setup.
+On the control machine, `./cpueval install` installs Ansible, Galaxy collections,
+and shell completion. See [Getting Started](docs/getting-started.md) for
+control-machine and DUT setup.
 
 ## Contributing
 

--- a/automation/cli/README.md
+++ b/automation/cli/README.md
@@ -11,6 +11,9 @@ Thin CLI wrapper for running full test matrices with easy overrides.
 ## Quick Start
 
 ```bash
+# One-time: Ansible, Galaxy collections, tab completion
+./cpueval install
+
 # Matrix suites - run full test matrix (no --model required!)
 ./cpueval --suite rhaiis-sweep           # 60 combinations: 5 models × 3 cores × 4 workloads
 ./cpueval --suite embedding              # 30 combinations: 5 models × 3 cores × 2 scenarios
@@ -31,11 +34,19 @@ Thin CLI wrapper for running full test matrices with easy overrides.
 
 ## Installation
 
-The `./cpueval` launcher automatically creates a virtual environment and installs
-dependencies on first run. It requires Python 3.10+; on RHEL 9 / UBI 9 it will
-install `python3.12` via dnf if `python3` is 3.9.
+From the repository root:
 
-For manual installation:
+```bash
+./cpueval install
+```
+
+This installs system packages (when `dnf` is present), Ansible Galaxy
+collections, and bash/zsh tab completion. The `./cpueval` launcher automatically
+creates a virtual environment and installs Python dependencies on first run.
+It requires Python 3.10+; on RHEL 9 / UBI 9 it will install `python3.12` via
+dnf if `python3` is 3.9.
+
+For a manual venv only (no system packages or collections):
 ```bash
 cd automation/cli
 python3 -m venv .venv

--- a/automation/test-execution/ansible/README.md
+++ b/automation/test-execution/ansible/README.md
@@ -9,22 +9,20 @@ Automated testing framework for vLLM embedding and LLM generative models with NU
 **On your control machine (where you run Ansible):**
 
 ```bash
-# Install Ansible (if not already installed)
-# On macOS
-brew install ansible
+# From the repository root (recommended)
+./cpueval install
+```
 
-# On Ubuntu/Debian
-sudo apt update && sudo apt install -y ansible
+This installs `ansible-core` (dnf or pip into the cpueval venv), Galaxy
+collections from `requirements.yml`, and bash/zsh tab completion. See
+[Getting Started](../../../docs/getting-started.md#1-clone-and-install) for
+platform notes (RHEL/Fedora/UBI, macOS, Ubuntu).
 
-# On RHEL/Fedora
-sudo dnf install -y ansible
+Verify:
 
-# Verify installation
+```bash
 ansible --version  # Should be 2.14+
-
-# Install required Ansible collections
-cd automation/test-execution/ansible
-ansible-galaxy collection install -r requirements.yml
+./cpueval doctor --no-ping
 ```
 
 **Ansible Version Compatibility:**
@@ -70,7 +68,7 @@ ansible -i inventory/hosts.yml all -b -m reboot
 - **Targets**: DUT and Load Generator hosts only (NOT your Ansible control machine)
 
 **Important Notes:**
-- **Option 2 (setup-platform.yml)**: Automatically installs Podman, Python 3, and all performance tools on **DUT and Load Generator hosts**. Your Ansible control machine needs Ansible itself and the collections from requirements.yml.
+- **Option 2 (setup-platform.yml)**: Automatically installs Podman, Python 3, and all performance tools on **DUT and Load Generator hosts**. On the control machine, run `./cpueval install` for Ansible and the collections from `requirements.yml`.
 - **Option 1 (Manual)**: If you prefer minimal setup, manually install Podman/Docker and Python 3 on **DUT and Load Generator hosts** before running test playbooks.
 - **Container Images (vLLM and GuideLLM)**: Automatically pulled during test execution. Test playbooks handle this—no manual installation needed.
 - **Reboot Required**: After running setup-platform.yml, reboot hosts for kernel parameters to take effect.

--- a/automation/test-execution/ansible/tests/README.md
+++ b/automation/test-execution/ansible/tests/README.md
@@ -172,8 +172,16 @@ Tests run automatically on:
 
 ### Ansible Not Found
 
+From the repository root, prefer:
+
 ```bash
-pip install ansible
+./cpueval install
+```
+
+For an isolated test environment without the launcher:
+
+```bash
+pip install ansible-core
 ```
 
 ### Container Runtime Not Available

--- a/docs/ansible/test-execution.md
+++ b/docs/ansible/test-execution.md
@@ -14,16 +14,18 @@ optimization.
 
 **Control Machine (where you run Ansible):**
 
+From the repository root:
+
 ```bash
-# Install Ansible
-pip install ansible-core
-
-# Navigate to ansible directory
-cd automation/test-execution/ansible
-
-# Install required collections
-ansible-galaxy collection install -r requirements.yml
+# Install Ansible, Galaxy collections, and tab completion
+./cpueval install
 ```
+
+See [Getting Started](../getting-started.md#1-clone-and-install) and the
+[cpueval CLI install command](../cpueval-cli.md#installation)
+for platform notes (`--skip-system-deps`, UBI 9, macOS/Ubuntu).
+
+Then run playbooks from `automation/test-execution/ansible/`.
 
 **Test Hosts (DUT and Load Generator):**
 

--- a/docs/audio-benchmarking.md
+++ b/docs/audio-benchmarking.md
@@ -45,6 +45,12 @@ Comprehensive guide for benchmarking audio models (ASR, translation, chat) on vL
 
 ## Quick Start
 
+From the repository root, install Ansible and Galaxy collections once:
+
+```bash
+./cpueval install
+```
+
 ### 1. Configure Hosts
 
 ```bash

--- a/docs/cpueval-cli.md
+++ b/docs/cpueval-cli.md
@@ -48,7 +48,7 @@ creates a virtual environment on first run. It requires **Python 3.10+**. On
 RHEL 9 / UBI 9, `python3` is 3.9; the launcher looks for `python3.12` /
 `python3.11` / `python3.10` and will install `python3.12` via `dnf` if needed.
 
-See [install - Install prerequisites](#install---install-prerequisites) for
+See [install - Install prerequisites](#install-prerequisites) for
 flags (`--skip-system-deps`, `--dry-run`, and so on).
 
 For a manual venv only (no system packages or collections):
@@ -249,7 +249,7 @@ Edit that file to change permanent defaults.
 > **Tip:** The suite YAML path is printed at the bottom of every `show` output. Edit it to
 > permanently change defaults; use CLI flags (e.g. `--cores`) to override for a single run.
 
-### install - Install prerequisites
+### install - Install prerequisites {#install-prerequisites}
 
 Automates the dependency setup steps required before running benchmarks.
 

--- a/docs/cpueval-cli.md
+++ b/docs/cpueval-cli.md
@@ -12,6 +12,9 @@ Matrix-first CLI for running comprehensive CPU benchmarks. Most suites run full 
 ## Quick Start
 
 ```bash
+# One-time: Ansible, Galaxy collections, tab completion
+./cpueval install
+
 # Matrix suites - run full matrices (no --model required!)
 ./cpueval --suite rhaiis-sweep           # 60 combinations: 5 models × 3 cores × 4 workloads
 ./cpueval --suite embedding              # 30 combinations: 5 models × 3 cores × 2 scenarios
@@ -33,12 +36,22 @@ Matrix-first CLI for running comprehensive CPU benchmarks. Most suites run full 
 
 ## Installation
 
-The `./cpueval` launcher automatically creates a virtual environment on first
-run. It requires **Python 3.10+**. On RHEL 9 / UBI 9, `python3` is 3.9; the
-launcher looks for `python3.12` / `python3.11` / `python3.10` and will install
-`python3.12` via `dnf` if needed.
+From the repository root:
 
-For manual installation:
+```bash
+./cpueval install
+```
+
+That command installs system packages (when `dnf` is present), Ansible Galaxy
+collections, and bash/zsh tab completion. The `./cpueval` launcher automatically
+creates a virtual environment on first run. It requires **Python 3.10+**. On
+RHEL 9 / UBI 9, `python3` is 3.9; the launcher looks for `python3.12` /
+`python3.11` / `python3.10` and will install `python3.12` via `dnf` if needed.
+
+See [install - Install prerequisites](#install---install-prerequisites) for
+flags (`--skip-system-deps`, `--dry-run`, and so on).
+
+For a manual venv only (no system packages or collections):
 
 ```bash
 cd automation/cli
@@ -319,6 +332,9 @@ cpueval system health check
 └──────────────────────┴──────────────┴────────────────────────────────────────┘
 
 ✗ Some checks failed
+
+Tip: Missing Ansible or collections? Run:
+  ./cpueval install
 ```
 
 Verifies:
@@ -807,6 +823,9 @@ cpueval is a **thin wrapper** that:
 ```bash
 # Check what's failing
 ./cpueval doctor
+
+# Missing Ansible or collections
+./cpueval install
 
 # Common fixes
 export DUT_HOSTNAME=my-dut

--- a/docs/design/full-testing-deck.md
+++ b/docs/design/full-testing-deck.md
@@ -129,6 +129,7 @@ cpueval is a wrapper around the ansible automation.
 
 | Command | Description |
 |---------|-------------|
+| `cpueval install` | Install Ansible, Galaxy collections, and tab completion |
 | `cpueval doctor` | Validate environment (Ansible, SSH, env vars) |
 | `cpueval --suite <name>` | Run a test suite |
 | `cpueval list` | List all available suites |
@@ -136,7 +137,7 @@ cpueval is a wrapper around the ansible automation.
 | `cpueval profiles` | List CPU pinning profiles |
 | `cpueval results [--last]` | View results in terminal |
 | `cpueval dashboard start/stop` | Launch/stop Streamlit dashboard |
-| `cpueval --install-completion` | Enable bash/zsh/fish tab completion |
+| `cpueval --install-completion` | Reinstall bash/zsh tab completion |
 
 ```bash
 cpueval doctor

--- a/docs/embedding-models.md
+++ b/docs/embedding-models.md
@@ -4,6 +4,9 @@
 
 This guide covers testing embedding models on Intel Xeon processors using the vLLM performance evaluation framework. The framework supports three execution modes to accommodate different testing scenarios.
 
+Install Ansible and Galaxy collections once from the repository root with
+`./cpueval install` (see [Getting Started](getting-started.md#1-clone-and-install)).
+
 ## Execution Modes
 
 ### 1. Managed Mode (Load Generator + DUT) - Default

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -199,7 +199,8 @@ cpueval system health check
 ┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Check                ┃ Status       ┃ Details                                ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ ansible-playbook     │ ✓            │ unknown                                │
+│ ansible-playbook     │ ✓            │ ansible-playbook                       │
+│ Ansible collections  │ ✓            │ containers.podman installed            │
 │ Inventory file       │ ✓            │ .../ansible/inventory/hosts.yml        │
 │ Environment vars     │ ✓            │ DUT_HOSTNAME, LOADGEN_HOSTNAME set     │
 │ Host connectivity    │ ✓            │ dut: ok, loadgen: ok                   │

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Central index for the vLLM CPU Performance Evaluation framework.
 
 | I want to… | Go to |
 | --- | --- |
-| Set up and run my first benchmark | [Getting Started](getting-started.md) |
+| Set up and run my first benchmark | [Getting Started](getting-started.md) (`./cpueval install`) |
 | See all supported test suites | **[Test Suites](test-suites.md)** |
 | Run benchmarks from the CLI | [cpueval CLI](cpueval-cli.md) |
 | Find supported models | [Model Catalog](../models/models.md) |
@@ -19,8 +19,8 @@ Central index for the vLLM CPU Performance Evaluation framework.
 
 | Page | Description |
 | --- | --- |
-| [getting-started.md](getting-started.md) | Environment setup and first run |
-| [cpueval-cli.md](cpueval-cli.md) | CLI reference (recommended entry point) |
+| [getting-started.md](getting-started.md) | `./cpueval install`, environment setup, and first run |
+| [cpueval-cli.md](cpueval-cli.md) | CLI reference (`install`, `doctor`, suites) |
 | [test-suites.md](test-suites.md) | Central test suite reference |
 
 ### Test Suites & Models

--- a/docs/methodology/cve-vloc.md
+++ b/docs/methodology/cve-vloc.md
@@ -195,7 +195,7 @@ scope bus` errors.
 > throughput. They measure raw inference speed under synthetic or extracted
 > prompts — they do NOT run the VLoc agent loop and cannot measure
 > localization quality. See [Why online and offline measure different
-> things](#online-vs-offline--why-they-measure-different-things) below.
+> things](#online-vs-offline) below.
 
 | Metric | Definition |
 |--------|-----------|
@@ -242,7 +242,7 @@ Optional: Gemma-4-E2B/E4B for additional comparison.
 
 ---
 
-### Online vs Offline — Why They Measure Different Things
+### Online vs Offline — Why They Measure Different Things {#online-vs-offline}
 
 The VLoc agent loop is inherently **interactive**: each tool call depends on
 the previous model output and sandbox response. This multi-turn reasoning

--- a/docs/sections/getting-started.md
+++ b/docs/sections/getting-started.md
@@ -3,5 +3,5 @@
 
 Set up your environment and run your first benchmarks.
 
-- [Quick Start](../getting-started.md) — environment setup and first run
-- [cpueval CLI](../cpueval-cli.md) — recommended CLI entry point
+- [Quick Start](../getting-started.md) — `./cpueval install`, environment setup, and first run
+- [cpueval CLI](../cpueval-cli.md) — recommended CLI entry point (`install`, `doctor`, suites)

--- a/docs/test-suites.md
+++ b/docs/test-suites.md
@@ -37,6 +37,9 @@ run, how to run it, and where to read the detailed methodology.
 A typical session looks like this:
 
 ```bash
+# 0. One-time: Ansible, Galaxy collections, tab completion
+./cpueval install
+
 # 1. List available suites
 ./cpueval list
 
@@ -119,6 +122,9 @@ cpueval system health check
 └──────────────────────┴──────────────┴────────────────────────────────────────┘
 
 ✗ Some checks failed
+
+Tip: Missing Ansible or collections? Run:
+  ./cpueval install
 
 Tip: Set required environment variables:
   export DUT_HOSTNAME=<dut-host>

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -10,7 +10,7 @@ configurations for evaluating vLLM inference performance on CPU-based systems.
 <div class="quick-links">
   <div class="link-card">
     <h3>Getting Started</h3>
-    <p>Configure your test environment and run your first benchmark</p>
+    <p>Install with <code>./cpueval install</code>, then run your first benchmark</p>
     <a href="docs/getting-started/">Quick Start Guide →</a>
   </div>
 
@@ -22,7 +22,7 @@ configurations for evaluating vLLM inference performance on CPU-based systems.
 
   <div class="link-card">
     <h3>cpueval CLI</h3>
-    <p>Recommended entry point for running benchmarks</p>
+    <p>Install, doctor, and run benchmark suites from one command</p>
     <a href="docs/cpueval-cli/">CLI Guide →</a>
   </div>
 

--- a/tests/audio-models/README.md
+++ b/tests/audio-models/README.md
@@ -101,15 +101,14 @@ Plus comprehensive coverage of scalability, format impact, and sustained load be
 
 ### Prerequisites
 
-1. **Ensure Ansible is configured:**
+1. **Install Ansible and collections** (from the repository root):
    ```bash
-   cd automation/test-execution/ansible
-   ansible-galaxy collection install -r requirements.yml
+   ./cpueval install
    ```
 
 2. **Verify system access:**
    ```bash
-   ansible -i inventory/hosts.yml all -m ping
+   ./cpueval doctor
    ```
 
 3. **Container runtime:**

--- a/tests/embedding-models/embedding-models.md
+++ b/tests/embedding-models/embedding-models.md
@@ -16,16 +16,15 @@ These tests evaluate embedding model performance using `vllm bench serve` to est
 ### Prerequisites
 
 ```bash
-# Ensure vLLM >= v0.11.0 (for embedding benchmarking support)
-pip install "vllm>=0.11.0"
-
-# For Ansible automation
-pip install ansible
-ansible-galaxy collection install containers.podman
+# From the repository root: Ansible, Galaxy collections, tab completion
+./cpueval install
 
 # Set environment variables
 export VLLM_CPU_KVCACHE_SPACE=1GiB
 ```
+
+vLLM 0.11.0+ (embedding benchmark support) is provided by the DUT container
+image; you do not need to `pip install vllm` on the control machine.
 
 ### Test Architectures
 


### PR DESCRIPTION
## Summary
- After [PR #203](https://github.com/redhat-et/vllm-cpu-perf-eval/pull/203) merged `./cpueval install`, several GitHub Pages and setup docs still told users to run `ansible-galaxy` / `pip install ansible` by hand.
- Homepage, docs index, Quick Start, Ansible, audio, and embedding guides now start from `./cpueval install`.
- `cpueval doctor` examples include the collections check and the `./cpueval install` tip.

## Test plan
- [ ] Confirm GitHub Pages preview after merge: homepage Getting Started card mentions `./cpueval install`
- [ ] Skim [Getting Started](https://redhat-et.github.io/vllm-cpu-perf-eval/docs/getting-started/) and [cpueval CLI](https://redhat-et.github.io/vllm-cpu-perf-eval/docs/cpueval-cli/) for a consistent install-first flow
- [ ] Check Ansible Test Execution, Audio, and Embedding pages no longer document a standalone `ansible-galaxy` step


Made with [Cursor](https://cursor.com)